### PR TITLE
Scaffold @wazoo/sparql-engine package and initial BGP evaluator

### DIFF
--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -13,6 +13,7 @@ import type {
   SparqlSelectResults,
 } from "@/sparql-engine-interface.ts";
 import { BgpEvaluator } from "@/evaluator/bgp-evaluator.ts";
+import { DataFactory } from "n3";
 
 /**
  * SparqlEvaluator processes parsed SPARQL AST queries against an RDFJS store.
@@ -100,27 +101,39 @@ export class SparqlEvaluator {
       return { quads };
     }
 
-    for (const _binding of bindings) {
+    for (const binding of bindings) {
       for (const t of query.template) {
-        const _s = this.bgpEvaluator.sparqlValueToRdfTerm(
-          this.bgpEvaluator.rdfTermToSparqlValue(
-            this.bgpEvaluator.sparqlTermToRdfTerm(t.subject),
-          ),
-        );
-        const _p = this.bgpEvaluator.sparqlValueToRdfTerm(
-          this.bgpEvaluator.rdfTermToSparqlValue(
-            this.bgpEvaluator.sparqlTermToRdfTerm(t.predicate),
-          ),
-        );
-        const _o = this.bgpEvaluator.sparqlValueToRdfTerm(
-          this.bgpEvaluator.rdfTermToSparqlValue(
-            this.bgpEvaluator.sparqlTermToRdfTerm(t.object),
-          ),
-        );
-        // Note: quad production will be refined in Phase 2
+        const s = this.resolveConstructTerm(t.subject, binding);
+        const p = this.resolveConstructTerm(t.predicate, binding);
+        const o = this.resolveConstructTerm(t.object, binding);
+
+        if (s && p && o) {
+          quads.push(
+            DataFactory.quad(
+              s as rdfjs.Quad_Subject,
+              p as rdfjs.Quad_Predicate,
+              o as rdfjs.Quad_Object,
+              DataFactory.defaultGraph(),
+            ),
+          );
+        }
       }
     }
 
     return { quads };
+  }
+
+  private resolveConstructTerm(
+    term: Parameters<BgpEvaluator["sparqlTermToRdfTerm"]>[0],
+    binding: SparqlBinding,
+  ): rdfjs.Term | null {
+    if (term.termType === "Variable") {
+      const bound = binding[term.value];
+      if (bound) {
+        return this.bgpEvaluator.sparqlValueToRdfTerm(bound);
+      }
+      return null;
+    }
+    return this.bgpEvaluator.sparqlTermToRdfTerm(term);
   }
 }

--- a/src/native-sparql-engine.test.ts
+++ b/src/native-sparql-engine.test.ts
@@ -66,3 +66,30 @@ Deno.test("NativeSparqlEngine - ASK query evaluation", async () => {
     assertEquals(falseResult.data.boolean, false);
   }
 });
+
+Deno.test("NativeSparqlEngine - CONSTRUCT query evaluation", async () => {
+  const store = new Store();
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/alice"),
+      namedNode("http://xmlns.com/foaf/0.1/name"),
+      literal("Alice"),
+    ),
+  );
+
+  const engine = new NativeSparqlEngine({ store });
+  const result = await engine.execute({
+    query:
+      "CONSTRUCT { ?person <http://schema.org/name> ?name } WHERE { ?person <http://xmlns.com/foaf/0.1/name> ?name }",
+  });
+
+  assertEquals(result.kind, "construct");
+  if (result.kind === "construct") {
+    assertEquals(result.data.quads.length, 1);
+    assertEquals(
+      result.data.quads[0].predicate.value,
+      "http://schema.org/name",
+    );
+    assertEquals(result.data.quads[0].object.value, "Alice");
+  }
+});


### PR DESCRIPTION
## Summary

Initial Phase 1 release of `@wazoo/sparql-engine`:

- **Canonical Interface Contracts**: Defined and exported `SparqlEngineInterface`, `SparqlRequest`, `SparqlResponse` (with `select`, `ask`, `construct`, `void` variants), `SparqlSelectResults`, `SparqlAskResults`, `SparqlConstructResults`, `SparqlBinding`, `SparqlValue`, and `NativeSparqlTransaction`.
- **SPARQL 1.1 AST Parser**: Built `SparqlParser` (`src/parser/sparql-parser.ts`) using `sparqljs` AST parser.
- **Basic Graph Pattern (BGP) Evaluator**: Built `BgpEvaluator` (`src/evaluator/bgp-evaluator.ts`) performing pattern matching and variable binding joins over `rdfjs.Store` sources.
- **Query Evaluator**: Built `SparqlEvaluator` (`src/evaluator/sparql-evaluator.ts`) evaluating `SELECT`, `ASK`, and `CONSTRUCT` queries.
- **Tooling & Packaging**: Configured Deno layout (`deno.json`), JSR dry-run publish (`publish:dry`), license, `README.md`, `AGENTS.md`, `ARCHITECTURE.md`, and GitHub Actions workflows (`ci.yml`, `publish.yml`).

## Local Verification
- `deno task ci` passed 100% green (`fmt`, `lint`, `check`, `test`).
- `deno task publish:dry` passed JSR package simulation cleanly.
