### PR TITLE
feat(w3c): close the W3C differential parity gaps to 95% (332/336)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       - run: deno task publish:dry
   # W3C differential gate: native must agree with comunica on the vendored
   # SPARQL 1.1 evaluation-core suite. The pass rate is the tracked progress
-  # metric — this job goes green once >= 90% of the suite agrees and turns
-  # fully green when native converges with comunica everywhere.
+  # metric — this job goes green once >= 95% (>= 320/336) of the suite agrees
+  # and turns fully green when native converges with comunica everywhere.
   w3c-parity:
     runs-on: ubuntu-latest
     steps:

--- a/src/evaluator/expression-evaluator.ts
+++ b/src/evaluator/expression-evaluator.ts
@@ -80,6 +80,21 @@ export interface ExpressionEvaluationContext {
    * negating it when absent.
    */
   evaluateNotExists?: (pattern: Pattern, solution: TermBinding) => boolean;
+
+  /**
+   * baseIri is the resolved query base (from the BASE directive), used to
+   * resolve relative IRI strings in IRI()/URI().
+   */
+  baseIri?: string;
+
+  /**
+   * bnodeMap is the per-solution blank-node cache for BNODE(str): the same
+   * string maps to the same blank node within a single solution mapping,
+   * while a fresh map per solution keeps nodes distinct across solutions
+   * (SPARQL 1.1 §17.4.1.5). Absent outside solution-scoped evaluation,
+   * where BNODE(str) falls back to a deterministic label.
+   */
+  bnodeMap?: Map<string, rdfjs.BlankNode>;
 }
 
 /**
@@ -477,7 +492,7 @@ export class ExpressionEvaluator {
           if (/[\s<>"{}`\\^]/.test(val.value)) {
             return undefined;
           }
-          return namedNode(val.value);
+          return namedNode(this.resolveIri(val.value, context?.baseIri));
         }
         return undefined;
       }
@@ -781,6 +796,27 @@ export class ExpressionEvaluator {
     return literalTerm.language !== undefined && literalTerm.language !== "";
   }
 
+  private isSimpleLiteral(literalTerm: rdfjs.Literal): boolean {
+    return !this.isLangTagged(literalTerm) &&
+      (literalTerm.datatype === undefined ||
+        literalTerm.datatype.value === XSD_STRING);
+  }
+
+  /**
+   * resolveIri resolves a relative IRI string against the query base IRI
+   * (RFC 3986); an absent base returns the string unchanged.
+   */
+  private resolveIri(value: string, baseIri: string | undefined): string {
+    if (!baseIri) {
+      return value;
+    }
+    try {
+      return new URL(value, baseIri).href;
+    } catch {
+      return value;
+    }
+  }
+
   /**
    * stringCase implements UCASE and LCASE: language-tagged inputs keep
    * their language, everything else becomes an xsd:string literal, and any
@@ -820,6 +856,7 @@ export class ExpressionEvaluator {
     context?: ExpressionEvaluationContext,
   ): rdfjs.Literal | undefined {
     let result = "";
+    let commonLang: string | null | undefined;
     for (const expression of expressions) {
       const value = this.evaluateWith(expression, binding, aggregates, context);
       if (
@@ -829,8 +866,17 @@ export class ExpressionEvaluator {
         return undefined;
       }
       result += value.value;
+      if (commonLang !== null) {
+        if (!this.isLangTagged(value)) {
+          commonLang = null;
+        } else if (commonLang === undefined) {
+          commonLang = value.language;
+        } else if (commonLang !== value.language) {
+          commonLang = null;
+        }
+      }
     }
-    return literal(result, namedNode(XSD_STRING));
+    return this.stringResult(result, commonLang ?? undefined);
   }
 
   /**
@@ -910,7 +956,10 @@ export class ExpressionEvaluator {
     if (value === undefined || datatype === undefined) {
       return undefined;
     }
-    if (value.termType !== "Literal" || datatype.termType !== "NamedNode") {
+    if (
+      value.termType !== "Literal" || datatype.termType !== "NamedNode" ||
+      !this.isSimpleLiteral(value)
+    ) {
       return undefined;
     }
     return literal(value.value, namedNode(datatype.value));
@@ -1048,7 +1097,7 @@ export class ExpressionEvaluator {
     const datatype = term.datatype?.value;
     if (datatype === XSD_BOOLEAN) {
       return literal(
-        term.value === "true" ? "1" : "0",
+        term.value === "true" || term.value === "1" ? "1" : "0",
         namedNode(XSD_INTEGER),
       );
     }
@@ -1057,10 +1106,12 @@ export class ExpressionEvaluator {
       if (typeof numeric === "bigint") {
         return literal(numeric.toString(), namedNode(XSD_INTEGER));
       }
-      if (Number.isInteger(numeric)) {
-        return literal(String(numeric), namedNode(XSD_INTEGER));
-      }
-      return undefined;
+      // XPath casting truncates non-integer numerics toward zero:
+      // xsd:integer(1.25) -> 1, xsd:integer(-2.5) -> -2.
+      return literal(
+        String(Number.isInteger(numeric) ? numeric : Math.trunc(numeric)),
+        namedNode(XSD_INTEGER),
+      );
     }
     if (this.isStringTyped(term) && /^-?\d+$/.test(term.value)) {
       return literal(term.value, namedNode(XSD_INTEGER));
@@ -1078,6 +1129,12 @@ export class ExpressionEvaluator {
     if (term === undefined || term.termType !== "Literal") {
       return undefined;
     }
+    if (term.datatype?.value === XSD_BOOLEAN) {
+      return literal(
+        term.value === "true" || term.value === "1" ? "1" : "0",
+        namedNode(XSD_DECIMAL),
+      );
+    }
     const numeric = numericValue(term);
     if (numeric !== null) {
       return literal(
@@ -1085,7 +1142,7 @@ export class ExpressionEvaluator {
         namedNode(XSD_DECIMAL),
       );
     }
-    if (this.isStringTyped(term) && /^-?\d+(\.\d+)?$/.test(term.value)) {
+    if (this.isStringTyped(term) && /^[+-]?\d+(\.\d+)?$/.test(term.value)) {
       return literal(
         formatNumber(Number(term.value), XSD_DECIMAL),
         namedNode(XSD_DECIMAL),
@@ -1135,6 +1192,12 @@ export class ExpressionEvaluator {
     if (term === undefined || term.termType !== "Literal") {
       return undefined;
     }
+    if (term.datatype?.value === XSD_BOOLEAN) {
+      return literal(
+        term.value === "true" || term.value === "1" ? "1" : "0",
+        namedNode(XSD_FLOAT),
+      );
+    }
     const numeric = numericValue(term);
     let n: number;
     if (numeric !== null) {
@@ -1160,13 +1223,30 @@ export class ExpressionEvaluator {
     if (term === undefined) {
       return undefined;
     }
-    if (
-      term.termType === "Literal" || term.termType === "NamedNode" ||
-      term.termType === "BlankNode"
-    ) {
+    if (term.termType === "NamedNode" || term.termType === "BlankNode") {
       return literal(term.value, namedNode(XSD_STRING));
     }
-    return undefined;
+    if (term.termType !== "Literal") {
+      return undefined;
+    }
+    const datatype = term.datatype?.value;
+    if (datatype === XSD_BOOLEAN) {
+      return literal(
+        term.value === "true" || term.value === "1" ? "true" : "false",
+        namedNode(XSD_STRING),
+      );
+    }
+    if (datatype !== undefined && NUMERIC_DATATYPES.has(datatype)) {
+      const numeric = numericValue(term);
+      if (numeric === null) {
+        return undefined;
+      }
+      return literal(
+        formatNumber(Number(numeric), datatype),
+        namedNode(XSD_STRING),
+      );
+    }
+    return literal(term.value, namedNode(XSD_STRING));
   }
 
   /**
@@ -1181,7 +1261,10 @@ export class ExpressionEvaluator {
       return undefined;
     }
     if (term.datatype?.value === XSD_BOOLEAN) {
-      return literal(term.value, namedNode(XSD_BOOLEAN));
+      return literal(
+        term.value === "true" || term.value === "1" ? "true" : "false",
+        namedNode(XSD_BOOLEAN),
+      );
     }
     const numeric = numericValue(term);
     if (numeric !== null) {
@@ -1341,6 +1424,14 @@ export class ExpressionEvaluator {
     if (value === undefined || needle === undefined) {
       return undefined;
     }
+    // A language-tagged needle must carry the first argument's tag, or the
+    // call is a type error (SPARQL 1.1 §17.4.3.10/11).
+    if (
+      this.isLangTagged(needle) &&
+      (!this.isLangTagged(value) || value.language !== needle.language)
+    ) {
+      return undefined;
+    }
     const index = value.value.indexOf(needle.value);
     let result: string;
     if (index === -1) {
@@ -1350,9 +1441,13 @@ export class ExpressionEvaluator {
     } else {
       result = value.value.slice(index + needle.value.length);
     }
+    // The first argument's language tag survives only when the needle is
+    // found; a missing needle yields the bare empty string.
     return this.stringResult(
       result,
-      this.isLangTagged(value) ? value.language : undefined,
+      index === -1
+        ? undefined
+        : (this.isLangTagged(value) ? value.language : undefined),
     );
   }
 

--- a/src/evaluator/expression-evaluator.ts
+++ b/src/evaluator/expression-evaluator.ts
@@ -509,7 +509,12 @@ export class ExpressionEvaluator {
       }
       case "BNODE":
       case "bnode":
-        return this.bnode(operation.args as Expression[], binding, aggregates);
+        return this.bnode(
+          operation.args as Expression[],
+          binding,
+          aggregates,
+          context,
+        );
       case "struuid":
       case "STRUUID":
         return this.struuid();
@@ -1669,8 +1674,9 @@ export class ExpressionEvaluator {
 
   /**
    * bnode implements BNODE: no argument mints a fresh blank node; a string
-   * argument creates a blank node labeled from it (the same label yields
-   * the same node within one query). Non-string arguments are type errors.
+   * argument reuses one blank node per distinct string within a single
+   * solution mapping (the context's bnodeMap), minting distinct nodes
+   * across solutions. Non-string arguments are type errors.
    */
   private bnode(
     args: Expression[],
@@ -1684,6 +1690,16 @@ export class ExpressionEvaluator {
     const value = this.stringTerm(args[0], binding, aggregates, context);
     if (value === undefined) {
       return undefined;
+    }
+    const bnodeMap = context?.bnodeMap;
+    if (bnodeMap !== undefined) {
+      const existing = bnodeMap.get(value.value);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const fresh = blankNode(`b${++this.bnodeCounter}`);
+      bnodeMap.set(value.value, fresh);
+      return fresh;
     }
     return blankNode(value.value);
   }

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -360,9 +360,15 @@ export class SparqlEvaluator {
       }
       return result;
     }
+    // BNODE(str) scopes its blank nodes to a single solution mapping, so each
+    // solution's projection carries a fresh bnode cache (SPARQL 1.1 §17.4.1.5).
+    const solutionContext: ExpressionEvaluationContext = {
+      ...(context ?? {}),
+      bnodeMap: new Map<string, rdfjs.BlankNode>(),
+    };
     const resolver = solution.group === null
       ? undefined
-      : this.aggregateResolver(solution, context);
+      : this.aggregateResolver(solution, solutionContext);
     for (const varName of vars) {
       const bound = binding[varName];
       if (bound) {
@@ -375,13 +381,13 @@ export class SparqlEvaluator {
           ? this.expressionEvaluator.evaluate(
             projection,
             mergedBinding,
-            context,
+            solutionContext,
           )
           : this.expressionEvaluator.evaluateWithAggregates(
             projection,
             mergedBinding,
             resolver,
-            context,
+            solutionContext,
           );
         if (value !== undefined) {
           result[varName] = value;

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -172,6 +172,7 @@ export class SparqlEvaluator {
     const existsContext: ExpressionEvaluationContext = {
       evaluateExists: (pattern, solution) =>
         evaluator.evaluateExists(pattern, solution),
+      baseIri: query.base,
     };
 
     const grouping = query.group ?? [];

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -64,6 +64,12 @@ export class SparqlEvaluator {
   /** expressionEvaluator evaluates ORDER BY expressions against solutions. */
   private readonly expressionEvaluator = new ExpressionEvaluator();
 
+  /**
+   * nextConstructBnodeId mints fresh labels for CONSTRUCT template blank
+   * nodes, which must be distinct per solution mapping (SPARQL 1.1 §16.2.1).
+   */
+  private nextConstructBnodeId = 0;
+
   private readonly store: rdfjs.Source<rdfjs.Quad>;
 
   public constructor(
@@ -418,13 +424,18 @@ export class SparqlEvaluator {
     }
 
     for (const binding of bindings) {
+      // Blank nodes in a CONSTRUCT template are fresh per solution mapping
+      // (SPARQL 1.1 §16.2.1): the parser expands RDF collections and _:b
+      // template terms into shared labels, so remap them per binding.
+      const bnodeMap = new Map<string, rdfjs.BlankNode>();
       for (const t of query.template) {
-        const s = this.resolveConstructTerm(t.subject, binding);
+        const s = this.resolveConstructTerm(t.subject, binding, bnodeMap);
         const p = this.resolveConstructTerm(
           simplePredicate(t.predicate),
           binding,
+          bnodeMap,
         );
-        const o = this.resolveConstructTerm(t.object, binding);
+        const o = this.resolveConstructTerm(t.object, binding, bnodeMap);
 
         if (s && p && o) {
           quads.push(
@@ -493,6 +504,7 @@ export class SparqlEvaluator {
   private resolveConstructTerm(
     term: SparqlTerm,
     binding: TermBinding,
+    bnodeMap: Map<string, rdfjs.BlankNode>,
   ): rdfjs.Term | null {
     if (term.termType === "Variable") {
       const bound = binding[term.value];
@@ -500,6 +512,15 @@ export class SparqlEvaluator {
         return bound;
       }
       return null;
+    }
+    if (term.termType === "BlankNode") {
+      const existing = bnodeMap.get(term.value);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const fresh = DataFactory.blankNode(`c${this.nextConstructBnodeId++}`);
+      bnodeMap.set(term.value, fresh);
+      return fresh;
     }
     return sparqlTermToRdfTerm(term);
   }

--- a/src/evaluator/update-evaluator.ts
+++ b/src/evaluator/update-evaluator.ts
@@ -19,7 +19,7 @@ import {
   probeQuadIndex,
   simplePredicate,
 } from "@/quad-store.ts";
-import { sparqlTermToRdfTerm, termKey } from "@/term/mod.ts";
+import { sameRdfTerm, sparqlTermToRdfTerm, termKey } from "@/term/mod.ts";
 import { DataFactory } from "n3";
 
 const { blankNode, quad, defaultGraph } = DataFactory;
@@ -216,21 +216,26 @@ export class UpdateEvaluator {
         return;
       }
       case "copy": {
+        // Snapshot the source before clearing the destination so COPYing a
+        // graph to itself is a no-op rather than an emptying.
+        const sourceQuads = await this.fetchGraphQuads(op.source as GraphRef);
         await this.applyClear(op.destination as GraphRef, remove);
-        await this.applyAdd(
-          op.source as GraphRef,
-          op.destination as GraphRef,
-          add,
-        );
+        this.addQuads(sourceQuads, op.destination as GraphRef, add);
         return;
       }
       case "move": {
+        // MOVEing a graph to itself is a no-op (SPARQL 1.1 Update §3.3.3).
+        if (
+          this.sameGraphRef(
+            op.source as GraphRef,
+            op.destination as GraphRef,
+          )
+        ) {
+          return;
+        }
+        const sourceQuads = await this.fetchGraphQuads(op.source as GraphRef);
         await this.applyClear(op.destination as GraphRef, remove);
-        await this.applyAdd(
-          op.source as GraphRef,
-          op.destination as GraphRef,
-          add,
-        );
+        this.addQuads(sourceQuads, op.destination as GraphRef, add);
         await this.applyClear(op.source as GraphRef, remove);
         return;
       }
@@ -313,7 +318,19 @@ export class UpdateEvaluator {
     },
     add: (item: rdfjs.Quad) => unknown,
   ): Promise<void> {
-    const sourceQuads = await this.fetchGraphQuads(sourceRef);
+    this.addQuads(await this.fetchGraphQuads(sourceRef), destRef, add);
+  }
+
+  private addQuads(
+    sourceQuads: rdfjs.Quad[],
+    destRef: {
+      default?: boolean;
+      named?: boolean;
+      all?: boolean;
+      name?: SparqlTerm;
+    },
+    add: (item: rdfjs.Quad) => unknown,
+  ): void {
     const destGraphTerm = (!destRef || destRef.default)
       ? defaultGraph()
       : destRef.name
@@ -322,6 +339,19 @@ export class UpdateEvaluator {
     for (const q of sourceQuads) {
       add(quad(q.subject, q.predicate, q.object, destGraphTerm));
     }
+  }
+
+  private sameGraphRef(a: GraphRef, b: GraphRef): boolean {
+    if (a.default && b.default) {
+      return true;
+    }
+    if (a.name && b.name) {
+      return sameRdfTerm(
+        sparqlTermToRdfTerm(a.name),
+        sparqlTermToRdfTerm(b.name),
+      );
+    }
+    return false;
   }
 
   /**

--- a/test/w3c/divergences.ts
+++ b/test/w3c/divergences.ts
@@ -11,6 +11,32 @@
  * Key format: `<category>:<manifest-local-name>`.
  */
 export const documentedDivergences: Record<string, string> = {
-  // Populated only when a W3C test hits a divergence already recorded as a
-  // decided Comunica bug. Nothing qualifies yet.
+  // COUNT inside GRAPH with no GROUP BY: the subquery yields one solution per
+  // named graph (empty matches still produce COUNT=0), so the outer query has
+  // two rows — one per graphData entry. Comunica lite collapses them into a
+  // single ungrouped row and drops the ?g binding. Native matches the W3C
+  // reference. (SPARQL 1.1 Query §18.2.2.2 aggregation, §13.3 GRAPH.)
+  "aggregates:agg-empty-group-count-graph":
+    "Native returns the two spec rows (singleton -> 0, pair -> 2); Comunica collapses to one ungrouped row and drops ?g. SPARQL 1.1 Query §18.2.2.2/§13.3.",
+
+  // VALUES inside GRAPH binding the same variable as the graph name: the
+  // VALUES row binds ?g and ?t, and GRAPH ?g joins those with the named
+  // graphs, keeping ?g bound. Native returns the three reference rows
+  // (matching graph.ttl); Comunica lite drops the ?g binding and returns two.
+  // (SPARQL 1.1 Query §10.2 VALUES, §13.3 GRAPH.)
+  "bindings:graph":
+    "Native keeps ?g bound through VALUES-in-GRAPH (3 rows, matching graph.ttl); Comunica drops ?g (2 rows). SPARQL 1.1 Query §10.2/§13.3.",
+
+  // LOAD ... SILENT: a failed remote retrieval must be ignored, leaving the
+  // store unchanged. Native honors SILENT; Comunica lite has no loader for
+  // the somescheme:// IRI and throws a query-source identification error.
+  // (SPARQL 1.1 Update §3.1.3 LOAD.)
+  "update-silent:load-silent":
+    "Native ignores the unloadable somescheme:// IRI per SILENT; Comunica lite throws a query-source identification error. SPARQL 1.1 Update §3.1.3.",
+
+  // LOAD ... INTO GRAPH ... SILENT: same as LOAD SILENT, but targeting a
+  // named graph. Native honors SILENT and leaves the graph unchanged;
+  // Comunica lite throws on the unloadable IRI. (SPARQL 1.1 Update §3.1.3.)
+  "update-silent:load-into-silent":
+    "Native ignores the unloadable somescheme:// IRI per SILENT; Comunica lite throws a query-source identification error. SPARQL 1.1 Update §3.1.3.",
 };

--- a/test/w3c/runner.ts
+++ b/test/w3c/runner.ts
@@ -96,6 +96,124 @@ function multisetEqual(a: string[], b: string[]): boolean {
 }
 
 /**
+ * isomorphicMultiset compares two multisets of records (each record an
+ * ordered list of canonical terms) up to blank-node renaming. Blank-node
+ * labels are engine-local and unobservable across queries, so two results
+ * agree exactly when a consistent relabeling makes them equal.
+ */
+function isomorphicMultiset(
+  a: CanonicalTerm[][],
+  b: CanonicalTerm[][],
+): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return multisetEqual(canonicalizeBnodes(a), canonicalizeBnodes(b));
+}
+
+/**
+ * canonicalizeBnodes relabels the blank nodes of a record multiset with
+ * canonical `_:0, _:1, ...` labels derived from structure by iterative
+ * partition refinement (Weisfeiler-Lehman style), so structurally identical
+ * results carrying different engine-local labels canonicalize identically.
+ */
+function canonicalizeBnodes(records: CanonicalTerm[][]): string[] {
+  const labels = new Set<string>();
+  const visit = (term: CanonicalTerm): void => {
+    if (term.termType === "BlankNode") {
+      labels.add(term.value);
+    } else if (term.termType === "Quad") {
+      if (term.subject) visit(term.subject);
+      if (term.predicate) visit(term.predicate);
+      if (term.object) visit(term.object);
+    }
+  };
+  for (const record of records) {
+    for (const term of record) {
+      visit(term);
+    }
+  }
+
+  const renderValue = (
+    term: CanonicalTerm,
+    map: Map<string, string>,
+  ): unknown => {
+    if (term.termType === "BlankNode") {
+      return { termType: "BlankNode", value: map.get(term.value) ?? "_" };
+    }
+    if (term.termType === "Quad") {
+      return {
+        termType: "Quad",
+        value: "",
+        subject: term.subject ? renderValue(term.subject, map) : undefined,
+        predicate: term.predicate
+          ? renderValue(term.predicate, map)
+          : undefined,
+        object: term.object ? renderValue(term.object, map) : undefined,
+      };
+    }
+    return term;
+  };
+  const render = (term: CanonicalTerm, map: Map<string, string>): string =>
+    JSON.stringify(renderValue(term, map));
+
+  const refersTo = (term: CanonicalTerm, label: string): boolean => {
+    if (term.termType === "BlankNode") {
+      return term.value === label;
+    }
+    if (term.termType === "Quad") {
+      return (term.subject !== undefined && refersTo(term.subject, label)) ||
+        (term.predicate !== undefined && refersTo(term.predicate, label)) ||
+        (term.object !== undefined && refersTo(term.object, label));
+    }
+    return false;
+  };
+
+  let current = new Map<string, string>();
+  for (const label of labels) {
+    current.set(label, "s0");
+  }
+  for (let round = 0; round <= labels.size + 1; round++) {
+    const signature = new Map<string, string>();
+    for (const label of labels) {
+      const contexts: string[] = [];
+      for (const record of records) {
+        for (let slot = 0; slot < record.length; slot++) {
+          if (refersTo(record[slot], label)) {
+            const others = record
+              .filter((_, index) => index !== slot)
+              .map((term) => render(term, current));
+            contexts.push(JSON.stringify([slot, ...others]));
+          }
+        }
+      }
+      contexts.sort();
+      signature.set(label, JSON.stringify(contexts));
+    }
+    const distinct = [...new Set(signature.values())].sort();
+    const idOf = new Map(distinct.map((text, index) => [text, `s${index}`]));
+    current = new Map(
+      [...labels].map((label) => [label, idOf.get(signature.get(label)!)!]),
+    );
+  }
+
+  const ordered = [...labels].sort((a, b) => {
+    const aId = current.get(a)!;
+    const bId = current.get(b)!;
+    if (aId !== bId) {
+      return aId < bId ? -1 : 1;
+    }
+    return a < b ? -1 : 1;
+  });
+  const canonical = new Map<string, string>();
+  ordered.forEach((label, index) => canonical.set(label, `_:${index}`));
+
+  return records.map((record) =>
+    record.map((term) => render(term, canonical)).join("\u0000")
+  );
+}
+
+/**
  * W3cRunner executes the W3C evaluation-core tests differentially.
  */
 export class W3cRunner {
@@ -307,10 +425,17 @@ export class W3cRunner {
           };
         }
         const native = this.nativeSelectStrings(nativeResult);
-        return multisetEqual(comunica, native) ? { status: "pass" } : {
-          status: "gap",
-          detail: this.firstDiff(native, comunica, "SELECT bindings"),
-        };
+        const nativeRecords = this.nativeSelectRecords(nativeResult);
+        const comunicaRecords = await this.runComunicaSelectRecords(
+          query,
+          store,
+        );
+        return isomorphicMultiset(nativeRecords, comunicaRecords)
+          ? { status: "pass" }
+          : {
+            status: "gap",
+            detail: this.firstDiff(native, comunica, "SELECT bindings"),
+          };
       }
       case "ask": {
         let comunica: boolean;
@@ -332,11 +457,16 @@ export class W3cRunner {
       }
       case "construct": {
         let comunicaSet: string[];
+        let comunicaRecords: CanonicalTerm[][];
         try {
           const stream = await this.comunicaEngine.queryQuads(query, options);
-          comunicaSet = (await stream.toArray())
+          const comunicaQuads = await stream.toArray();
+          comunicaSet = comunicaQuads
             .map((item) => canonicalQuadString(item, canonicalizeComunicaTerm))
             .sort();
+          comunicaRecords = comunicaQuads.map((item) =>
+            this.quadRecords(item, canonicalizeComunicaTerm)
+          );
         } catch (error) {
           return {
             status: "gap",
@@ -348,10 +478,15 @@ export class W3cRunner {
         const nativeSet = nativeResult.data.quads
           .map((item) => canonicalQuadString(item, canonicalizeRdfTerm))
           .sort();
-        return multisetEqual(comunicaSet, nativeSet) ? { status: "pass" } : {
-          status: "gap",
-          detail: this.firstDiff(nativeSet, comunicaSet, "CONSTRUCT quads"),
-        };
+        const nativeRecords = nativeResult.data.quads.map((item) =>
+          this.quadRecords(item, canonicalizeRdfTerm)
+        );
+        return isomorphicMultiset(nativeRecords, comunicaRecords)
+          ? { status: "pass" }
+          : {
+            status: "gap",
+            detail: this.firstDiff(nativeSet, comunicaSet, "CONSTRUCT quads"),
+          };
       }
       default:
         return {
@@ -374,6 +509,19 @@ export class W3cRunner {
     });
   }
 
+  private nativeSelectRecords(nativeResult: SparqlResponse): CanonicalTerm[][] {
+    if (nativeResult.kind !== "select") {
+      return [];
+    }
+    return nativeResult.data.results.bindings.map((binding) => {
+      const record: Record<string, CanonicalTerm> = {};
+      for (const name of Object.keys(binding)) {
+        record[name] = canonicalizeSparqlValue(binding[name]);
+      }
+      return Object.keys(record).sort().map((name) => record[name]);
+    });
+  }
+
   private async runComunicaSelect(
     query: string,
     store: N3Store,
@@ -390,6 +538,32 @@ export class W3cRunner {
       }
       return bindingRecord(canonical);
     });
+  }
+
+  private async runComunicaSelectRecords(
+    query: string,
+    store: N3Store,
+  ): Promise<CanonicalTerm[][]> {
+    const raw = await runComunicaRawSelectBindings(
+      this.comunicaEngine,
+      query,
+      store,
+    );
+    return raw.map((record) => {
+      const canonical: Record<string, CanonicalTerm> = {};
+      for (const name of Object.keys(record)) {
+        canonical[name] = canonicalizeComunicaTerm(record[name]);
+      }
+      return Object.keys(canonical).sort().map((name) => canonical[name]);
+    });
+  }
+
+  private quadRecords(
+    item: rdfjs.Quad,
+    canonicalize: (term: rdfjs.Term) => CanonicalTerm,
+  ): CanonicalTerm[] {
+    return [item.subject, item.predicate, item.object, item.graph]
+      .map((term) => canonicalize(term));
   }
 
   private firstDiff(a: string[], b: string[], label: string): string {
@@ -449,15 +623,24 @@ export class W3cRunner {
 
     const nativeSet = this.storeQuadStrings(nativeStore).sort();
     const comunicaSet = this.storeQuadStrings(comunicaStore).sort();
-    return multisetEqual(nativeSet, comunicaSet) ? { status: "pass" } : {
-      status: "gap",
-      detail: this.firstDiff(nativeSet, comunicaSet, "final store contents"),
-    };
+    const nativeRecords = this.storeQuadRecords(nativeStore);
+    const comunicaRecords = this.storeQuadRecords(comunicaStore);
+    return isomorphicMultiset(nativeRecords, comunicaRecords)
+      ? { status: "pass" }
+      : {
+        status: "gap",
+        detail: this.firstDiff(nativeSet, comunicaSet, "final store contents"),
+      };
   }
 
   private storeQuadStrings(store: N3Store): string[] {
     const quads: rdfjs.Quad[] = store.getQuads(null, null, null, null);
     return quads.map((item) => canonicalQuadString(item, canonicalizeRdfTerm));
+  }
+
+  private storeQuadRecords(store: N3Store): CanonicalTerm[][] {
+    const quads: rdfjs.Quad[] = store.getQuads(null, null, null, null);
+    return quads.map((item) => this.quadRecords(item, canonicalizeRdfTerm));
   }
 
   /**

--- a/test/w3c/w3c-main.ts
+++ b/test/w3c/w3c-main.ts
@@ -115,14 +115,14 @@ const { cases, skipped } = loadAllCases();
 const report = await new W3cRunner(readFixture).run(cases);
 printReport(report, skipped);
 
-// Coverage gate: the milestone target is >= 90% of the differential suite
-// passing (ceiling-rounded so 336 tests requires >= 303). Runner errors are
+// Coverage gate: the milestone target is >= 95% of the differential suite
+// passing (ceiling-rounded so 336 tests requires >= 320). Runner errors are
 // always fatal — they indicate a harness bug, not a parity gap.
-const threshold = Math.ceil(report.total * 0.9);
+const threshold = Math.ceil(report.total * 0.95);
 if (report.pass < threshold || report.error > 0) {
   console.error(
     `\nW3C differential gate FAILED: ${report.pass}/${report.total} pass is ` +
-      `below the ${threshold} (>=90%) threshold, with ${report.gap} parity ` +
+      `below the ${threshold} (>=95%) threshold, with ${report.gap} parity ` +
       `gap(s) and ${report.error} error(s). The parity-gap count is the ` +
       `tracked progress metric — each gap is a place native must converge ` +
       `with comunica.`,
@@ -131,6 +131,6 @@ if (report.pass < threshold || report.error > 0) {
 }
 console.log(
   `\nW3C differential gate passed: ${report.pass}/${report.total} pass is at ` +
-    `or above the ${threshold} (>=90%) threshold (plus ` +
+    `or above the ${threshold} (>=95%) threshold (plus ` +
     `${report.allowlisted} allowlisted documented divergences).`,
 );

--- a/vendor/sparql-parser/ast.ts
+++ b/vendor/sparql-parser/ast.ts
@@ -158,6 +158,7 @@ export interface SelectQuery {
   type: "query";
   queryType: "SELECT";
   prefixes?: Record<string, string>;
+  base?: string;
   variables: Array<VariableTerm | Wildcard | VariableExpression>;
   where?: Pattern[];
   group?: Grouping[];
@@ -175,6 +176,7 @@ export interface AskQuery {
   type: "query";
   queryType: "ASK";
   prefixes?: Record<string, string>;
+  base?: string;
   where?: Pattern[];
   from?: FromClause;
 }
@@ -183,6 +185,7 @@ export interface ConstructQuery {
   type: "query";
   queryType: "CONSTRUCT";
   prefixes?: Record<string, string>;
+  base?: string;
   template?: Triple[];
   where?: Pattern[];
   from?: FromClause;
@@ -192,6 +195,7 @@ export interface DescribeQuery {
   type: "query";
   queryType: "DESCRIBE";
   prefixes?: Record<string, string>;
+  base?: string;
   variables: Array<VariableTerm | Wildcard>;
   where?: Pattern[];
   from?: FromClause;


### PR DESCRIPTION
## Summary

Raises the native engine's W3C differential parity from 92.6% (311/336) to **98.8% (332/336 pass, 0 gap, 0 error)** and moves the gate to 95% (`Math.ceil(total * 0.95) = 320`).

## Result tuple

`total 336 · pass 332 · gap 0 · error 0 · allowlisted 4 · skipped 0`

## What changed

- **Parser** — expose the query BASE directive on AST query nodes.
- **Evaluator** — resolve `IRI()`/`URI()` against the BASE; close the XSD-cast and string-function gaps (`STRDT`, `CONCAT`, `STRBEFORE`/`STRAFTER`); scope `BNODE(str)` blank nodes per solution; mint fresh blank nodes per `CONSTRUCT` solution.
- **Update** — snapshot sources for `COPY`/`MOVE` and no-op self-targets.
- **Runner** — compare SELECT/CONSTRUCT/update results up to blank-node isomorphism.
- **Allowlist** — four documented native-correct vs Comunica divergences.
- **Gate** — raise the differential gate to 95% (`w3c-main.ts` + CI comment).

## Verification

- `deno task test:w3c` — 332/336, 0 error ✅
- `deno task ci` — fmt + lint + check + 270 tests ✅
- `deno task bench` — three-engine cross-verification ✅
- `deno task publish:dry` — clean ✅

## Notes

The four allowlisted divergences (`agg-empty-group-count-graph`, `bindings:graph`, `load-silent`, `load-into-silent`) are cases where native is spec-correct and Comunica lite is buggy. Per the metric decision (#19), they route through a W3C-reference check (#20), which takes them off the allowlist and lands 336/336.

Related: #16, #19, #20