### PR TITLE
chore(w3c): raise the differential gate to 99%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - run: deno task publish:dry
   # W3C differential gate: native must agree with comunica on the vendored
   # SPARQL 1.1 evaluation-core suite. The pass rate is the tracked progress
-  # metric — this job goes green once >= 95% (>= 320/336) of the suite agrees
+  # metric — this job goes green once >= 99% (>= 333/336) of the suite agrees
   # and turns fully green when native converges with comunica everywhere.
   w3c-parity:
     runs-on: ubuntu-latest

--- a/test/w3c/w3c-main.ts
+++ b/test/w3c/w3c-main.ts
@@ -115,14 +115,14 @@ const { cases, skipped } = loadAllCases();
 const report = await new W3cRunner(readFixture).run(cases);
 printReport(report, skipped);
 
-// Coverage gate: the milestone target is >= 95% of the differential suite
-// passing (ceiling-rounded so 336 tests requires >= 320). Runner errors are
+// Coverage gate: the milestone target is >= 99% of the differential suite
+// passing (ceiling-rounded so 336 tests requires >= 333). Runner errors are
 // always fatal — they indicate a harness bug, not a parity gap.
-const threshold = Math.ceil(report.total * 0.95);
+const threshold = Math.ceil(report.total * 0.99);
 if (report.pass < threshold || report.error > 0) {
   console.error(
     `\nW3C differential gate FAILED: ${report.pass}/${report.total} pass is ` +
-      `below the ${threshold} (>=95%) threshold, with ${report.gap} parity ` +
+      `below the ${threshold} (>=99%) threshold, with ${report.gap} parity ` +
       `gap(s) and ${report.error} error(s). The parity-gap count is the ` +
       `tracked progress metric — each gap is a place native must converge ` +
       `with comunica.`,
@@ -131,6 +131,6 @@ if (report.pass < threshold || report.error > 0) {
 }
 console.log(
   `\nW3C differential gate passed: ${report.pass}/${report.total} pass is at ` +
-    `or above the ${threshold} (>=95%) threshold (plus ` +
+    `or above the ${threshold} (>=99%) threshold (plus ` +
     `${report.allowlisted} allowlisted documented divergences).`,
 );


### PR DESCRIPTION
Closes #17.

Completes the 99% parity milestone:

- `test:w3c` reports **336/336 pass · 0 gap · 0 error · 0 allowlisted · 0 skipped** (≥333/336 = 99.11%).
- Raises the gate to `Math.ceil(total * 0.99) = 333` in `test/w3c/w3c-main.ts`.
- Updates the `w3c-parity` job comment in `.github/workflows/ci.yml` to `>= 99% (>= 333/336)`.

No remaining gaps — the four former divergences are spec-verified against the W3C reference (per #19/#20), so the gap inventory is empty.

Verification:
- `deno task test:w3c` → 336/336, 0 gap, 0 error
- `deno task ci` → fmt + lint + check + 270 tests green
- `deno task bench` → three-engine cross-verification green