### PR TITLE
test(parity): guard REDUCED dedup against Comunica

### DIFF
--- a/test/parity/parity.test.ts
+++ b/test/parity/parity.test.ts
@@ -522,6 +522,13 @@ const wildcardCases: ParityTestCase[] = [
     orderSensitive: true,
   },
   {
+    name: "SELECT - REDUCED deduplicates duplicate projected solutions",
+    kind: "select",
+    query: `SELECT REDUCED ?o WHERE { ?s ${pPred} ?o } ORDER BY ?o`,
+    quads: pathGraphQuads,
+    orderSensitive: true,
+  },
+  {
     name: "SELECT - LIMIT and OFFSET slice ordered results",
     kind: "select",
     query: `SELECT ?o WHERE { ?s ${pPred} ?o } ORDER BY ?o LIMIT 2 OFFSET 1`,


### PR DESCRIPTION
Adds a `SELECT REDUCED` parity case that mirrors the existing `SELECT DISTINCT` case, so the REDUCED ≡ DISTINCT engine fix (landed in #21) is guarded by `deno test` rather than only the benchmark's cross-verification.

- New case: `SELECT REDUCED ?o WHERE { ?s <.../p> ?o } ORDER BY ?o` over `pathGraphQuads` (which contains duplicate `?o` values), asserted order-sensitively against Comunica.

Verification:
- `deno test --allow-all test/parity/parity.test.ts` → 140 passed
- `deno task ci` → fmt + lint + check + 271 tests green