### PR TITLE
feat: RDF 1.2 reified-triple and triple-term support (eval-triple-terms 33/41)

### DIFF
--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -28,6 +28,11 @@ import {
 } from "@/evaluator/join.ts";
 import type { ScanEntry, TermBinding } from "@/evaluator/join.ts";
 import { sameRdfTerm, sparqlTermToRdfTerm, termKey } from "@/term/mod.ts";
+import {
+  expandReifiedTriples,
+  isReifiesPattern,
+  RDF_REIFIES,
+} from "@/evaluator/reified.ts";
 
 export type { TermBinding } from "@/evaluator/join.ts";
 
@@ -184,32 +189,40 @@ export class BgpEvaluator {
     switch (pattern.type) {
       case "bgp": {
         let result = bindings;
-        for (const triple of pattern.triples) {
+        for (const triple of expandReifiedTriples(pattern.triples)) {
           if (isPropertyPath(triple.predicate)) {
             throw new Error(
               "Property paths inside EXISTS are not supported",
             );
           }
           const predicate = simplePredicate(triple.predicate);
+          const reifies = isReifiesPattern(predicate, triple.object);
           const entry: ScanEntry = {
             subject: triple.subject,
             predicate,
             object: triple.object,
+            reifies,
             // probeQuadIndex checks only s/p/o, so the graph scope is
-            // enforced afterwards over the probed candidates.
-            candidates: probeQuadIndex(
-              this.existsIndex!,
-              candidates,
-              triple.subject.termType === "Variable"
-                ? null
-                : sparqlTermToRdfTerm(triple.subject),
-              predicate.termType === "Variable"
-                ? null
-                : sparqlTermToRdfTerm(predicate),
-              triple.object.termType === "Variable"
-                ? null
-                : sparqlTermToRdfTerm(triple.object),
-            ).filter((item) => sameRdfTerm(item.graph, graph)),
+            // enforced afterwards over the probed candidates. Reifies
+            // patterns scan every `rdf:reifies` statement in the scope.
+            candidates: reifies
+              ? candidates.filter((item) =>
+                item.predicate.termType === "NamedNode" &&
+                item.predicate.value === RDF_REIFIES
+              )
+              : probeQuadIndex(
+                this.existsIndex!,
+                candidates,
+                triple.subject.termType === "Variable"
+                  ? null
+                  : sparqlTermToRdfTerm(triple.subject),
+                predicate.termType === "Variable"
+                  ? null
+                  : sparqlTermToRdfTerm(predicate),
+                triple.object.termType === "Variable"
+                  ? null
+                  : sparqlTermToRdfTerm(triple.object),
+              ).filter((item) => sameRdfTerm(item.graph, graph)),
           };
           result = joinTriplePattern(result, entry);
         }
@@ -569,12 +582,15 @@ export class BgpEvaluator {
     bindings: TermBinding[],
     store: rdfjs.Source<rdfjs.Quad>,
   ): Promise<TermBinding[]> {
-    const hasPath = triples.some((triple) => isPropertyPath(triple.predicate));
-    if (this.reorderPatterns && triples.length > 1 && !hasPath) {
-      return await this.evaluateWithReordering(triples, bindings, store);
+    // Reified-triple patterns (`<< s p o >>`, annotation `{| ... |}`) expand
+    // into plain `rdf:reifies` triples before any scanning or reordering.
+    const expanded = expandReifiedTriples(triples);
+    const hasPath = expanded.some((triple) => isPropertyPath(triple.predicate));
+    if (this.reorderPatterns && expanded.length > 1 && !hasPath) {
+      return await this.evaluateWithReordering(expanded, bindings, store);
     }
     let result = bindings;
-    for (const triple of triples) {
+    for (const triple of expanded) {
       if (isPropertyPath(triple.predicate)) {
         const entry = await scanPathEntry(
           store,

--- a/src/evaluator/expression-evaluator.ts
+++ b/src/evaluator/expression-evaluator.ts
@@ -630,6 +630,15 @@ export class ExpressionEvaluator {
    * everything else compares as RDF terms.
    */
   private valuesEqual(a: rdfjs.Term, b: rdfjs.Term): boolean {
+    if (a.termType === "Quad" && b.termType === "Quad") {
+      // RDFterm-equal recurses through triple terms on all three positions.
+      return this.valuesEqual(a.subject, b.subject) &&
+        this.valuesEqual(a.predicate, b.predicate) &&
+        this.valuesEqual(a.object, b.object);
+    }
+    if (a.termType === "Quad" || b.termType === "Quad") {
+      return false;
+    }
     if (a.termType !== "Literal" || b.termType !== "Literal") {
       return sameRdfTerm(a, b);
     }

--- a/src/evaluator/join.ts
+++ b/src/evaluator/join.ts
@@ -10,6 +10,7 @@ import {
   probeQuadIndex,
   simplePredicate,
 } from "@/quad-store.ts";
+import { isReifiesPattern } from "@/evaluator/reified.ts";
 import { sameRdfTerm, sparqlTermToRdfTerm, termKey } from "@/term/mod.ts";
 
 /**
@@ -29,6 +30,12 @@ export interface ScanEntry {
   predicate: SparqlTerm;
   object: SparqlTerm;
   candidates: rdfjs.Quad[];
+  /**
+   * reifies marks a `?r rdf:reifies <<( s p o )>>` pattern, which joins by
+   * decomposing each candidate's quoted-triple-term object instead of
+   * matching the object position directly.
+   */
+  reifies?: boolean;
 }
 
 /**
@@ -149,12 +156,24 @@ export function scanEntry(
   const subject = pattern.subject;
   const predicate = simplePredicate(pattern.predicate);
   const object = pattern.object;
-  return matchQuads(
-    store,
-    patternConstant(subject),
-    patternConstant(predicate),
-    patternConstant(object),
-  ).then((candidates) => ({ subject, predicate, object, candidates }));
+  const reifies = isReifiesPattern(predicate, object);
+  // Reifies patterns scan every `rdf:reifies` statement; the join decomposes
+  // each candidate's quoted triple term. Everything else matches positionally.
+  const candidates = reifies
+    ? matchQuads(store, null, predicate, null)
+    : matchQuads(
+      store,
+      patternConstant(subject),
+      patternConstant(predicate),
+      patternConstant(object),
+    );
+  return candidates.then((cs) => ({
+    subject,
+    predicate,
+    object,
+    candidates: cs,
+    reifies,
+  }));
 }
 
 function isQueryVar(term: SparqlTerm): boolean {
@@ -178,6 +197,9 @@ export function joinTriplePattern(
   currentBindings: TermBinding[],
   entry: ScanEntry,
 ): TermBinding[] {
+  if (entry.reifies) {
+    return joinReifiesPattern(currentBindings, entry);
+  }
   const subject = entry.subject;
   const predicate = entry.predicate;
   const object = entry.object;
@@ -261,6 +283,79 @@ export function joinTriplePattern(
   }
 
   return nextBindings;
+}
+
+/**
+ * matchReifierPosition matches one position of a quoted triple term against a
+ * concrete term: a variable position binds (or must agree with an existing
+ * binding), and a constant position must be the same RDF term.
+ */
+function matchReifierPosition(
+  term: SparqlTerm,
+  value: rdfjs.Term,
+  binding: TermBinding,
+): TermBinding | null {
+  if (isQueryVar(term)) {
+    const name = getQueryVarName(term);
+    const existing = binding[name];
+    if (existing !== undefined) {
+      return sameRdfTerm(existing, value) ? binding : null;
+    }
+    return { ...binding, [name]: value };
+  }
+  return sameRdfTerm(sparqlTermToRdfTerm(term), value) ? binding : null;
+}
+
+/**
+ * joinReifiesPattern joins solutions against a `?r rdf:reifies <<( s p o )>>`
+ * pattern. Each candidate `X rdf:reifies TT` decomposes its quoted triple term
+ * TT and matches its subject/predicate/object against the pattern's three
+ * positions (binding variables), then binds the reifier variable to X.
+ */
+function joinReifiesPattern(
+  currentBindings: TermBinding[],
+  entry: ScanEntry,
+): TermBinding[] {
+  const reifier = entry.subject;
+  const tripleTerm = entry.object as rdfjs.Quad;
+  const result: TermBinding[] = [];
+  for (const binding of currentBindings) {
+    for (const candidate of entry.candidates) {
+      if (candidate.object.termType !== "Quad") {
+        continue;
+      }
+      const quoted = candidate.object as rdfjs.Quad;
+      let extended = matchReifierPosition(
+        tripleTerm.subject,
+        quoted.subject,
+        binding,
+      );
+      if (extended === null) {
+        continue;
+      }
+      extended = matchReifierPosition(
+        tripleTerm.predicate,
+        quoted.predicate,
+        extended,
+      );
+      if (extended === null) {
+        continue;
+      }
+      extended = matchReifierPosition(
+        tripleTerm.object,
+        quoted.object,
+        extended,
+      );
+      if (extended === null) {
+        continue;
+      }
+      const bound = matchReifierPosition(reifier, candidate.subject, extended);
+      if (bound !== null) {
+        result.push(bound);
+      }
+    }
+  }
+  return result;
 }
 
 /**

--- a/src/evaluator/reified.ts
+++ b/src/evaluator/reified.ts
@@ -1,0 +1,96 @@
+import type * as rdfjs from "@rdfjs/types";
+import { DataFactory } from "n3";
+import type { Term as SparqlTerm, Triple } from "@/parser/sparql-parser.ts";
+
+/**
+ * RDF_REIFIES is the RDF 1.2 predicate connecting a reifier to the triple
+ * term it reifies. Reified-triple data (`<< s p o >>`, annotation syntax
+ * `{| ... |}`) is materialized by n3 as `_:r rdf:reifies <<( s p o )>>`,
+ * so pattern matching routes through this predicate.
+ */
+export const RDF_REIFIES = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
+
+/**
+ * reifierCounter mints distinct reifier labels across a process. Labels are
+ * opaque (never projected), so uniqueness is all that matters; the `reifier-`
+ * prefix is disjoint from the parser's `e_`/`g_` blank-node labels and n3's
+ * `n3-` data labels.
+ */
+let reifierCounter = 0;
+
+function freshReifier(): rdfjs.BlankNode {
+  return DataFactory.blankNode(`reifier-${reifierCounter++}`);
+}
+
+interface ExpandedTerm {
+  /** term is the substituted term (a reifier for quoted triples). */
+  term: SparqlTerm;
+  /** triples are the emitted `rdf:reifies` statements for nested reifiers. */
+  triples: Triple[];
+}
+
+/**
+ * expandQuotedTerm expands one RDF 1.2 reified-triple pattern term
+ * (`<< s p o >>`) into a fresh reifier variable plus the `rdf:reifies`
+ * statement that binds it to the quoted triple term. Nested quoted triples
+ * recurse, so `<< << s p o >> q r >>` produces two reifiers chained through
+ * their `rdf:reifies` statements.
+ */
+function expandQuotedTerm(term: SparqlTerm): ExpandedTerm {
+  if (term.termType !== "Quad") {
+    return { term, triples: [] };
+  }
+  const s = expandQuotedTerm(term.subject);
+  const p = expandQuotedTerm(term.predicate);
+  const o = expandQuotedTerm(term.object);
+  const reifier = freshReifier();
+  const tripleTerm: rdfjs.Quad = DataFactory.quad(
+    s.term as rdfjs.Quad_Subject,
+    p.term as rdfjs.Quad_Predicate,
+    o.term as rdfjs.Quad_Object,
+  );
+  const reifies: Triple = {
+    subject: reifier,
+    predicate: DataFactory.namedNode(RDF_REIFIES),
+    object: tripleTerm,
+  };
+  return {
+    term: reifier,
+    triples: [...s.triples, ...p.triples, ...o.triples, reifies],
+  };
+}
+
+/**
+ * expandReifiedTriples rewrites a triple-pattern block so reified-triple
+ * patterns (`<< s p o >>` in subject or object position) become plain
+ * triples that match the RDF 1.2 reifier representation in the store. Each
+ * quoted term becomes a fresh reifier (a blank node the BGP treats as an
+ * internal variable) joined to its quoted triple term via `rdf:reifies`.
+ */
+export function expandReifiedTriples(triples: Triple[]): Triple[] {
+  const expanded: Triple[] = [];
+  for (const triple of triples) {
+    const s = expandQuotedTerm(triple.subject);
+    const o = expandQuotedTerm(triple.object);
+    // A predicate is never a quoted triple (property paths are not terms),
+    // so it passes through unchanged.
+    const p = triple.predicate;
+    expanded.push(...s.triples, ...o.triples);
+    expanded.push({ subject: s.term, predicate: p, object: o.term });
+  }
+  return expanded;
+}
+
+/**
+ * isReifiesPattern reports whether a triple pattern is the `rdf:reifies`
+ * decomposition form — a `rdf:reifies` predicate with a quoted-triple-term
+ * object — which the join must decompose from the store's reifier quads.
+ */
+export function isReifiesPattern(
+  predicate: SparqlTerm,
+  object: SparqlTerm,
+): boolean {
+  return predicate.termType === "NamedNode" &&
+    predicate.value === RDF_REIFIES &&
+    object.termType === "Quad";
+}

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -18,6 +18,7 @@ import type {
 } from "@/sparql-engine-interface.ts";
 import { aggregateValue, groupSolutions } from "@/evaluator/aggregate.ts";
 import { innerJoin } from "@/evaluator/join.ts";
+import { expandReifiedTriples } from "@/evaluator/reified.ts";
 import {
   BgpEvaluator,
   expressionContainsExists,
@@ -427,12 +428,17 @@ export class SparqlEvaluator {
       return { quads };
     }
 
+    // Reified-triple templates (`<< s p o >>`, annotation `{| ... |}`)
+    // expand into a reifier blank node joined to its `rdf:reifies` triple
+    // term, so the template instantiates the RDF 1.2 reifier representation.
+    const template = expandReifiedTriples(query.template);
+
     for (const binding of bindings) {
       // Blank nodes in a CONSTRUCT template are fresh per solution mapping
       // (SPARQL 1.1 §16.2.1): the parser expands RDF collections and _:b
       // template terms into shared labels, so remap them per binding.
       const bnodeMap = new Map<string, rdfjs.BlankNode>();
-      for (const t of query.template) {
+      for (const t of template) {
         const s = this.resolveConstructTerm(t.subject, binding, bnodeMap);
         const p = this.resolveConstructTerm(
           simplePredicate(t.predicate),
@@ -527,8 +533,19 @@ export class SparqlEvaluator {
       return fresh;
     }
     if (term.termType === "Quad") {
-      throw new Error(
-        "Reified-triple CONSTRUCT templates are not yet supported",
+      // A triple term in a template resolves its three positions recursively,
+      // so embedded variables and nested quoted triples instantiate per
+      // solution.
+      const s = this.resolveConstructTerm(term.subject, binding, bnodeMap);
+      const p = this.resolveConstructTerm(term.predicate, binding, bnodeMap);
+      const o = this.resolveConstructTerm(term.object, binding, bnodeMap);
+      if (!s || !p || !o) {
+        return null;
+      }
+      return DataFactory.quad(
+        s as rdfjs.Quad_Subject,
+        p as rdfjs.Quad_Predicate,
+        o as rdfjs.Quad_Object,
       );
     }
     return sparqlTermToRdfTerm(term);

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -526,6 +526,11 @@ export class SparqlEvaluator {
       bnodeMap.set(term.value, fresh);
       return fresh;
     }
+    if (term.termType === "Quad") {
+      throw new Error(
+        "Reified-triple CONSTRUCT templates are not yet supported",
+      );
+    }
     return sparqlTermToRdfTerm(term);
   }
 }

--- a/src/evaluator/update-evaluator.ts
+++ b/src/evaluator/update-evaluator.ts
@@ -687,6 +687,11 @@ export class UpdateEvaluator {
       bnodeMap.set(term.value, fresh);
       return fresh;
     }
+    if (term.termType === "Quad") {
+      throw new Error(
+        "Reified-triple update templates are not yet supported",
+      );
+    }
     // Constants resolve through the shared term conversion; only the blank
     // node handling is update-specific (fresh labels per execution).
     return sparqlTermToRdfTerm(term);

--- a/src/evaluator/update-evaluator.ts
+++ b/src/evaluator/update-evaluator.ts
@@ -20,6 +20,7 @@ import {
   simplePredicate,
 } from "@/quad-store.ts";
 import { sameRdfTerm, sparqlTermToRdfTerm, termKey } from "@/term/mod.ts";
+import { expandReifiedTriples } from "@/evaluator/reified.ts";
 import { DataFactory } from "n3";
 
 const { blankNode, quad, defaultGraph } = DataFactory;
@@ -442,9 +443,16 @@ export class UpdateEvaluator {
     if (bindings.length === 0) {
       return;
     }
-    const graph = pattern.type === "graph"
-      ? this.convertTerm(pattern.name, null)
-      : (withGraph ?? defaultGraph());
+    const graphName = pattern.type === "graph" ? pattern.name : null;
+    // A variable graph name resolves per solution (`GRAPH ?g { ... }`); a
+    // constant graph (or a non-GRAPH template) fixes the graph for every
+    // solution and keeps the single store scan.
+    const variableGraph = graphName?.termType === "Variable";
+    const fixedGraph = !variableGraph
+      ? graphName
+        ? this.convertTerm(graphName, null)
+        : (withGraph ?? defaultGraph())
+      : null;
     const triples: Triple[] =
       (pattern as unknown as { triples?: Triple[] }).triples ??
         (pattern as unknown as { patterns?: { triples?: Triple[] }[] }).patterns
@@ -452,12 +460,13 @@ export class UpdateEvaluator {
         [];
     for (const triple of triples) {
       const scan = this.deleteScanPositions(triple);
+      // A variable graph scans every graph and filters per solution below.
       const candidates = await matchQuads(
         this.options.store,
         scan.s,
         scan.p,
         scan.o,
-        graph,
+        variableGraph ? null : fixedGraph,
       );
       const index = buildQuadIndex(candidates);
       // Quads are removed at most once across all solutions: a second
@@ -465,6 +474,14 @@ export class UpdateEvaluator {
       // index scan, and buffering duplicate deletes wastes transaction space.
       const removed = new Set<string>();
       for (const binding of bindings) {
+        let graph: rdfjs.Term | null = fixedGraph;
+        if (variableGraph) {
+          const bound = binding[graphName!.value];
+          if (!bound) {
+            continue;
+          }
+          graph = bound;
+        }
         const subject = this.resolveDeleteTerm(triple.subject, binding);
         const predicate = this.resolveDeleteTerm(
           simplePredicate(triple.predicate),
@@ -485,6 +502,9 @@ export class UpdateEvaluator {
           object.kind === "wildcard" ? null : object.term,
         );
         for (const item of matches) {
+          if (variableGraph && !sameRdfTerm(item.graph, graph!)) {
+            continue;
+          }
           const key = termKey(item);
           if (removed.has(key)) {
             continue;
@@ -535,12 +555,12 @@ export class UpdateEvaluator {
       ? this.convertTerm(pattern.name, null)
       : (withGraph ?? defaultGraph());
     const quads: rdfjs.Quad[] = [];
-    const triples: Triple[] =
+    const rawTriples: Triple[] =
       (pattern as unknown as { triples?: Triple[] }).triples ??
         (pattern as unknown as { patterns?: { triples?: Triple[] }[] }).patterns
           ?.flatMap((p) => p.triples ?? []) ??
         [];
-    for (const triple of triples) {
+    for (const triple of expandReifiedTriples(rawTriples)) {
       const subject = this.resolveInsertTerm(triple.subject, binding, bnodeMap);
       const predicate = this.resolveInsertTerm(
         simplePredicate(triple.predicate),
@@ -620,6 +640,22 @@ export class UpdateEvaluator {
       bnodeMap.set(term.value, fresh);
       return { kind: "value", term: fresh };
     }
+    if (term.termType === "Quad") {
+      const s = this.resolveInsertTerm(term.subject, binding, bnodeMap);
+      const p = this.resolveInsertTerm(term.predicate, binding, bnodeMap);
+      const o = this.resolveInsertTerm(term.object, binding, bnodeMap);
+      if (s.kind !== "value" || p.kind !== "value" || o.kind !== "value") {
+        return { kind: "skip" };
+      }
+      return {
+        kind: "value",
+        term: quad(
+          s.term as rdfjs.Quad_Subject,
+          p.term as rdfjs.Quad_Predicate,
+          o.term as rdfjs.Quad_Object,
+        ),
+      };
+    }
     return { kind: "value", term: this.convertTerm(term, null) };
   }
 
@@ -633,11 +669,12 @@ export class UpdateEvaluator {
     pattern: Pattern,
     bnodeMap: Map<string, rdfjs.BlankNode> | null,
   ): rdfjs.Quad[] {
-    const triples: Triple[] =
+    const rawTriples: Triple[] =
       (pattern as unknown as { triples?: Triple[] }).triples ??
         (pattern as unknown as { patterns?: { triples?: Triple[] }[] }).patterns
           ?.flatMap((p) => p.triples ?? []) ??
         [];
+    const triples: Triple[] = expandReifiedTriples(rawTriples);
     if (pattern.type === "graph") {
       const graph = this.convertTerm(pattern.name, bnodeMap);
       return triples.map((item) => this.convertTriple(item, graph, bnodeMap));
@@ -688,8 +725,10 @@ export class UpdateEvaluator {
       return fresh;
     }
     if (term.termType === "Quad") {
-      throw new Error(
-        "Reified-triple update templates are not yet supported",
+      return quad(
+        this.convertTerm(term.subject, bnodeMap) as rdfjs.Quad_Subject,
+        this.convertTerm(term.predicate, bnodeMap) as rdfjs.Quad_Predicate,
+        this.convertTerm(term.object, bnodeMap) as rdfjs.Quad_Object,
       );
     }
     // Constants resolve through the shared term conversion; only the blank

--- a/src/term/convert.ts
+++ b/src/term/convert.ts
@@ -23,6 +23,11 @@ export function sparqlTermToRdfTerm(term: SparqlTerm): rdfjs.Term {
         return literal(term.value, namedNode(term.datatype.value));
       }
       return literal(term.value);
+    case "Quad":
+      // RDF 1.2 triple terms are already RDF/JS Quad terms (the parser builds
+      // them with N3's DataFactory); their sub-terms are structural matches,
+      // so pass them through unchanged.
+      return term;
     default:
       throw new Error(`Unsupported term type: ${term.termType}`);
   }

--- a/src/term/ordering.ts
+++ b/src/term/ordering.ts
@@ -52,12 +52,13 @@ function compareLiterals(a: rdfjs.Literal, b: rdfjs.Literal): number {
 /**
  * compareRdfTerms orders two RDF terms (or undefined for an unbound
  * variable) per SPARQL 1.1 §12.4: unbound sorts lowest, then blank nodes,
- * then IRIs, then literals. Literals order by datatype IRI first (plain
- * literals counting as xsd:string), numerically within the same numeric
- * datatype, then by lexical form. Blank-node labels and the relative order
- * of terms the spec leaves undefined (mixed blank nodes, RDF-star quads)
- * are compared deterministically. Returns a negative, zero, or positive
- * number suitable for Array.prototype.sort.
+ * then IRIs, then literals, then triple terms (per RDF 1.2's total order).
+ * Literals order by datatype IRI first (plain literals counting as
+ * xsd:string), numerically within the same numeric datatype, then by lexical
+ * form. Triple terms order lexicographically by subject, predicate, then
+ * object, recursively. Blank-node labels and the relative order of terms the
+ * spec leaves undefined are compared deterministically. Returns a negative,
+ * zero, or positive number suitable for Array.prototype.sort.
  */
 export function compareRdfTerms(
   a: rdfjs.Term | undefined,
@@ -94,6 +95,15 @@ export function compareRdfTerms(
       return compareStrings(a.value, (b as rdfjs.NamedNode).value);
     case "Literal":
       return compareLiterals(a as rdfjs.Literal, b as rdfjs.Literal);
+    case "Quad": {
+      // Triple terms order lexicographically by subject, predicate, then
+      // object (recursively), ignoring the graph component.
+      const qa = a as rdfjs.Quad;
+      const qb = b as rdfjs.Quad;
+      return compareRdfTerms(qa.subject, qb.subject) ||
+        compareRdfTerms(qa.predicate, qb.predicate) ||
+        compareRdfTerms(qa.object, qb.object);
+    }
     default:
       return compareStrings(termKey(a), termKey(b));
   }

--- a/test/w3c/sparql12-gap.ts
+++ b/test/w3c/sparql12-gap.ts
@@ -394,7 +394,7 @@ async function evaluate(testCase: W3cTestCase): Promise<Verdict> {
   }
 
   // ttl (CONSTRUCT) and trig (update) both compare a final graph.
-  const reference = parseGraphReference(testCase, resultFile);
+  const reference = parseGraphReference(testCase, compareFile);
   if (native.result.kind === "construct") {
     const nativeRecords = nativeQuadRecords(native.result.data.quads);
     if (isomorphicMultiset(nativeRecords, reference)) return { status: "pass" };

--- a/test/w3c/sparql12-gap.ts
+++ b/test/w3c/sparql12-gap.ts
@@ -351,27 +351,26 @@ async function evaluate(testCase: W3cTestCase): Promise<Verdict> {
     };
   }
 
-  if (kind === "srx") {
-    // SPARQL XML results are not parsed yet; their .srj siblings cover the
-    // same query/data, so defer these two tests until an XML reader lands.
-    return {
-      status: "deferred",
-      detail: "SPARQL XML result parsing not yet implemented",
-    };
-  }
+  // SPARQL XML results (.srx) and their JSON siblings (.srj) encode the same
+  // expected bindings — the W3C suite ships both serializations for one
+  // test — so route XML results through the JSON reader.
+  const compareFile = kind === "srx"
+    ? resultFile?.replace(/\.srx$/, ".srj")
+    : resultFile;
+  const compareKind = kind === "srx" ? "srj" : kind;
 
-  if (!resultFile) {
+  if (!compareFile) {
     return { status: "error", detail: "no result file" };
   }
 
-  if (kind === "srj") {
+  if (compareKind === "srj") {
     if (native.result.kind !== "select") {
       return {
         status: "error",
         detail: `expected SELECT, native returned ${native.result.kind}`,
       };
     }
-    const reference = parseSrj(resultFile);
+    const reference = parseSrj(compareFile);
     const nativeRecords = nativeSelectRecords(native.result);
     const referenceRecords = recordsOf(reference);
     if (isomorphicMultiset(nativeRecords, referenceRecords)) {


### PR DESCRIPTION
## Summary

Implements the evaluator half of #32 and the unambiguous semantic gaps of #29: accept Quad triple terms at the parser-to-term boundary, match `<< s p o >>` reified-triple and `{| ... |}` annotation patterns through `rdf:reifies`, instantiate those templates in CONSTRUCT/update, and handle triple-term value-equality and ordering.

## Commits

- `43fa2b8` feat(evaluator): match RDF 1.2 reified-triple patterns through rdf:reifies
- `de5bb6a` feat(evaluator): instantiate reified-triple CONSTRUCT and update templates (plus variable-graph DELETE)
- `79cf9e3` feat(evaluator): value-equality and ordering over RDF 1.2 triple terms
- `f2ef745` test(w3c): route SPARQL XML results through their JSON siblings
- `5df195d` fix(w3c): narrow the result file in the gap harness srx routing

## Measurement (native vs W3C reference)

`deno run --allow-all test/w3c/sparql12-gap.ts`:

```
before: 6 pass  · 2 gap · 31 error · 2 deferred
after:  33 pass · 1 gap · 7 error · 0 deferred
```

## Remaining 8 gaps (all triaged)

- **construct-5** (1, HOLD) — the fixture's two-reifier translation contradicts construct-4's one-reifier form for the same RDF-star annotation; traced to w3c/rdf-tests#168 with no documented resolution.
- **grammar** (7) — `<<( )>>` triple-term syntax (basic-8/9, pattern-10/11, expr-1/2) and `~` reifier binding (pattern-8); these need the vendored jison parser regenerated (#31), not hand-editable parse tables.

## Verification

- `deno task ci` → 271 tests green
- `deno task test:w3c` → 336/336 full pass (1.1 gate unchanged)
- `deno task bench` → three-engine cross-verification green

Progress on #32; unblocks part of #29.