### PR TITLE
docs: document relationship to @worlds/client SparqlEngineInterface

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,8 +26,25 @@ engine for RDF/JS Quad Stores (`rdfjs.Store`).
 
 ## Contracts
 
-- `SparqlEngineInterface`: Canonical Wazoo SPARQL engine execution interface.
+- `SparqlEngineInterface`: SPARQL engine execution interface, duplicated
+  identically from `@worlds/client` (see Relationship to @worlds/client).
 - `SparqlRequest` / `SparqlResponse`: Strongly typed request and response
   envelopes (`select`, `ask`, `construct`, `void`).
-- `NativeSparqlTransaction`: Structural interface for atomic SPARQL `UPDATE`
+- `WazooSparqlTransaction`: Structural interface for atomic SPARQL `UPDATE`
   mutations.
+
+## Relationship to @worlds/client
+
+`WazooSparqlEngine` implements the same `SparqlEngineInterface` as
+`ComunicaSparqlEngine` in `@worlds/client` (`@worlds/client/comunica`), so it is
+a drop-in replacement: swap the `sparqlEngine` passed to a `Client` without
+changing client code. `WazooSparqlTransaction` mirrors the structural shape of
+`@worlds/client`'s `Transaction`, so durable backends can pass their existing
+transaction objects.
+
+The interface is intentionally duplicated in both packages under an
+identical-spec policy: the two copies must stay identical. Behavioral deltas
+today: `ComunicaSparqlEngine` enforces `timeoutMs` and accepts a request-level
+`baseIri`, while the native engine derives the base IRI from the query's `BASE`
+directive and does not yet enforce a timeout. Keep these differences in mind
+when swapping engines.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,6 +2,15 @@
 
 - **WazooSparqlEngine** — the in-repo SPARQL engine; the subject of this effort.
   Must be observably interchangeable with the parity reference.
+- **SparqlEngineInterface** — the shared execution contract
+  (`execute(request) => Promise<SparqlResponse>`) that `WazooSparqlEngine`
+  implements and `@worlds/client`'s `ComunicaSparqlEngine` also implements. The
+  interface is duplicated identically in both packages under an identical-spec
+  policy; reconcile any drift deliberately.
+- **ComunicaSparqlEngine** — the `@worlds/client` adapter
+  (`@worlds/client/comunica`) that wraps a caller-provided Comunica engine over
+  an RDF/JS store. `WazooSparqlEngine` is a drop-in replacement behind
+  `SparqlEngineInterface`, with no client changes.
 - **Parity reference** — the installed `@comunica/query-sparql-rdfjs-lite`
   (5.3.0) that the native engine is measured against. The porting surface is the
   lite config (`config-rdfjs-lite-v5-1-3.json` in the Comunica monorepo).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Wazoo-native SPARQL 1.1 Query & Update Engine over RDF/JS Quad Stores.
   Comunica framework overhead.
 - **JSR & Deno Native**: Published on JSR as `@wazoo/sparql-engine` for Deno,
   Node.js, and browser environments.
+- **Drop-in for `@worlds/client`**: Implements the same `SparqlEngineInterface`
+  as `ComunicaSparqlEngine` (`@worlds/client/comunica`), so it can be swapped
+  into a `Client` without client changes.
 
 ## Usage
 


### PR DESCRIPTION
Documents the relationship between @wazoo/sparql-engine and @worlds/client: WazooSparqlEngine implements the same SparqlEngineInterface as ComunicaSparqlEngine and is a drop-in replacement behind Client.sparql.