### PR TITLE
feat(evaluator): implement DESCRIBE with outgoing-arc descriptions

### DIFF
--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -3,6 +3,7 @@ import type {
   AggregateExpression,
   AskQuery,
   ConstructQuery,
+  DescribeQuery,
   Expression,
   Pattern,
   SelectQuery,
@@ -24,7 +25,11 @@ import {
   expressionContainsExists,
 } from "@/evaluator/bgp-evaluator.ts";
 import type { TermBinding } from "@/evaluator/bgp-evaluator.ts";
-import { buildDatasetStore, simplePredicate } from "@/quad-store.ts";
+import {
+  buildDatasetStore,
+  matchQuads,
+  simplePredicate,
+} from "@/quad-store.ts";
 import { ExpressionEvaluator } from "@/evaluator/expression-evaluator.ts";
 import type { ExpressionEvaluationContext } from "@/evaluator/expression-evaluator.ts";
 import {
@@ -123,8 +128,17 @@ export class SparqlEvaluator {
               kind: "construct",
               data: await this.evaluateConstruct(query),
             };
+          case "DESCRIBE":
+            return {
+              kind: "construct",
+              data: await this.evaluateDescribe(query),
+            };
           default:
-            throw new Error(`Unsupported query type: ${query.queryType}`);
+            throw new Error(
+              `Unsupported query type: ${
+                (query as { queryType?: string }).queryType
+              }`,
+            );
         }
       default:
         throw new Error(`Unsupported SPARQL operation type: ${query.type}`);
@@ -415,6 +429,89 @@ export class SparqlEvaluator {
       head: { link: null },
       boolean: bindings.length > 0,
     };
+  }
+
+  /**
+   * describeStoreFor returns the RDF/JS source to describe against: the
+   * shared store, or the materialized active dataset for a query with
+   * FROM / FROM NAMED clauses (mirrors bgpEvaluatorFor).
+   */
+  private async describeStoreFor(
+    from: { default: SparqlTerm[]; named: SparqlTerm[] } | undefined,
+  ): Promise<rdfjs.Source<rdfjs.Quad>> {
+    if (
+      from === undefined ||
+      (from.default.length === 0 && from.named.length === 0)
+    ) {
+      return this.store;
+    }
+    return await buildDatasetStore(
+      this.store,
+      from.default.map((term) => sparqlTermToRdfTerm(term)),
+      from.named.map((term) => sparqlTermToRdfTerm(term)),
+    );
+  }
+
+  /**
+   * evaluateDescribe implements DESCRIBE (SPARQL 1.1 §16.4). The described
+   * resources are the explicit IRIs from the DESCRIBE list plus, per
+   * solution, the IRI/blank-node bindings of the listed variables — or of
+   * every variable for DESCRIBE * — from the optional WHERE clause.
+   * Literals are not describable. Each resource's description is its
+   * outgoing arcs, the shape the Comunica parity oracle produces (the spec
+   * leaves the description shape to the implementation); the result is an
+   * RDF graph, so duplicates collapse.
+   */
+  private async evaluateDescribe(
+    query: DescribeQuery,
+  ): Promise<SparqlConstructResults> {
+    const bindings = query.where?.length
+      ? await (await this.bgpEvaluatorFor(query.from)).evaluateBgp(query.where)
+      : [];
+
+    const resources = new Set<rdfjs.Term>();
+    const collect = (term: rdfjs.Term | undefined): void => {
+      if (
+        term !== undefined &&
+        (term.termType === "NamedNode" || term.termType === "BlankNode")
+      ) {
+        resources.add(term);
+      }
+    };
+    for (const variable of query.variables) {
+      const termType = (variable as { termType?: string }).termType;
+      if (termType === "NamedNode") {
+        // DESCRIBE <iri> — the WHERE clause does not add resources.
+        resources.add(variable as unknown as rdfjs.Term);
+      } else if (termType === "Variable") {
+        const name = (variable as { value: string }).value;
+        for (const binding of bindings) {
+          collect(binding[name]);
+        }
+      } else if (termType === "Wildcard") {
+        for (const binding of bindings) {
+          for (const name of Object.keys(binding)) {
+            collect(binding[name]);
+          }
+        }
+      }
+    }
+
+    const source = await this.describeStoreFor(query.from);
+    const quads: rdfjs.Quad[] = [];
+    for (const resource of resources) {
+      quads.push(...(await matchQuads(source, resource, null, null)));
+    }
+    const seen = new Set<string>();
+    const graph: rdfjs.Quad[] = [];
+    for (const quad of quads) {
+      const key = termKey(quad);
+      if (!seen.has(key)) {
+        seen.add(key);
+        graph.push(quad);
+      }
+    }
+    return { quads: graph };
   }
 
   private async evaluateConstruct(

--- a/src/wazoo-sparql-engine.test.ts
+++ b/src/wazoo-sparql-engine.test.ts
@@ -880,6 +880,116 @@ Deno.test("WazooSparqlEngine - ASK query evaluation", async () => {
   }
 });
 
+Deno.test("WazooSparqlEngine - DESCRIBE IRI returns outgoing arcs", async () => {
+  const store = new Store();
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/alice"),
+      namedNode("http://example.org/name"),
+      literal("Ethan"),
+    ),
+  );
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/bob"),
+      namedNode("http://example.org/knows"),
+      namedNode("http://example.org/alice"),
+    ),
+  );
+  const engine = new WazooSparqlEngine({ store });
+  const result = await engine.execute({
+    query: "DESCRIBE <http://example.org/alice>",
+  });
+  assertEquals(result.kind, "construct");
+  if (result.kind === "construct") {
+    // Outgoing arcs only: bob knows alice is incoming and must be excluded.
+    assertEquals(result.data.quads.length, 1);
+    assertEquals(
+      result.data.quads[0].predicate.value,
+      "http://example.org/name",
+    );
+  }
+});
+
+Deno.test("WazooSparqlEngine - DESCRIBE variable describes bindings, skips literals", async () => {
+  const store = new Store();
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/a"),
+      namedNode("http://example.org/p"),
+      literal("hello"),
+    ),
+  );
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/a"),
+      namedNode("http://example.org/q"),
+      namedNode("http://example.org/b"),
+    ),
+  );
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/b"),
+      namedNode("http://example.org/r"),
+      namedNode("http://example.org/c"),
+    ),
+  );
+  const engine = new WazooSparqlEngine({ store });
+  const result = await engine.execute({
+    query: "DESCRIBE ?o WHERE { <http://example.org/a> ?p ?o }",
+  });
+  assertEquals(result.kind, "construct");
+  if (result.kind === "construct") {
+    // ?o binds the literal (not describable) and :b; only :b is described.
+    const contents = result.data.quads.map((q) =>
+      `${q.subject.value} ${q.predicate.value} ${q.object.value}`
+    );
+    assertEquals(contents, [
+      "http://example.org/b http://example.org/r http://example.org/c",
+    ]);
+  }
+});
+Deno.test("WazooSparqlEngine - DESCRIBE star describes the bound variables only", async () => {
+  const store = new Store();
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/a"),
+      namedNode("http://example.org/p"),
+      namedNode("http://example.org/b"),
+    ),
+  );
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/b"),
+      namedNode("http://example.org/p"),
+      namedNode("http://example.org/c"),
+    ),
+  );
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/a"),
+      namedNode("http://example.org/p"),
+      namedNode("http://example.org/c"),
+    ),
+  );
+  const engine = new WazooSparqlEngine({ store });
+  const result = await engine.execute({
+    query: "PREFIX : <http://example.org/> DESCRIBE * WHERE { :a :p ?o }",
+  });
+  assertEquals(result.kind, "construct");
+  if (result.kind === "construct") {
+    // DESCRIBE * describes the variables bound in the WHERE (?o → :b, :c),
+    // not the constant :a; only :b has an outgoing arc. The result is a
+    // deduped graph set.
+    const contents = result.data.quads.map((q) =>
+      `${q.subject.value} ${q.predicate.value} ${q.object.value}`
+    );
+    assertEquals(contents, [
+      "http://example.org/b http://example.org/p http://example.org/c",
+    ]);
+  }
+});
+
 Deno.test("WazooSparqlEngine - CONSTRUCT query evaluation", async () => {
   const store = new Store();
   store.addQuad(

--- a/test/parity/parity-harness.ts
+++ b/test/parity/parity-harness.ts
@@ -12,7 +12,7 @@ import { createQuadStore } from "./parity-fixtures.ts";
 /**
  * ParityQueryKind selects which result channel a parity test case compares.
  */
-export type ParityQueryKind = "select" | "ask" | "construct";
+export type ParityQueryKind = "select" | "ask" | "construct" | "describe";
 
 /**
  * ParityTestCase describes a single differential query comparison.
@@ -338,6 +338,23 @@ async function compareResult(
       );
       const nativeQuads = nativeResult.data.quads.map(canonicalQuadString);
       return compareMultisets(comunicaQuads, nativeQuads, "CONSTRUCT quads");
+    }
+    case "describe": {
+      if (nativeResult.kind !== "construct") {
+        return `Native engine returned ${nativeResult.kind} instead of construct (DESCRIBE)`;
+      }
+      const comunicaQuads = await runComunicaConstruct(
+        comunicaEngine,
+        testCase.query,
+        comunicaStore,
+      );
+      // DESCRIBE results are graphs (sets): Comunica's stream may repeat a
+      // resource's arcs, so both sides are deduplicated before comparing.
+      const comunicaSet = [...new Set(comunicaQuads)];
+      const nativeSet = [
+        ...new Set(nativeResult.data.quads.map(canonicalQuadString)),
+      ];
+      return compareMultisets(comunicaSet, nativeSet, "DESCRIBE quads");
     }
   }
 }

--- a/test/parity/parity.test.ts
+++ b/test/parity/parity.test.ts
@@ -472,6 +472,40 @@ const constructCases: ParityTestCase[] = [
   },
 ];
 
+const describeCases: ParityTestCase[] = [
+  {
+    name: "DESCRIBE - IRI resource: outgoing arcs only",
+    kind: "describe",
+    query: `DESCRIBE ${exampleAlice}`,
+    quads: basicKnowledgeGraphQuads,
+  },
+  {
+    name: "DESCRIBE - variable bindings describe each resource",
+    kind: "describe",
+    query: `DESCRIBE ?person WHERE { ?person ${foafName} ?name }`,
+    quads: basicKnowledgeGraphQuads,
+  },
+  {
+    name: "DESCRIBE - star describes bound variables of the WHERE",
+    kind: "describe",
+    query: `DESCRIBE * WHERE { ${exampleAlice} ${foafKnows} ?friend }`,
+    quads: basicKnowledgeGraphQuads,
+  },
+  {
+    name: "DESCRIBE - IRI with WHERE describes only the IRI",
+    kind: "describe",
+    query:
+      `DESCRIBE ${exampleAlice} WHERE { ${exampleNobody} ${foafName} ?name }`,
+    quads: basicKnowledgeGraphQuads,
+  },
+  {
+    name: "DESCRIBE - unknown resource yields the empty graph",
+    kind: "describe",
+    query: `DESCRIBE ${exampleNobody}`,
+    quads: basicKnowledgeGraphQuads,
+  },
+];
+
 const path = (id: string) => `<http://example.org/${id}>`;
 const pPred = path("p");
 const qPred = path("q");
@@ -1107,6 +1141,7 @@ const allCases: ParityTestCase[] = [
   ...selectCases,
   ...askCases,
   ...constructCases,
+  ...describeCases,
   ...wildcardCases,
   ...pathCases,
   ...aggregateCases,

--- a/vendor/sparql-parser/generate-parser.ts
+++ b/vendor/sparql-parser/generate-parser.ts
@@ -23,7 +23,6 @@
  */
 import jison from "npm:jison@0.4.18";
 import { parse as parseGrammar } from "npm:ebnf-parser@0.1.10";
-import { fileURLToPath } from "node:url";
 
 const GRAMMAR_PATH = new URL("./sparql.jison", import.meta.url);
 const OUTPUT_PATH = new URL("./parser.ts", import.meta.url);
@@ -108,12 +107,14 @@ export function generateParserSource(rawGrammar: string): string {
  * fmt-stable and regeneration reproduces it byte-for-byte.
  */
 async function formatWithDenoFmt(source: string): Promise<string> {
-  // fileURLToPath yields a platform-native path (URL.pathname is a POSIX-style
-  // `/C:/...` string that the Windows CLI mangles), so the `deno fmt`
-  // subprocess sees a valid target.
-  const tempPath = fileURLToPath(
-    new URL("./.parser-fmt.tmp.ts", import.meta.url),
-  );
+  // The temp file lives in the OS temp dir (not the repo, where a crashed run
+  // would leak it into fmt:check and git status), and fileURLToPath is unused:
+  // Deno.makeTempFile already returns a platform-native path (URL.pathname is
+  // a POSIX-style `/C:/...` string that the Windows CLI mangles).
+  const tempPath = await Deno.makeTempFile({
+    prefix: "parser-fmt-",
+    suffix: ".ts",
+  });
   await Deno.writeTextFile(tempPath, source);
   try {
     const cmd = new Deno.Command(Deno.execPath(), {


### PR DESCRIPTION
Closes #43

## What

Implements `DESCRIBE` (SPARQL 1.1 §16.4), which the README claimed but the evaluator threw `Unsupported query type: DESCRIBE` on:

- `DESCRIBE <iri>` — describes the explicit IRIs (a WHERE clause adds no resources).
- `DESCRIBE ?x WHERE { ... }` — describes the IRI/blank-node bindings of `?x` per solution.
- `DESCRIBE * WHERE { ... }` — describes the IRI/blank-node bindings of every variable.
- Literals are not describable; each resource's description is its **outgoing arcs**, deduplicated into a graph set.
- Result reuses the `construct` response kind and honors `FROM`/`FROM NAMED` through the shared dataset store.

## How the shape was chosen

Probed the reference engines first: Comunica (the parity oracle) describes outgoing arcs only — no incoming, no recursion, literals skipped — while Oxigraph's DESCRIBE was a no-op in the probe. Since §16.4 leaves the description shape to the implementation, we match the parity oracle. Known Comunica quirk **not** replicated: `DESCRIBE *` on a fully-open pattern returns 0 quads there; the native engine follows the spec reading (describe all bound variables).

## Also

- `generate-parser.ts` now writes its `deno fmt` scratch file to the OS temp dir instead of the repo, so an interrupted codegen run can't leak a file into `fmt:check`/`git status`.

## Verification

- `deno task ci`: 284/284 (5 new DESCRIBE parity cases vs Comunica + 3 unit tests)
- eval-triple-terms gap harness: 41/41
- W3C differential gate: 336/336
- bench: green