### PR TITLE
feat(expr): RDF 1.2 directional literals in the SPARQL expression layer

### DIFF
--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -25,6 +25,7 @@ import {
   minus,
   scanEntry,
   scanPathEntry,
+  scanPathEntrySync,
 } from "@/evaluator/join.ts";
 import type { ScanEntry, TermBinding } from "@/evaluator/join.ts";
 import { sameRdfTerm, sparqlTermToRdfTerm, termKey } from "@/term/mod.ts";
@@ -159,9 +160,9 @@ export class BgpEvaluator {
    * evaluateExistsGroup threads solutions through a pattern list with the
    * synchronous exists evaluator, mirroring evaluateGroup for the pattern
    * forms the W3C EXISTS surface exercises (BGP, FILTER, GRAPH, BIND,
-   * VALUES, nested EXISTS). OPTIONAL / MINUS / UNION / subqueries and
-   * property paths inside EXISTS raise a clear error rather than silently
-   * returning a wrong answer.
+   * VALUES, nested EXISTS, and property paths over the graph-scoped
+   * candidate set). OPTIONAL / MINUS / UNION / subqueries inside EXISTS
+   * raise a clear error rather than silently returning a wrong answer.
    */
   private evaluateExistsGroup(
     patterns: Pattern[],
@@ -191,9 +192,18 @@ export class BgpEvaluator {
         let result = bindings;
         for (const triple of expandReifiedTriples(pattern.triples)) {
           if (isPropertyPath(triple.predicate)) {
-            throw new Error(
-              "Property paths inside EXISTS are not supported",
+            // Property paths inside EXISTS evaluate synchronously over the
+            // graph-scoped candidate set, mirroring the main-pattern
+            // scanPathEntry semantics (pair dedup unless multiset, constant
+            // endpoint pruning, reflexive closures over the scope's nodes).
+            const entry = scanPathEntrySync(
+              candidates,
+              triple.predicate,
+              triple.subject,
+              triple.object,
             );
+            result = joinPathPattern(result, entry);
+            continue;
           }
           const predicate = simplePredicate(triple.predicate);
           const reifies = isReifiesPattern(predicate, triple.object);

--- a/src/evaluator/expression-evaluator.ts
+++ b/src/evaluator/expression-evaluator.ts
@@ -7,7 +7,11 @@ import type {
   Pattern,
   Term as SparqlTerm,
 } from "@/parser/sparql-parser.ts";
-import { DataFactory } from "@/term/mod.ts";
+import {
+  DataFactory,
+  RDF_DIR_LANG_STRING,
+  RDF_LANG_STRING,
+} from "@/term/mod.ts";
 import {
   md5Hex,
   parseDateTime,
@@ -663,45 +667,59 @@ export class ExpressionEvaluator {
         );
       }
       case "haslang": {
+        // hasLANG(term): true iff the term is a literal with a language tag
+        // (datatype rdf:langString or rdf:dirLangString); false otherwise.
         const val = this.evaluateWith(arg(0), binding, aggregates, context);
-        if (val === undefined || val.termType !== "Literal") {
-          return booleanLiteral(false);
-        }
-        if (operation.args.length > 1) {
-          const lang = this.evaluateWith(arg(1), binding, aggregates, context);
-          if (lang === undefined || lang.termType !== "Literal") {
-            return booleanLiteral(false);
-          }
-          return booleanLiteral(
-            val.language.toLowerCase() === lang.value.toLowerCase(),
-          );
-        }
-        return booleanLiteral(val.language !== "");
+        return booleanLiteral(
+          val !== undefined && val.termType === "Literal" &&
+            val.language !== "",
+        );
       }
       case "langdir": {
+        // LANGDIR(literal): the base direction ("ltr"/"rtl"), or the empty
+        // string when the literal has none; non-literals are a type error.
         const val = this.evaluateWith(arg(0), binding, aggregates, context);
         if (val === undefined || val.termType !== "Literal") {
           return undefined;
         }
-        return DataFactory.literal(val.language ? "ltr" : "");
+        return DataFactory.literal(val.direction ?? "");
       }
       case "strlangdir": {
+        // STRLANGDIR(lexicalForm, langTag, baseDirection): constructs an
+        // rdf:dirLangString literal; an empty tag, a direction other than
+        // "ltr"/"rtl", or a non-string argument is a type error.
         const val = this.evaluateWith(arg(0), binding, aggregates, context);
         const lang = this.evaluateWith(arg(1), binding, aggregates, context);
+        const dir = this.evaluateWith(arg(2), binding, aggregates, context);
         if (
           val === undefined || val.termType !== "Literal" ||
-          lang === undefined || lang.termType !== "Literal"
+          lang === undefined || lang.termType !== "Literal" ||
+          dir === undefined || dir.termType !== "Literal"
         ) {
           return undefined;
         }
-        return DataFactory.literal(val.value, lang.value);
+        if (
+          !this.isStringTyped(val) || !this.isStringTyped(lang) ||
+          !this.isStringTyped(dir) || lang.value === ""
+        ) {
+          return undefined;
+        }
+        if (dir.value !== "ltr" && dir.value !== "rtl") {
+          return undefined;
+        }
+        return DataFactory.literal(val.value, {
+          language: lang.value,
+          direction: dir.value,
+        });
       }
       case "haslangdir": {
+        // hasLANGDIR(term): true iff the term is a literal with a base
+        // direction (datatype rdf:dirLangString); false otherwise.
         const val = this.evaluateWith(arg(0), binding, aggregates, context);
-        if (val === undefined || val.termType !== "Literal") {
-          return booleanLiteral(false);
-        }
-        return booleanLiteral(Boolean(val.language));
+        return booleanLiteral(
+          val !== undefined && val.termType === "Literal" &&
+            Boolean(val.direction),
+        );
       }
       default:
         throw new Error(
@@ -749,8 +767,11 @@ export class ExpressionEvaluator {
       const aLang = a.language !== undefined && a.language !== "";
       const bLang = b.language !== undefined && b.language !== "";
       if (aLang || bLang) {
+        // RDF 1.2: lang-tagged strings are the same term only when the value,
+        // language tag, and base direction all match.
         return aLang && bLang && a.value === b.value &&
-          a.language === b.language;
+          a.language === b.language &&
+          (a.direction ?? "") === (b.direction ?? "");
       }
       return a.value === b.value;
     }
@@ -953,6 +974,7 @@ export class ExpressionEvaluator {
     return this.stringResult(
       transformed,
       this.isLangTagged(value) ? value.language : undefined,
+      this.isLangTagged(value) ? (value.direction ?? "") : undefined,
     );
   }
 
@@ -967,7 +989,10 @@ export class ExpressionEvaluator {
     context?: ExpressionEvaluationContext,
   ): rdfjs.Literal | undefined {
     let result = "";
+    // undefined = no language-tagged argument seen yet; null = the arguments
+    // disagree on language or direction, so the result is a plain string.
     let commonLang: string | null | undefined;
+    let commonDir: "ltr" | "rtl" | null | undefined;
     for (const expression of expressions) {
       const value = this.evaluateWith(expression, binding, aggregates, context);
       if (
@@ -978,16 +1003,27 @@ export class ExpressionEvaluator {
       }
       result += value.value;
       if (commonLang !== null) {
+        const direction = value.direction ?? "";
         if (!this.isLangTagged(value)) {
           commonLang = null;
+          commonDir = null;
         } else if (commonLang === undefined) {
           commonLang = value.language;
-        } else if (commonLang !== value.language) {
+          commonDir = direction === "" ? null : direction;
+        } else if (
+          commonLang !== value.language ||
+          commonDir !== (direction === "" ? null : direction)
+        ) {
           commonLang = null;
+          commonDir = null;
         }
       }
     }
-    return this.stringResult(result, commonLang ?? undefined);
+    return this.stringResult(
+      result,
+      commonLang ?? undefined,
+      commonDir ?? undefined,
+    );
   }
 
   /**
@@ -1039,6 +1075,7 @@ export class ExpressionEvaluator {
     return this.stringResult(
       sliced,
       this.isLangTagged(str) ? str.language : undefined,
+      this.isLangTagged(str) ? (str.direction ?? "") : undefined,
     );
   }
 
@@ -1073,7 +1110,17 @@ export class ExpressionEvaluator {
     ) {
       return undefined;
     }
-    return literal(value.value, namedNode(datatype.value));
+    // rdf:langString/rdf:dirLangString cannot be constructed via STRDT —
+    // STRLANG/STRLANGDIR are the constructors for them (SPARQL 1.2
+    // §17.4.3.14); an rdf:langString with no language or a dirLangString
+    // with no direction would be ill-formed.
+    const datatypeIri = datatype.value;
+    if (
+      datatypeIri === RDF_LANG_STRING || datatypeIri === RDF_DIR_LANG_STRING
+    ) {
+      return undefined;
+    }
+    return literal(value.value, namedNode(datatypeIri));
   }
 
   /**
@@ -1108,6 +1155,11 @@ export class ExpressionEvaluator {
       return undefined;
     }
     if (lang.termType !== "Literal" || !this.isStringTyped(lang)) {
+      return undefined;
+    }
+    // The langTag must not be empty (SPARQL 1.2 §17.4.3.12); an empty tag
+    // would produce an ill-formed rdf:langString literal.
+    if (lang.value === "") {
       return undefined;
     }
     return literal(value.value, lang.value);
@@ -1435,16 +1487,19 @@ export class ExpressionEvaluator {
   }
 
   /**
-   * stringResult builds a string-function result: language-tagged inputs
-   * keep their language, everything else becomes an xsd:string literal.
+   * stringResult builds a string-function result: language-tagged inputs keep
+   * their language and base direction (rdf:dirLangString when a direction is
+   * present), everything else becomes an xsd:string literal.
    */
   private stringResult(
     value: string,
     lang: string | undefined,
+    direction?: "ltr" | "rtl" | "",
   ): rdfjs.Literal {
-    return lang === undefined || lang === ""
-      ? literal(value, namedNode(XSD_STRING))
-      : literal(value, lang);
+    if (lang === undefined || lang === "") {
+      return literal(value, namedNode(XSD_STRING));
+    }
+    return literal(value, { language: lang, direction: direction ?? "" });
   }
 
   /**
@@ -1559,6 +1614,9 @@ export class ExpressionEvaluator {
       index === -1
         ? undefined
         : (this.isLangTagged(value) ? value.language : undefined),
+      index === -1
+        ? undefined
+        : (this.isLangTagged(value) ? (value.direction ?? "") : undefined),
     );
   }
 
@@ -1636,6 +1694,7 @@ export class ExpressionEvaluator {
     return this.stringResult(
       result,
       this.isLangTagged(value) ? value.language : undefined,
+      this.isLangTagged(value) ? (value.direction ?? "") : undefined,
     );
   }
 

--- a/src/evaluator/join.ts
+++ b/src/evaluator/join.ts
@@ -487,7 +487,7 @@ export function isPropertyPath(
  * multiset; the composition operators ^, /, and | inherit multiset semantics
  * from their parts, while the remaining operators yield a set of pairs.
  */
-function isMultisetPath(path: PathElement): boolean {
+export function isMultisetPath(path: PathElement): boolean {
   if ("termType" in path) {
     return true;
   }
@@ -919,4 +919,360 @@ function resolveTerm(
     return null;
   }
   return sparqlTermToRdfTerm(term);
+}
+
+/* ------------------------------------------------------------------ */
+/* Synchronous path evaluation over a pre-materialized quad array     */
+/* (the EXISTS hooks' drained store snapshot).                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * matchQuadsSync filters a pre-materialized quad array (already scoped to a
+ * single graph) by a triple pattern — the synchronous counterpart to
+ * matchQuads, used by the EXISTS hooks which operate on the drained snapshot
+ * instead of issuing stream matches.
+ */
+export function matchQuadsSync(
+  candidates: rdfjs.Quad[],
+  s: rdfjs.Term | null,
+  p: rdfjs.Term | null,
+  o: rdfjs.Term | null,
+): rdfjs.Quad[] {
+  return candidates.filter((quad) =>
+    (s === null || sameRdfTerm(quad.subject, s)) &&
+    (p === null || sameRdfTerm(quad.predicate, p)) &&
+    (o === null || sameRdfTerm(quad.object, o))
+  );
+}
+
+/**
+ * graphNodesSync returns every term appearing as a subject or object of any
+ * candidate quad — the node set the reflexive path forms (? and *) are
+ * defined over, restricted to the EXISTS snapshot's graph scope.
+ */
+export function graphNodesSync(candidates: rdfjs.Quad[]): rdfjs.Term[] {
+  const nodes = new Map<string, rdfjs.Term>();
+  for (const quad of candidates) {
+    nodes.set(termKey(quad.subject), quad.subject);
+    nodes.set(termKey(quad.object), quad.object);
+  }
+  return [...nodes.values()];
+}
+
+/**
+ * pathStepsSync evaluates one step of a property path from a single anchor
+ * term over a pre-materialized quad array — the synchronous counterpart to
+ * pathSteps for the EXISTS hooks. In forward direction term is the path
+ * subject and the result is the set of reachable objects; in backward
+ * direction term is the path object and the result is the set of reachable
+ * subjects. Results are deduplicated. The semantics mirror the async
+ * version exactly (inverse, sequence, alternative, zero-or-one, closures,
+ * and negated property sets).
+ */
+export function pathStepsSync(
+  candidates: rdfjs.Quad[],
+  path: PathElement,
+  direction: "forward" | "backward",
+  term: rdfjs.Term,
+): rdfjs.Term[] {
+  // A plain IRI is a link path: forward matches outgoing edges, backward
+  // matches incoming edges.
+  if ("termType" in path) {
+    return direction === "forward"
+      ? matchQuadsSync(candidates, term, path, null).map((q) => q.object)
+      : matchQuadsSync(candidates, null, path, term).map((q) => q.subject);
+  }
+
+  switch (path.pathType) {
+    case "^":
+      // The inverse of a path runs the inner path in the opposite direction.
+      return pathStepsSync(
+        candidates,
+        path.items[0],
+        direction === "forward" ? "backward" : "forward",
+        term,
+      );
+    case "/": {
+      if (direction === "forward") {
+        let current = [term];
+        for (const item of path.items) {
+          const next: rdfjs.Term[] = [];
+          for (const node of current) {
+            for (
+              const target of pathStepsSync(candidates, item, "forward", node)
+            ) {
+              next.push(target);
+            }
+          }
+          current = next;
+          if (current.length === 0) {
+            break;
+          }
+        }
+        return current;
+      }
+      let current = [term];
+      for (let i = path.items.length - 1; i >= 0; i--) {
+        const item = path.items[i];
+        const next: rdfjs.Term[] = [];
+        for (const node of current) {
+          for (
+            const source of pathStepsSync(
+              candidates,
+              item,
+              "backward",
+              node,
+            )
+          ) {
+            next.push(source);
+          }
+        }
+        current = next;
+        if (current.length === 0) {
+          break;
+        }
+      }
+      return current;
+    }
+    case "|": {
+      const results: rdfjs.Term[] = [];
+      const seen = new Set<string>();
+      for (const item of path.items) {
+        for (
+          const target of pathStepsSync(candidates, item, direction, term)
+        ) {
+          if (!seen.has(termKey(target))) {
+            seen.add(termKey(target));
+            results.push(target);
+          }
+        }
+      }
+      return results;
+    }
+    case "?": {
+      // Zero-or-one: the anchor itself plus the inner path's targets.
+      const results: rdfjs.Term[] = [term];
+      for (
+        const target of pathStepsSync(
+          candidates,
+          path.items[0],
+          direction,
+          term,
+        )
+      ) {
+        if (!sameRdfTerm(target, term)) {
+          results.push(target);
+        }
+      }
+      return results;
+    }
+    case "*": {
+      // Zero-or-more: reflexive-transitive closure of the inner path.
+      const results: rdfjs.Term[] = [term];
+      const visited = new Set<string>([termKey(term)]);
+      const queue: rdfjs.Term[] = [term];
+      while (queue.length > 0) {
+        const current = queue.shift()!;
+        for (
+          const target of pathStepsSync(
+            candidates,
+            path.items[0],
+            direction,
+            current,
+          )
+        ) {
+          const key = termKey(target);
+          if (!visited.has(key)) {
+            visited.add(key);
+            results.push(target);
+            queue.push(target);
+          }
+        }
+      }
+      return results;
+    }
+    case "+": {
+      // One-or-more: transitive closure of the inner path. The start term is
+      // not reflexive for +, but in a cycle it IS reachable from itself via
+      // one or more steps, so when the walk returns to it it is emitted once
+      // (and never re-queued, keeping the traversal finite).
+      const results: rdfjs.Term[] = [];
+      const visited = new Set<string>();
+      const queue: rdfjs.Term[] = [term];
+      const startKey = termKey(term);
+      let startEmitted = false;
+      while (queue.length > 0) {
+        const current = queue.shift()!;
+        for (
+          const target of pathStepsSync(
+            candidates,
+            path.items[0],
+            direction,
+            current,
+          )
+        ) {
+          const key = termKey(target);
+          if (key === startKey) {
+            if (!startEmitted) {
+              startEmitted = true;
+              results.push(target);
+            }
+            continue;
+          }
+          if (!visited.has(key)) {
+            visited.add(key);
+            results.push(target);
+            queue.push(target);
+          }
+        }
+      }
+      return results;
+    }
+    case "!": {
+      // Negated property set: direct excluded predicates apply to matching
+      // edges in the primary direction, and inverse excluded predicates apply
+      // to matching edges in the opposite direction.
+      const directExcluded = new Set<string>();
+      const inverseExcluded = new Set<string>();
+      let hasInverse = false;
+
+      const collectNpsItems = (items: PathElement[]) => {
+        for (const item of items) {
+          if ("termType" in item) {
+            directExcluded.add(item.value);
+          } else if (
+            typeof item === "object" && item !== null && "type" in item
+          ) {
+            const pObj = item as {
+              type: string;
+              pathType?: string;
+              items?: PathElement[];
+            };
+            if (pObj.pathType === "|") {
+              collectNpsItems(pObj.items ?? []);
+            } else if (pObj.pathType === "^") {
+              const invItem = pObj.items?.[0] as SparqlTerm | undefined;
+              if (invItem?.value) {
+                inverseExcluded.add(invItem.value);
+                hasInverse = true;
+              }
+            }
+          }
+        }
+      };
+      collectNpsItems(path.items);
+
+      const results: rdfjs.Term[] = [];
+      const seen = new Set<string>();
+
+      if (direction === "forward") {
+        if (directExcluded.size > 0) {
+          for (const q of matchQuadsSync(candidates, term, null, null)) {
+            if (!directExcluded.has(q.predicate.value)) {
+              const key = termKey(q.object);
+              if (!seen.has(key)) {
+                seen.add(key);
+                results.push(q.object);
+              }
+            }
+          }
+        }
+        if (hasInverse) {
+          for (const q of matchQuadsSync(candidates, null, null, term)) {
+            if (!inverseExcluded.has(q.predicate.value)) {
+              const key = termKey(q.subject);
+              if (!seen.has(key)) {
+                seen.add(key);
+                results.push(q.subject);
+              }
+            }
+          }
+        }
+      } else {
+        if (directExcluded.size > 0) {
+          for (const q of matchQuadsSync(candidates, null, null, term)) {
+            if (!directExcluded.has(q.predicate.value)) {
+              const key = termKey(q.subject);
+              if (!seen.has(key)) {
+                seen.add(key);
+                results.push(q.subject);
+              }
+            }
+          }
+        }
+        if (hasInverse) {
+          for (const q of matchQuadsSync(candidates, term, null, null)) {
+            if (!inverseExcluded.has(q.predicate.value)) {
+              const key = termKey(q.object);
+              if (!seen.has(key)) {
+                seen.add(key);
+                results.push(q.object);
+              }
+            }
+          }
+        }
+      }
+      return results;
+    }
+    default:
+      throw new Error(
+        `Unsupported property path type: ${
+          (path as { pathType: string }).pathType
+        }`,
+      );
+  }
+}
+
+/**
+ * scanPathEntrySync resolves a property-path triple pattern over a
+ * pre-materialized quad array (the EXISTS snapshot's graph scope) — the
+ * synchronous counterpart to scanPathEntry. Pair semantics are identical:
+ * pairs are deduplicated unless the path is multiset, and a constant
+ * endpoint prunes the evaluation to that end.
+ */
+export function scanPathEntrySync(
+  candidates: rdfjs.Quad[],
+  path: PropertyPath,
+  subject: SparqlTerm,
+  object: SparqlTerm,
+): PathEntry {
+  const pairs: PathPair[] = [];
+  const seen = new Set<string>();
+  const allowDuplicates = isMultisetPath(path);
+  const addPair = (s: rdfjs.Term, o: rdfjs.Term): void => {
+    if (allowDuplicates) {
+      pairs.push({ subject: s, object: o });
+    } else {
+      const key = `${termKey(s)}\u0000${termKey(o)}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        pairs.push({ subject: s, object: o });
+      }
+    }
+  };
+
+  const subjectConstant = subject.termType !== "Variable";
+  const objectConstant = object.termType !== "Variable";
+
+  if (subjectConstant) {
+    const from = sparqlTermToRdfTerm(subject);
+    for (const target of pathStepsSync(candidates, path, "forward", from)) {
+      addPair(from, target);
+    }
+  } else if (objectConstant) {
+    const to = sparqlTermToRdfTerm(object);
+    for (const source of pathStepsSync(candidates, path, "backward", to)) {
+      addPair(source, to);
+    }
+  } else {
+    // Both endpoints unbound: evaluate forward from every graph node. The
+    // reflexive forms (? and *) include the (node, node) pair themselves.
+    for (const node of graphNodesSync(candidates)) {
+      for (const target of pathStepsSync(candidates, path, "forward", node)) {
+        addPair(node, target);
+      }
+    }
+  }
+
+  return { subject, object, pairs };
 }

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -577,11 +577,11 @@ export class SparqlEvaluator {
   /**
    * orderBindings sorts term bindings by the query's ORDER BY clauses, using
    * the term module's ordering (unbound lowest, then blank nodes, IRIs, and
-   * literals; literals by datatype, numeric value, then lexical form).
-   * Comparison is stable, so ties keep the evaluation order. Only variable
-   * and constant-term expressions are supported; anything else (function
-   * calls, arithmetic) has no expression evaluator yet and raises a clear
-   * error.
+   * literals; literals by datatype, numeric value, then lexical form, with
+   * rdf:dirLangString values tie-broken by base direction). Comparison is
+   * stable, so ties keep the evaluation order. Any expression the expression
+   * evaluator supports (variables, constants, builtin function calls) can be
+   * sorted on; genuinely unsupported expressions raise a clear error.
    */
   private orderBindings(
     solutions: SelectSolution[],

--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -51,36 +51,38 @@ arity token (`FUNC_ARITY0/1/2/3`). The grammar productions build `functionCall`
 AST nodes generically from the lexed text (lowercased), so extending the
 whitelist is a lexer-only change:
 
-| Function                                         | Arity | Rule              | Change                                  |
-| ------------------------------------------------ | ----- | ----------------- | --------------------------------------- |
-| `LANGDIR(simpleLiteral)`                         | 1     | FUNC_ARITY1 group | added `LANGDIR` **before** `LANG`       |
-| `hasLang(langString, language)`                  | 2     | FUNC_ARITY2 group | appended `hasLang`                      |
-| `STRLANGDIR(simpleLiteral, language)`            | 2     | FUNC_ARITY2 group | added `STRLANGDIR` **before** `STRLANG` |
-| `hasLangDir(langDirString, language, direction)` | 3     | FUNC_ARITY3 rule  | added `hasLangDir` to the `IF` rule     |
+| Function                                        | Arity | Rule              | Change                                     |
+| ----------------------------------------------- | ----- | ----------------- | ------------------------------------------ |
+| `LANGDIR(literal)`                              | 1     | FUNC_ARITY1 group | added `LANGDIR` **before** `LANG`          |
+| `hasLang(term)`                                 | 1     | FUNC_ARITY1 group | appended `hasLangDir` **before** `hasLang` |
+| `hasLangDir(term)`                              | 1     | FUNC_ARITY1 group | same entry (unary, like `hasLang`)         |
+| `STRLANGDIR(simpleLiteral, langTag, direction)` | 3     | FUNC_ARITY3 rule  | added `STRLANGDIR` to the `IF` rule        |
 
 Two lexer subtleties matter here:
 
 1. **Ordered alternation within a rule.** JavaScript regex alternation is
-   first-match, not longest-match. `LANGDIR` must appear before `LANG`, and
-   `STRLANGDIR` before `STRLANG`, or the shorter name lexes first and the
+   first-match, not longest-match. `LANGDIR` must appear before `LANG` (and
+   `hasLangDir` before `hasLang`) or the shorter name lexes first and the
    remainder of the input becomes `INVALID`.
 2. **Longest match across rules.** The lexer tests rules in order and keeps the
-   longest match, so `hasLangDir` (its own rule) wins over `hasLang`, and
-   `LANGMATCHES` over `LANG`. Existing behavior is unaffected.
+   longest match, so `STRLANGDIR` (FUNC_ARITY3) wins over `STRLANG`
+   (FUNC_ARITY2), `hasLangDir` over `hasLang`, and `LANGMATCHES` over `LANG`.
+   Existing behavior is unaffected.
 
 Parse results (AST names are lowercased, matching sparqljs convention):
 
 ```ts
-LANGDIR("hello")                -> { type: "functionCall", name: "langdir", args: [..] }
-hasLang("hello", "en")          -> { type: "functionCall", name: "haslang", args: [..] }
-STRLANGDIR("hello", "en")       -> { type: "functionCall", name: "strlangdir", args: [..] }
-hasLangDir("hello", "en", "ltr")-> { type: "functionCall", name: "haslangdir", args: [..] }
+LANGDIR("hello"@en)             -> { type: "functionCall", name: "langdir", args: [..] }
+hasLang("hello"@en)             -> { type: "functionCall", name: "haslang", args: [..] }
+hasLangDir("hello"@en--ltr)     -> { type: "functionCall", name: "haslangdir", args: [..] }
+STRLANGDIR("hello", "en", "ltr")-> { type: "functionCall", name: "strlangdir", args: [..] }
 ```
 
-Out of scope for the patch: the variadic `hasLang(simpleLiteral)` and
-`hasLang(simpleLiteral, language, direction)` forms (arity tokens are fixed).
-Neither sparqljs nor traqula can express them, so they are unreachable in both
-engines; they would require real grammar surgery if ever needed.
+The arities match the SPARQL 1.2 grammar (production [141] `BuiltInCall`):
+`hasLang`/`hasLangDir` are unary term tests and `STRLANGDIR` takes
+`(lexicalForm, langTag, baseDirection)`. Earlier drafts of the spec had
+binary/ternary `hasLang` forms; the in-repo grammar follows the published
+grammar, matching what `@traqula/parser-sparql-1-2` accepts.
 
 ### RDF 1.2 triple terms, reifiers, and annotations (grammar productions)
 

--- a/src/parser/mod.test.ts
+++ b/src/parser/mod.test.ts
@@ -34,17 +34,17 @@ Deno.test("parser: LANGDIR accepts a lang-tagged literal", () => {
   assertEquals(name, "langdir");
 });
 
-Deno.test("parser: hasLang parses as a functionCall", () => {
+Deno.test("parser: hasLang parses as a unary functionCall", () => {
   const { name, args } = parseExpression(
-    'SELECT ?x WHERE { BIND(hasLang("hello", "en") AS ?x) }',
+    'SELECT ?x WHERE { BIND(hasLang("hello"@en) AS ?x) }',
   );
   assertEquals(name, "haslang");
-  assertEquals(args.length, 2);
+  assertEquals(args.length, 1);
 });
 
 Deno.test("parser: hasLang works in FILTER", () => {
   const ast = new Parser().parse(
-    'SELECT ?x WHERE { ?s ?p ?x FILTER(hasLang(?x, "en")) }',
+    "SELECT ?x WHERE { ?s ?p ?x FILTER(hasLang(?x)) }",
   );
   if (ast.type !== "query") throw new Error("expected a query");
   const where = ast.where as Array<
@@ -54,20 +54,20 @@ Deno.test("parser: hasLang works in FILTER", () => {
   assertEquals(filter?.expression?.operator, "haslang");
 });
 
-Deno.test("parser: STRLANGDIR parses as a functionCall", () => {
+Deno.test("parser: STRLANGDIR parses as a ternary functionCall", () => {
   const { name, args } = parseExpression(
-    'SELECT ?x WHERE { BIND(STRLANGDIR("hello", "en") AS ?x) }',
+    'SELECT ?x WHERE { BIND(STRLANGDIR("hello", "en", "ltr") AS ?x) }',
   );
   assertEquals(name, "strlangdir");
-  assertEquals(args.length, 2);
+  assertEquals(args.length, 3);
 });
 
-Deno.test("parser: hasLangDir parses as a functionCall", () => {
+Deno.test("parser: hasLangDir parses as a unary functionCall", () => {
   const { name, args } = parseExpression(
-    'SELECT ?x WHERE { BIND(hasLangDir("hello", "en", "ltr") AS ?x) }',
+    'SELECT ?x WHERE { BIND(hasLangDir("hello"@en--ltr) AS ?x) }',
   );
   assertEquals(name, "haslangdir");
-  assertEquals(args.length, 3);
+  assertEquals(args.length, 1);
 });
 
 Deno.test("parser: prefix conflicts still lex correctly", () => {
@@ -81,6 +81,23 @@ Deno.test("parser: prefix conflicts still lex correctly", () => {
     parseExpression(`SELECT ?x WHERE { BIND(${expr} AS ?x) }`).name
   );
   assertEquals(names, ["lang", "strlang", "langmatches", "str"]);
+});
+
+Deno.test("parser: recursive unary ! allows double negation", () => {
+  // SPARQL 1.2 grammar [135] makes '!' recursive: `!!x` == !(!x).
+  const ast = new Parser().parse(
+    "SELECT ?v WHERE { VALUES ?v { true false } BIND(!!?v AS ?ebv) }",
+  );
+  if (ast.type !== "query") throw new Error("expected a query");
+  const where = ast.where as Array<
+    { type: string; expression?: { operator: string; args: unknown[] } }
+  >;
+  const bind = where.find((w) => w.type === "bind");
+  assertEquals(bind?.expression?.operator, "!");
+  assertEquals(
+    (bind?.expression?.args[0] as { operator?: string })?.operator,
+    "!",
+  );
 });
 
 Deno.test("parser: unknown bare function names still rejected", () => {

--- a/src/parser/mod.ts
+++ b/src/parser/mod.ts
@@ -7,10 +7,10 @@
  * direction functions below and the RDF 1.2 triple-term/reifier/annotation
  * forms (see README.md):
  *
- *   - `LANGDIR(simpleLiteral)`            — arity 1
- *   - `hasLang(langString, language)`     — arity 2
- *   - `STRLANGDIR(simpleLiteral, lang)`   — arity 2
- *   - `hasLangDir(dirLangString, lang, dir)` — arity 3
+ *   - `LANGDIR(literal)`                  — arity 1
+ *   - `hasLang(term)`                     — arity 1
+ *   - `hasLangDir(term)`                  — arity 1
+ *   - `STRLANGDIR(simpleLiteral, langTag, baseDirection)` — arity 3
  *
  * The grammar patch (see README.md) is in two parts: a lexer whitelist
  * extension for the four direction functions (they join existing

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -285,8 +285,8 @@ var SparqlParser = (function () {
     $Vw = [28, 29, 45, 53, 87],
     $Vx = [1, 139],
     $Vy = [1, 152],
-    $Vz = [1, 128],
-    $VA = [1, 127],
+    $Vz = [1, 127],
+    $VA = [1, 128],
     $VB = [1, 129],
     $VC = [1, 141],
     $VD = [1, 142],
@@ -3233,10 +3233,10 @@ var SparqlParser = (function () {
 
           break;
         case 169:
-          this.$ = operation("UPLUS", [$$[$0]]);
+          this.$ = operation("!", [$$[$0]]);
           break;
         case 170:
-          this.$ = operation($$[$0 - 1], [$$[$0]]);
+          this.$ = operation("UPLUS", [$$[$0]]);
           break;
         case 171:
           this.$ = operation("UMINUS", [$$[$0]]);
@@ -4011,9 +4011,13 @@ var SparqlParser = (function () {
         87: $Vb,
         172: 135,
         174: 138,
+        227: $Vz,
         258: 155,
         260: 156,
-        267: 269,
+        262: 269,
+        266: $VA,
+        267: 130,
+        268: $VB,
         269: 137,
         270: 140,
         271: $VC,
@@ -8125,9 +8129,18 @@ var SparqlParser = (function () {
     return Parser.factory.literal(value, type);
   }
 
-  // Creates a literal with the given value and language
+  // Creates a literal with the given value and language; a trailing "--ltr"/
+  // "--rtl" (guaranteed by the LANGTAG terminal) becomes the RDF 1.2 base
+  // direction, yielding an rdf:dirLangString literal.
   function createLangLiteral(value, lang) {
-    return Parser.factory.literal(value, lang);
+    const dash = lang.indexOf("--");
+    if (dash === -1) {
+      return Parser.factory.literal(value, lang);
+    }
+    return Parser.factory.literal(value, {
+      language: lang.slice(0, dash),
+      direction: lang.slice(dash + 2),
+    });
   }
 
   function nestedTriple(subject, predicate, object) {
@@ -9402,12 +9415,12 @@ var SparqlParser = (function () {
         /^(?:BOUND)/i,
         /^(?:BNODE)/i,
         /^(?:(RAND|NOW|UUID|STRUUID))/i,
-        /^(?:(LANGDIR|LANG|DATATYPE|IRI|URI|ABS|CEIL|FLOOR|ROUND|STRLEN|STR|UCASE|LCASE|ENCODE_FOR_URI|YEAR|MONTH|DAY|HOURS|MINUTES|SECONDS|TIMEZONE|TZ|MD5|SHA1|SHA256|SHA384|SHA512|isIRI|isURI|isBLANK|isLITERAL|isNUMERIC))/i,
+        /^(?:(LANGDIR|LANG|DATATYPE|IRI|URI|ABS|CEIL|FLOOR|ROUND|STRLEN|STR|UCASE|LCASE|ENCODE_FOR_URI|YEAR|MONTH|DAY|HOURS|MINUTES|SECONDS|TIMEZONE|TZ|MD5|SHA1|SHA256|SHA384|SHA512|isIRI|isURI|isBLANK|isLITERAL|isNUMERIC|hasLangDir|hasLang))/i,
         /^(?:(SUBJECT|PREDICATE|OBJECT|isTRIPLE))/i,
-        /^(?:(LANGMATCHES|CONTAINS|STRSTARTS|STRENDS|STRBEFORE|STRAFTER|STRLANGDIR|STRLANG|STRDT|sameTerm|hasLang))/i,
+        /^(?:(LANGMATCHES|CONTAINS|STRSTARTS|STRENDS|STRBEFORE|STRAFTER|STRLANG|STRDT|sameTerm))/i,
         /^(?:CONCAT)/i,
         /^(?:COALESCE)/i,
-        /^(?:IF|hasLangDir)/i,
+        /^(?:IF|STRLANGDIR)/i,
         /^(?:TRIPLE)/i,
         /^(?:REGEX)/i,
         /^(?:SUBSTR)/i,
@@ -9424,7 +9437,7 @@ var SparqlParser = (function () {
         /^(?:(((([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])(?:(?:(((?:([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])|_))|-|[0-9]|\u00B7|[\u0300-\u036F\u203F-\u2040])|\.)*(((?:([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])|_))|-|[0-9]|\u00B7|[\u0300-\u036F\u203F-\u2040]))?)?:)((?:((?:([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])|_))|:|[0-9]|((%([0-9A-Fa-f])([0-9A-Fa-f]))|(\\(_|~|\.|-|!|\$|&|'|\(|\)|\*|\+|,|;|=|\/|\?|#|@|%))))(?:(?:(((?:([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])|_))|-|[0-9]|\u00B7|[\u0300-\u036F\u203F-\u2040])|\.|:|((%([0-9A-Fa-f])([0-9A-Fa-f]))|(\\(_|~|\.|-|!|\$|&|'|\(|\)|\*|\+|,|;|=|\/|\?|#|@|%))))*(?:(((?:([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])|_))|-|[0-9]|\u00B7|[\u0300-\u036F\u203F-\u2040])|:|((%([0-9A-Fa-f])([0-9A-Fa-f]))|(\\(_|~|\.|-|!|\$|&|'|\(|\)|\*|\+|,|;|=|\/|\?|#|@|%)))))?)))/i,
         /^(?:(_:(?:((?:([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])|_))|[0-9])(?:(?:(((?:([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])|_))|-|[0-9]|\u00B7|[\u0300-\u036F\u203F-\u2040])|\.)*(((?:([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])|_))|-|[0-9]|\u00B7|[\u0300-\u036F\u203F-\u2040]))?))/i,
         /^(?:([\?\$]((?:((?:([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])|_))|[0-9])(?:((?:([A-Za-z\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u02FF\u0370-\u037D\u037F-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFD]|[\uD800-\uDB7F][\uDC00-\uDFFF])|_))|[0-9]|\u00B7|[\u0300-\u036F\u203F-\u2040])*)))/i,
-        /^(?:(@[a-zA-Z]+(?:-[a-zA-Z0-9]+)*))/i,
+        /^(?:(@[a-zA-Z]+(?:-[a-zA-Z0-9]+)*(--(ltr|rtl))?))/i,
         /^(?:([0-9]+))/i,
         /^(?:([0-9]*\.[0-9]+))/i,
         /^(?:([0-9]+\.[0-9]*([eE][+-]?[0-9]+)|\.([0-9])+([eE][+-]?[0-9]+)|([0-9])+([eE][+-]?[0-9]+)))/i,

--- a/src/parser/sparql.jison
+++ b/src/parser/sparql.jison
@@ -150,9 +150,18 @@
     return Parser.factory.literal(value, type);
   }
 
-  // Creates a literal with the given value and language
+  // Creates a literal with the given value and language; a trailing "--ltr"/
+  // "--rtl" (guaranteed by the LANGTAG terminal) becomes the RDF 1.2 base
+  // direction, yielding an rdf:dirLangString literal.
   function createLangLiteral(value, lang) {
-    return Parser.factory.literal(value, lang);
+    const dash = lang.indexOf('--');
+    if (dash === -1) {
+      return Parser.factory.literal(value, lang);
+    }
+    return Parser.factory.literal(value, {
+      language: lang.slice(0, dash),
+      direction: lang.slice(dash + 2),
+    });
   }
 
   function nestedTriple(subject, predicate, object) {
@@ -550,7 +559,7 @@ BLANK_NODE_LABEL      "_:"(?:{PN_CHARS_U}|[0-9])(?:(?:{PN_CHARS}|".")*{PN_CHARS}
 // [108] (and [143]-[144])
 VAR                   [\?\$]{VARNAME}
 // [145]
-LANGTAG               "@"[a-zA-Z]+(?:"-"[a-zA-Z0-9]+)*
+LANGTAG               "@"[a-zA-Z]+(?:"-"[a-zA-Z0-9]+)*("--"("ltr"|"rtl"))?
 // [146]
 INTEGER               [0-9]+
 // [147]
@@ -701,12 +710,12 @@ SPACES_COMMENTS       (\s+|{COMMENT}\n\r?)+
 "BOUND"                  return 'BOUND'
 "BNODE"                  return 'BNODE'
 ("RAND"|"NOW"|"UUID"|"STRUUID") return 'FUNC_ARITY0'
-("LANGDIR"|"LANG"|"DATATYPE"|"IRI"|"URI"|"ABS"|"CEIL"|"FLOOR"|"ROUND"|"STRLEN"|"STR"|"UCASE"|"LCASE"|"ENCODE_FOR_URI"|"YEAR"|"MONTH"|"DAY"|"HOURS"|"MINUTES"|"SECONDS"|"TIMEZONE"|"TZ"|"MD5"|"SHA1"|"SHA256"|"SHA384"|"SHA512"|"isIRI"|"isURI"|"isBLANK"|"isLITERAL"|"isNUMERIC") return 'FUNC_ARITY1'
+("LANGDIR"|"LANG"|"DATATYPE"|"IRI"|"URI"|"ABS"|"CEIL"|"FLOOR"|"ROUND"|"STRLEN"|"STR"|"UCASE"|"LCASE"|"ENCODE_FOR_URI"|"YEAR"|"MONTH"|"DAY"|"HOURS"|"MINUTES"|"SECONDS"|"TIMEZONE"|"TZ"|"MD5"|"SHA1"|"SHA256"|"SHA384"|"SHA512"|"isIRI"|"isURI"|"isBLANK"|"isLITERAL"|"isNUMERIC"|"hasLangDir"|"hasLang") return 'FUNC_ARITY1'
 ("SUBJECT"|"PREDICATE"|"OBJECT"|"isTRIPLE") return 'FUNC_ARITY1_SPARQL_STAR'
-("LANGMATCHES"|"CONTAINS"|"STRSTARTS"|"STRENDS"|"STRBEFORE"|"STRAFTER"|"STRLANGDIR"|"STRLANG"|"STRDT"|"sameTerm"|"hasLang") return 'FUNC_ARITY2'
+("LANGMATCHES"|"CONTAINS"|"STRSTARTS"|"STRENDS"|"STRBEFORE"|"STRAFTER"|"STRLANG"|"STRDT"|"sameTerm") return 'FUNC_ARITY2'
 "CONCAT"                 return 'CONCAT'
 "COALESCE"               return 'COALESCE'
-"IF"|"hasLangDir"         return 'FUNC_ARITY3'
+"IF"|"STRLANGDIR"        return 'FUNC_ARITY3'
 "TRIPLE"                 return 'FUNC_ARITY3_SPARQL_STAR'
 "REGEX"                  return 'REGEX'
 "SUBSTR"                 return 'SUBSTR'
@@ -1456,10 +1465,11 @@ MultiplicativeExpressionTail
     : ( '*' | '/' ) UnaryExpression -> [$1, $2]
     ;
 
-// [118]
+// [135] — SPARQL 1.2 makes '!' recursive so `!!x` (double negation) parses;
+// '+'/'-' remain single-shot (the pre-existing sparqljs 1.1 behavior).
 UnaryExpression
-    : '+' PrimaryExpression -> operation('UPLUS', [$2])
-    | '!'  PrimaryExpression -> operation($1, [$2])
+    : '!' UnaryExpression -> operation('!', [$2])
+    | '+' PrimaryExpression -> operation('UPLUS', [$2])
     | '-'  PrimaryExpression -> operation('UMINUS', [$2])
     | PrimaryExpression -> $1
     ;

--- a/src/sparql-engine-interface.ts
+++ b/src/sparql-engine-interface.ts
@@ -79,6 +79,8 @@ export type SparqlValue =
     type: "literal";
     value: string;
     "xml:lang"?: string;
+    /** Base direction ("ltr"/"rtl") of an RDF 1.2 directional language-tagged literal, per the SPARQL 1.2 results JSON/XML formats. */
+    "its:dir"?: "ltr" | "rtl";
     datatype?: string;
   }
   | {

--- a/src/term/canonical.ts
+++ b/src/term/canonical.ts
@@ -76,6 +76,7 @@ export function canonicalizeSparqlValue(value: SparqlValue): CanonicalTerm {
       };
       if (value["xml:lang"]) {
         canonical.language = value["xml:lang"];
+        if (value["its:dir"]) canonical.direction = value["its:dir"];
       } else if (value.datatype && value.datatype !== XSD_STRING) {
         canonical.datatype = value.datatype;
       }

--- a/src/term/convert.ts
+++ b/src/term/convert.ts
@@ -52,6 +52,9 @@ export function rdfTermToSparqlValue(term: rdfjs.Term): SparqlValue {
       const result: SparqlValue = { type: "literal", value: term.value };
       if (term.language) {
         result["xml:lang"] = term.language;
+        if (term.direction) {
+          result["its:dir"] = term.direction as "ltr" | "rtl";
+        }
       } else if (
         term.datatype &&
         term.datatype.value !== XSD_STRING

--- a/src/term/mod.ts
+++ b/src/term/mod.ts
@@ -1,5 +1,10 @@
 export { sameRdfTerm, termKey } from "@/term/identity.ts";
-export { DataFactory, dataFactory } from "@/term/data-factory.ts";
+export {
+  DataFactory,
+  dataFactory,
+  RDF_DIR_LANG_STRING,
+  RDF_LANG_STRING,
+} from "@/term/data-factory.ts";
 export { rdfTermToSparqlValue, sparqlTermToRdfTerm } from "@/term/convert.ts";
 export {
   canonicalizeRdfTerm,

--- a/src/term/term.test.ts
+++ b/src/term/term.test.ts
@@ -32,6 +32,9 @@ Deno.test("termKey agrees with sameRdfTerm on term identity", () => {
     literal("plain"),
     literal("hello", "en"),
     literal("hello", "fr"),
+    literal("hello", { language: "en", direction: "ltr" }),
+    literal("hello", { language: "en", direction: "rtl" }),
+    literal("hello", { language: "ar", direction: "rtl" }),
     literal("42", xsdInteger),
     literal("42"),
     quad(ex("s"), ex("p"), literal("o")),
@@ -56,8 +59,15 @@ Deno.test("canonicalize agrees across the RDF/JS and SparqlValue representations
     blankNode("x"),
     literal("plain"),
     literal("hello", "en"),
+    literal("hello", { language: "en", direction: "ltr" }),
+    literal("hello", { language: "ar", direction: "rtl" }),
     literal("42", xsdInteger),
     quad(ex("s"), ex("p"), literal("o")),
+    quad(
+      ex("s"),
+      ex("p"),
+      literal("hello", { language: "en", direction: "ltr" }),
+    ),
     quad(ex("s"), ex("p"), quad(ex("s1"), ex("p1"), ex("o1"))),
   ];
   for (const term of terms) {

--- a/src/wazoo-sparql-engine.test.ts
+++ b/src/wazoo-sparql-engine.test.ts
@@ -2381,6 +2381,265 @@ Deno.test("WazooSparqlEngine - LANG and LANGMATCHES", async () => {
   });
 });
 
+Deno.test("WazooSparqlEngine - RDF 1.2 directional literal functions", async () => {
+  const engine = emptyEngine();
+  const RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+
+  // LANGDIR returns the base direction; empty when absent; non-literals error.
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(LANGDIR("abc"@en--ltr) AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "ltr" },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(LANGDIR("abc"@en) AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "" },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(LANGDIR("abc") AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "" },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      "SELECT ?v WHERE { BIND(LANGDIR(<http://x>) AS ?v) }",
+      "v",
+    ),
+    null,
+  );
+
+  // hasLang / hasLangDir are unary term tests.
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(hasLang("abc"@en--ltr) AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "true", datatype: `${XSD}boolean` },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(hasLang("abc") AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "false", datatype: `${XSD}boolean` },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(hasLangDir("abc"@en--ltr) AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "true", datatype: `${XSD}boolean` },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(hasLangDir("abc"@en) AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "false", datatype: `${XSD}boolean` },
+  );
+
+  // STRLANGDIR builds an rdf:dirLangString literal; bad args are errors.
+  const built = await bindValue(
+    engine,
+    'SELECT ?v WHERE { BIND(STRLANGDIR("abc", "en", "ltr") AS ?v) }',
+    "v",
+  );
+  assertEquals(built, { type: "literal", value: "abc", lang: "en" });
+  const builtDatatype = await bindValue(
+    engine,
+    'SELECT ?v WHERE { BIND(DATATYPE(STRLANGDIR("abc", "ar", "rtl")) AS ?v) }',
+    "v",
+  );
+  assertEquals(builtDatatype, {
+    type: "uri",
+    value: `${RDF}dirLangString`,
+  });
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(STRLANGDIR("abc", "en", "LTR") AS ?v) }',
+      "v",
+    ),
+    null,
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(STRLANGDIR("abc", "", "ltr") AS ?v) }',
+      "v",
+    ),
+    null,
+  );
+
+  // STRLANG rejects an empty tag; STRDT rejects the rdf:langString and
+  // rdf:dirLangString datatypes.
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(STRLANG("abc", "") AS ?v) }',
+      "v",
+    ),
+    null,
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      `SELECT ?v WHERE { BIND(STRDT("abc", <${RDF}langString>) AS ?v) }`,
+      "v",
+    ),
+    null,
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      `SELECT ?v WHERE { BIND(STRDT("abc", <${RDF}dirLangString>) AS ?v) }`,
+      "v",
+    ),
+    null,
+  );
+
+  // Literal equality in filters includes the direction.
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND("x"@en--ltr = "x"@en--ltr AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "true", datatype: `${XSD}boolean` },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND("x"@en = "x"@en--ltr AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "false", datatype: `${XSD}boolean` },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND("x"@en--ltr = "x"@en--rtl AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "false", datatype: `${XSD}boolean` },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND("x"@en--ltr != "x"@en--rtl AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "true", datatype: `${XSD}boolean` },
+  );
+
+  // String functions preserve the direction.
+  const ucaseDir = await bindValue(
+    engine,
+    'SELECT ?v WHERE { BIND(DATATYPE(UCASE("abc"@en--ltr)) AS ?v) }',
+    "v",
+  );
+  assertEquals(ucaseDir, { type: "uri", value: `${RDF}dirLangString` });
+  const concatDir = await bindValue(
+    engine,
+    'SELECT ?v WHERE { BIND(DATATYPE(CONCAT("a"@en--ltr, "b"@en--ltr)) AS ?v) }',
+    "v",
+  );
+  assertEquals(concatDir, { type: "uri", value: `${RDF}dirLangString` });
+  const concatMixed = await bindValue(
+    engine,
+    'SELECT ?v WHERE { BIND(DATATYPE(CONCAT("a"@en--ltr, "b"@en)) AS ?v) }',
+    "v",
+  );
+  assertEquals(concatMixed, { type: "uri", value: `${XSD}string` });
+
+  // LANGMATCHES over a directional literal: LANG strips the direction.
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(LANGMATCHES(LANG("x"@en--ltr), "en") AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "true", datatype: `${XSD}boolean` },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(LANGMATCHES(LANG("x"@en--ltr), "fr") AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "false", datatype: `${XSD}boolean` },
+  );
+});
+
+Deno.test("WazooSparqlEngine - directional literals match only with same direction", async () => {
+  const store = new Store();
+  const RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/s"),
+      namedNode("http://example.org/p"),
+      literal("x", { language: "en", direction: "ltr" }),
+    ),
+  );
+  const engine = new WazooSparqlEngine({ store });
+
+  // firstObject runs a SELECT and returns the first row's `o` binding, or
+  // null when the query produced no rows (a no-match filter).
+  async function firstObject(query: string) {
+    const result = await engine.execute({ query });
+    if (result.kind !== "select") {
+      throw new Error(`expected select, got ${result.kind}`);
+    }
+    return result.data.results.bindings[0]?.o ?? null;
+  }
+
+  // A directional literal in the query matches the store term with the same
+  // direction and only that direction.
+  assertEquals(
+    await firstObject(
+      "SELECT ?o WHERE { <http://example.org/s> <http://example.org/p> ?o " +
+        'FILTER(?o = "x"@en--ltr) }',
+    ),
+    { type: "literal", value: "x", "xml:lang": "en" },
+  );
+  assertEquals(
+    await firstObject(
+      "SELECT ?o WHERE { <http://example.org/s> <http://example.org/p> ?o " +
+        'FILTER(?o = "x"@en--rtl) }',
+    ),
+    null,
+  );
+  assertEquals(
+    await firstObject(
+      "SELECT ?o WHERE { <http://example.org/s> <http://example.org/p> ?o " +
+        'FILTER(?o = "x"@en) }',
+    ),
+    null,
+  );
+  assertEquals(
+    await firstObject(
+      `SELECT ?o WHERE { <http://example.org/s> <http://example.org/p> ?o ` +
+        `FILTER(DATATYPE(?o) = <${RDF}dirLangString>) }`,
+    ),
+    { type: "literal", value: "x", "xml:lang": "en" },
+  );
+});
+
 Deno.test("WazooSparqlEngine - COALESCE, IF, IN, NOT IN, SAMETERM", async () => {
   const engine = emptyEngine();
   const coalesce = await bindValue(

--- a/src/wazoo-sparql-engine.test.ts
+++ b/src/wazoo-sparql-engine.test.ts
@@ -2615,7 +2615,7 @@ Deno.test("WazooSparqlEngine - directional literals match only with same directi
       "SELECT ?o WHERE { <http://example.org/s> <http://example.org/p> ?o " +
         'FILTER(?o = "x"@en--ltr) }',
     ),
-    { type: "literal", value: "x", "xml:lang": "en" },
+    { type: "literal", value: "x", "xml:lang": "en", "its:dir": "ltr" },
   );
   assertEquals(
     await firstObject(
@@ -2636,8 +2636,157 @@ Deno.test("WazooSparqlEngine - directional literals match only with same directi
       `SELECT ?o WHERE { <http://example.org/s> <http://example.org/p> ?o ` +
         `FILTER(DATATYPE(?o) = <${RDF}dirLangString>) }`,
     ),
-    { type: "literal", value: "x", "xml:lang": "en" },
+    { type: "literal", value: "x", "xml:lang": "en", "its:dir": "ltr" },
   );
+});
+
+Deno.test("WazooSparqlEngine - results serialize directional literals with its:dir", async () => {
+  const store = new Store();
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/s"),
+      namedNode("http://example.org/p"),
+      literal("x", { language: "en", direction: "ltr" }),
+    ),
+  );
+  const engine = new WazooSparqlEngine({ store });
+
+  // A directional literal in the store round-trips through the SELECT wire
+  // format with its base direction (SPARQL 1.2 results JSON `its:dir` key,
+  // which the XML format mirrors as an its:dir attribute).
+  const direct = await engine.execute({
+    query:
+      "SELECT ?o WHERE { <http://example.org/s> <http://example.org/p> ?o }",
+  });
+  if (direct.kind !== "select") {
+    throw new Error(`expected select, got ${direct.kind}`);
+  }
+  assertEquals(direct.data.results.bindings[0].o, {
+    type: "literal",
+    value: "x",
+    "xml:lang": "en",
+    "its:dir": "ltr",
+  });
+
+  // The direction also round-trips nested inside a triple term result.
+  const triple = await engine.execute({
+    query:
+      'SELECT ?t WHERE { BIND(TRIPLE(<http://s>, <http://p>, "x"@en--ltr) AS ?t) }',
+  });
+  if (triple.kind !== "select") {
+    throw new Error(`expected select, got ${triple.kind}`);
+  }
+  assertEquals(triple.data.results.bindings[0].t, {
+    type: "triple",
+    value: {
+      subject: { type: "uri", value: "http://s" },
+      predicate: { type: "uri", value: "http://p" },
+      object: {
+        type: "literal",
+        value: "x",
+        "xml:lang": "en",
+        "its:dir": "ltr",
+      },
+    },
+  });
+
+  // A plain lang-tagged literal carries no direction key.
+  const plain = await engine.execute({
+    query: 'SELECT ?o WHERE { BIND("y"@en AS ?o) }',
+  });
+  if (plain.kind !== "select") {
+    throw new Error(`expected select, got ${plain.kind}`);
+  }
+  assertEquals(plain.data.results.bindings[0].o, {
+    type: "literal",
+    value: "y",
+    "xml:lang": "en",
+  });
+});
+
+Deno.test("WazooSparqlEngine - TRIPLE/SUBJECT/OBJECT preserve the direction", async () => {
+  const engine = emptyEngine();
+
+  // OBJECT of a triple term keeps the directional literal intact, so it
+  // round-trips with its direction and compares direction-sensitively.
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(OBJECT(TRIPLE(<http://s>, <http://p>, "x"@en--ltr)) AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "x", lang: "en" },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(OBJECT(TRIPLE(<http://s>, <http://p>, "x"@en--ltr)) = "x"@en--ltr AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "true", datatype: `${XSD}boolean` },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(OBJECT(TRIPLE(<http://s>, <http://p>, "x"@en--ltr)) = "x"@en AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "false", datatype: `${XSD}boolean` },
+  );
+  assertEquals(
+    await bindValue(
+      engine,
+      'SELECT ?v WHERE { BIND(LANGDIR(OBJECT(TRIPLE(<http://s>, <http://p>, "x"@en--rtl))) AS ?v) }',
+      "v",
+    ),
+    { type: "literal", value: "rtl" },
+  );
+});
+
+Deno.test("WazooSparqlEngine - ORDER BY orders directional literals deterministically", async () => {
+  const store = new Store();
+  // Same lexical form, three direction variants: the datatype rdf:dirLangString
+  // sorts before rdf:langString, and within it the direction breaks the tie
+  // ("" < "ltr" < "rtl" codepoint-wise), so ASC is en--ltr, en--rtl, en.
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/a"),
+      namedNode("http://example.org/p"),
+      literal("x", { language: "en", direction: "rtl" }),
+    ),
+  );
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/b"),
+      namedNode("http://example.org/p"),
+      literal("x", { language: "en", direction: "ltr" }),
+    ),
+  );
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/c"),
+      namedNode("http://example.org/p"),
+      literal("x", "en"),
+    ),
+  );
+  const engine = new WazooSparqlEngine({ store });
+
+  async function orderedObjects(order: string): Promise<string[]> {
+    const result = await engine.execute({
+      query:
+        `SELECT ?o WHERE { ?s <http://example.org/p> ?o } ORDER BY ${order}`,
+    });
+    if (result.kind !== "select") {
+      throw new Error(`expected select, got ${result.kind}`);
+    }
+    return result.data.results.bindings.map((b) => {
+      const o = b.o as { value: string; "its:dir"?: string };
+      return `${o.value}@${o["its:dir"] ?? ""}`;
+    });
+  }
+
+  assertEquals(await orderedObjects("ASC(?o)"), ["x@ltr", "x@rtl", "x@"]);
+  assertEquals(await orderedObjects("DESC(?o)"), ["x@", "x@rtl", "x@ltr"]);
 });
 
 Deno.test("WazooSparqlEngine - COALESCE, IF, IN, NOT IN, SAMETERM", async () => {

--- a/src/wazoo-sparql-engine.test.ts
+++ b/src/wazoo-sparql-engine.test.ts
@@ -2789,6 +2789,178 @@ Deno.test("WazooSparqlEngine - ORDER BY orders directional literals deterministi
   assertEquals(await orderedObjects("DESC(?o)"), ["x@", "x@rtl", "x@ltr"]);
 });
 
+Deno.test("WazooSparqlEngine - property paths inside EXISTS evaluate like the main pattern", async () => {
+  // Default graph: a -p-> b -q-> c -q-> d, plus a labeled edge b -r-> c.
+  // Named graph g1 carries a -p-> b -q-> c (same nodes).
+  const store = new Store();
+  const ex = (local: string) => namedNode(`http://example.org/${local}`);
+  const add = (
+    s: string,
+    p: string,
+    o: string,
+    graph?: string,
+  ) => store.addQuad(quad(ex(s), ex(p), ex(o), graph ? ex(graph) : undefined));
+  add("a", "p", "b");
+  add("b", "q", "c");
+  add("c", "q", "d");
+  add("b", "r", "c");
+  add("a", "p", "b", "g1");
+  add("b", "q", "c", "g1");
+  const engine = new WazooSparqlEngine({ store });
+
+  async function projected(query: string, variable: string): Promise<string[]> {
+    const result = await engine.execute({ query });
+    if (result.kind !== "select") {
+      throw new Error(`expected select, got ${result.kind}`);
+    }
+    return result.data.results.bindings.map((b) =>
+      String((b[variable] as { value: string }).value)
+    ).sort();
+  }
+
+  // EXISTS: b reaches c and d via q+ (one or more q edges), so a passes.
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?o <http://example.org/q>+ ?z } }",
+      "s",
+    ),
+    ["http://example.org/a"],
+  );
+  // zero-or-more also admits b itself (reflexive), so EXISTS holds.
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?o <http://example.org/q>* ?z } }",
+      "s",
+    ),
+    ["http://example.org/a"],
+  );
+  // NOT EXISTS with a zero-or-one path: b -q-> c exists, so b is excluded.
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { ?s <http://example.org/p> ?o " +
+        "FILTER NOT EXISTS { ?o <http://example.org/q>? ?z } }",
+      "s",
+    ),
+    [],
+  );
+  // Sequence: b -q-> c -q-> d, so EXISTS { ?o <q>/<q> ?z } holds.
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?o <http://example.org/q>/<http://example.org/q> ?z } }",
+      "s",
+    ),
+    ["http://example.org/a"],
+  );
+  // Alternative: b -r-> c, so (q|r) matches.
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?o (<http://example.org/q>|<http://example.org/r>) ?z } }",
+      "s",
+    ),
+    ["http://example.org/a"],
+  );
+  // Inverse: nothing points at b via q (c does via b, d via c), so no pass.
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?o ^<http://example.org/q> ?x } }",
+      "s",
+    ),
+    [],
+  );
+  // Negated property set: b has a q edge and an r edge; excluding q still
+  // matches r, so EXISTS holds.
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?o !(<http://example.org/q>) ?z } }",
+      "s",
+    ),
+    ["http://example.org/a"],
+  );
+  // Negated property set excluding both q and r leaves b with no edges.
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?o !(<http://example.org/q>|<http://example.org/r>) ?z } }",
+      "s",
+    ),
+    [],
+  );
+  // Correlated: the outer binding of ?o is visible inside the path pattern's
+  // subject, and the path binds both endpoints.
+  assertEquals(
+    await projected(
+      "SELECT ?s ?o WHERE { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?s <http://example.org/p>+ ?x } }",
+      "s",
+    ),
+    ["http://example.org/a"],
+  );
+});
+
+Deno.test("WazooSparqlEngine - property paths inside EXISTS respect GRAPH scopes", async () => {
+  // Named graph g1: a -p-> b -q-> c. Default graph also carries a -p-> b and
+  // b -q-> c -q-> d, so a plain default-graph EXISTS would pass for q+ even
+  // when the GRAPH-scoped one must not (the scope only reaches c).
+  const store = new Store();
+  const ex = (local: string) => namedNode(`http://example.org/${local}`);
+  const add = (s: string, p: string, o: string, graph?: string) =>
+    store.addQuad(quad(ex(s), ex(p), ex(o), graph ? ex(graph) : undefined));
+  add("a", "p", "b");
+  add("b", "q", "c");
+  add("c", "q", "d");
+  add("a", "p", "b", "g1");
+  add("b", "q", "c", "g1");
+  const engine = new WazooSparqlEngine({ store });
+
+  async function projected(query: string, variable: string): Promise<string[]> {
+    const result = await engine.execute({ query });
+    if (result.kind !== "select") {
+      throw new Error(`expected select, got ${result.kind}`);
+    }
+    return result.data.results.bindings.map((b) =>
+      String((b[variable] as { value: string }).value)
+    ).sort();
+  }
+
+  // Inside the g1 scope, q+ reaches only c (no d), but the EXISTS still holds
+  // for a — the scope is respected, not leaked into the default graph.
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { GRAPH <http://example.org/g1> { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?o <http://example.org/q>+ ?z } } }",
+      "s",
+    ),
+    ["http://example.org/a"],
+  );
+  // A scope with no q edges at all: EXISTS fails inside it, so a is not
+  // emitted even though the default graph would satisfy the path.
+  store.addQuad(quad(ex("a"), ex("p"), ex("b"), ex("g2")));
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { GRAPH <http://example.org/g2> { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?o <http://example.org/q>+ ?z } } }",
+      "s",
+    ),
+    [],
+  );
+  // GRAPH ?g with a bound ?g enumerates the named graphs; only g1 satisfies
+  // the q+ EXISTS, so a (from g1) is the sole row.
+  assertEquals(
+    await projected(
+      "SELECT ?s WHERE { GRAPH ?g { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?o <http://example.org/q>+ ?z } } }",
+      "s",
+    ),
+    ["http://example.org/a"],
+  );
+});
+
 Deno.test("WazooSparqlEngine - COALESCE, IF, IN, NOT IN, SAMETERM", async () => {
   const engine = emptyEngine();
   const coalesce = await bindValue(

--- a/test/w3c/fixtures/sparql12/expression/expr-01.rq
+++ b/test/w3c/fixtures/sparql12/expression/expr-01.rq
@@ -1,1 +1,0 @@
-SELECT (hasLang("hello", "en") AS ?has) WHERE {}

--- a/test/w3c/fixtures/sparql12/expression/expr-02.rq
+++ b/test/w3c/fixtures/sparql12/expression/expr-02.rq
@@ -1,1 +1,0 @@
-SELECT (LANGDIR("hello") AS ?dir) WHERE {}

--- a/test/w3c/fixtures/sparql12/expression/expr-03.rq
+++ b/test/w3c/fixtures/sparql12/expression/expr-03.rq
@@ -1,1 +1,0 @@
-SELECT (LANGDIR("hello"@en) AS ?dir) WHERE {}

--- a/test/w3c/fixtures/sparql12/expression/expr-04.rq
+++ b/test/w3c/fixtures/sparql12/expression/expr-04.rq
@@ -1,1 +1,0 @@
-SELECT (STRLANGDIR("hello", "en") AS ?l) WHERE {}

--- a/test/w3c/fixtures/sparql12/expression/expr-05.rq
+++ b/test/w3c/fixtures/sparql12/expression/expr-05.rq
@@ -1,1 +1,0 @@
-SELECT (hasLangDir("hello", "en", "ltr") AS ?has) WHERE {}

--- a/test/w3c/fixtures/sparql12/expression/manifest.ttl
+++ b/test/w3c/fixtures/sparql12/expression/manifest.ttl
@@ -1,37 +1,63 @@
-@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
-@prefix dawgt: <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix :       <https://w3c.github.io/rdf-tests/sparql/sparql12/expression/manifest#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix mf:     <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+@prefix qt:     <http://www.w3.org/2001/sw/DataAccess/tests/test-query#> .
+@prefix dawgt:  <http://www.w3.org/2001/sw/DataAccess/tests/test-dawg#> .
 
-<> a mf:Manifest ;
-  mf:entries (
-    <#expr-01>
-    <#expr-02>
-    <#expr-03>
-    <#expr-04>
-    <#expr-05>
-  ) .
+<>  rdf:type mf:Manifest ;
+    rdfs:label "Expression" ;
+    mf:entries
+    (
+    :not-not
+    :triple-on-literals
+    :triple-on-str-literals
+    :triple-on-triple-terms
+    :triple-on-undefs
+    ) .
 
-<#expr-01> a mf:PositiveSyntaxTest11 ;
-  mf:name "Expression expr-01" ;
-  dawgt:approval dawgt:Approved ;
-  mf:action <expr-01.rq> .
 
-<#expr-02> a mf:PositiveSyntaxTest11 ;
-  mf:name "Expression expr-02" ;
-  dawgt:approval dawgt:Approved ;
-  mf:action <expr-02.rq> .
+:not-not rdf:type mf:QueryEvaluationTest ;
+    mf:name "not-not";
+    rdfs:comment    "Double negation !!" ;
+    dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <not-not.rq> ] ;
+    mf:result  <not-not.srx>
+    .
 
-<#expr-03> a mf:PositiveSyntaxTest11 ;
-  mf:name "Expression expr-03" ;
-  dawgt:approval dawgt:Approved ;
-  mf:action <expr-03.rq> .
+:triple-on-literals rdf:type mf:QueryEvaluationTest ;
+    mf:name "triple on literals";
+    rdfs:comment    "Evaluation of TRIPLE builtin on literals" ;
+    dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <triple-on-literals.rq> ] ;
+    mf:result  <triple-on-literals.srj>
+    .
 
-<#expr-04> a mf:PositiveSyntaxTest11 ;
-  mf:name "Expression expr-04" ;
-  dawgt:approval dawgt:Approved ;
-  mf:action <expr-04.rq> .
+:triple-on-str-literals rdf:type mf:QueryEvaluationTest ;
+    mf:name "triple on string literals";
+    rdfs:comment    "Evaluation of TRIPLE builtin on string literals" ;
+    dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <triple-on-str-literals.rq> ] ;
+    mf:result  <triple-on-str-literals.srj>
+    .
 
-<#expr-05> a mf:PositiveSyntaxTest11 ;
-  mf:name "Expression expr-05" ;
-  dawgt:approval dawgt:Approved ;
-  mf:action <expr-05.rq> .
+:triple-on-triple-terms rdf:type mf:QueryEvaluationTest ;
+    mf:name "triple on triple terms";
+    rdfs:comment    "Evaluation of TRIPLE builtin on triple terms" ;
+    dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <triple-on-triple-terms.rq> ] ;
+    mf:result  <triple-on-triple-terms.srj>
+    .
 
+:triple-on-undefs rdf:type mf:QueryEvaluationTest ;
+    mf:name "triple on undefs";
+    rdfs:comment    "Evaluation of TRIPLE builtin on UNDEFs" ;
+    dawgt:approval dawgt:Proposed ;
+    mf:action
+         [ qt:query  <triple-on-undefs.rq> ] ;
+    mf:result  <triple-on-undefs.srj>
+    .

--- a/test/w3c/fixtures/sparql12/expression/not-not.rq
+++ b/test/w3c/fixtures/sparql12/expression/not-not.rq
@@ -1,0 +1,7 @@
+PREFIX : <http://example/>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?v ?ebv {
+  VALUES ?v { true 1 "a" false 0 "" "a"@en "z"^^xsd:boolean "2020-01-01T00:00:00Z"^^xsd:dateTime :a }
+  BIND(!!?v AS ?ebv)
+}

--- a/test/w3c/fixtures/sparql12/expression/not-not.srx
+++ b/test/w3c/fixtures/sparql12/expression/not-not.srx
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+  <head>
+    <variable name="v"/>
+    <variable name="ebv"/>
+  </head>
+  <results>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">true</literal>
+      </binding>
+      <binding name="ebv">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">true</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">1</literal>
+      </binding>
+      <binding name="ebv">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">true</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#string">a</literal>
+      </binding>
+      <binding name="ebv">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">true</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">false</literal>
+      </binding>
+      <binding name="ebv">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">false</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#integer">0</literal>
+      </binding>
+      <binding name="ebv">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">false</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#string"></literal>
+      </binding>
+      <binding name="ebv">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">false</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal xml:lang="en">a</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#boolean">z</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <literal datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-01-01T00:00:00Z</literal>
+      </binding>
+    </result>
+    <result>
+      <binding name="v">
+        <uri>http://example/a</uri>
+      </binding>
+    </result>
+  </results>
+</sparql>

--- a/test/w3c/fixtures/sparql12/expression/srj-01.srj
+++ b/test/w3c/fixtures/sparql12/expression/srj-01.srj
@@ -1,1 +1,0 @@
-{"head":{"vars":["has","dir","l"]},"results":{"bindings":[]}}

--- a/test/w3c/fixtures/sparql12/expression/srj-02.srj
+++ b/test/w3c/fixtures/sparql12/expression/srj-02.srj
@@ -1,1 +1,0 @@
-{"head":{"vars":["has","dir","l"]},"results":{"bindings":[]}}

--- a/test/w3c/fixtures/sparql12/expression/srj-03.srj
+++ b/test/w3c/fixtures/sparql12/expression/srj-03.srj
@@ -1,1 +1,0 @@
-{"head":{"vars":["has","dir","l"]},"results":{"bindings":[]}}

--- a/test/w3c/fixtures/sparql12/expression/srj-04.srj
+++ b/test/w3c/fixtures/sparql12/expression/srj-04.srj
@@ -1,1 +1,0 @@
-{"head":{"vars":["has","dir","l"]},"results":{"bindings":[]}}

--- a/test/w3c/fixtures/sparql12/expression/srj-05.srj
+++ b/test/w3c/fixtures/sparql12/expression/srj-05.srj
@@ -1,1 +1,0 @@
-{"head":{"vars":["has","dir","l"]},"results":{"bindings":[]}}

--- a/test/w3c/fixtures/sparql12/expression/triple-on-literals.rq
+++ b/test/w3c/fixtures/sparql12/expression/triple-on-literals.rq
@@ -1,0 +1,18 @@
+PREFIX : <http://example/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?subject ?predicate ?object ?triple {
+  VALUES (?subject ?predicate ?object) {
+    (:a :b :c)
+    (true :b :c)
+    (:a true :c)
+    (:a :b true)
+    (1 :b :c)
+    (:a 2 :c)
+    (:a :b 3)
+    ("a"^^:type :b :c)
+    (:a "b"^^:type :c)
+    (:a :b "c"^^:type)
+  }
+  BIND(TRIPLE(?subject, ?predicate, ?object) AS ?triple)
+}

--- a/test/w3c/fixtures/sparql12/expression/triple-on-literals.srj
+++ b/test/w3c/fixtures/sparql12/expression/triple-on-literals.srj
@@ -1,0 +1,234 @@
+{
+    "head": {
+        "vars": [
+            "subject",
+            "predicate",
+            "object",
+            "triple"
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "http://example/c",
+                            "type": "uri"
+                        }
+                    },
+                    "type": "triple"
+                }
+            },
+            {
+                "subject": {
+                    "value": "true",
+                    "type": "literal",
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "true",
+                    "type": "literal",
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "true",
+                    "type": "literal",
+                    "datatype": "http://www.w3.org/2001/XMLSchema#boolean"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "true",
+                            "type": "literal",
+                            "datatype": "http://www.w3.org/2001/XMLSchema#boolean"
+                        }
+                    },
+                    "type": "triple"
+                }
+            },
+            {
+                "subject": {
+                    "value": "1",
+                    "type": "literal",
+                    "datatype": "http://www.w3.org/2001/XMLSchema#integer"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "2",
+                    "type": "literal",
+                    "datatype": "http://www.w3.org/2001/XMLSchema#integer"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "3",
+                    "type": "literal",
+                    "datatype": "http://www.w3.org/2001/XMLSchema#integer"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "3",
+                            "type": "literal",
+                            "datatype": "http://www.w3.org/2001/XMLSchema#integer"
+                        }
+                    },
+                    "type": "triple"
+                }
+            },
+            {
+                "subject": {
+                    "value": "a",
+                    "type": "literal",
+                    "datatype": "http://example/type"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "b",
+                    "type": "literal",
+                    "datatype": "http://example/type"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "c",
+                    "type": "literal",
+                    "datatype": "http://example/type"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "c",
+                            "type": "literal",
+                            "datatype": "http://example/type"
+                        }
+                    },
+                    "type": "triple"
+                }
+            }
+        ]
+    }
+}

--- a/test/w3c/fixtures/sparql12/expression/triple-on-str-literals.rq
+++ b/test/w3c/fixtures/sparql12/expression/triple-on-str-literals.rq
@@ -1,0 +1,18 @@
+PREFIX : <http://example/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?subject ?predicate ?object ?triple {
+  VALUES (?subject ?predicate ?object) {
+    (:a :b :c)
+    ("a" :b :c)
+    (:a "b" :c)
+    (:a :b "c")
+    ("a"@nl :b :c)
+    (:a "b"@nl :c)
+    (:a :b "c"@nl)
+    ("a"@nl--ltr :b :c)
+    (:a "b"@nl--ltr :c)
+    (:a :b "c"@nl--ltr)
+  }
+  BIND(TRIPLE(?subject, ?predicate, ?object) AS ?triple)
+}

--- a/test/w3c/fixtures/sparql12/expression/triple-on-str-literals.srj
+++ b/test/w3c/fixtures/sparql12/expression/triple-on-str-literals.srj
@@ -1,0 +1,234 @@
+{
+    "head": {
+        "vars": [
+            "subject",
+            "predicate",
+            "object",
+            "triple"
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "http://example/c",
+                            "type": "uri"
+                        }
+                    },
+                    "type": "triple"
+                }
+            },
+            {
+                "subject": {
+                    "value": "a",
+                    "type": "literal"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "b",
+                    "type": "literal"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "c",
+                    "type": "literal"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "c",
+                            "type": "literal"
+                        }
+                    },
+                    "type": "triple"
+                }
+            },
+            {
+                "subject": {
+                    "value": "a",
+                    "type": "literal",
+                    "xml:lang": "nl"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "b",
+                    "type": "literal",
+                    "xml:lang": "nl"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "c",
+                    "type": "literal",
+                    "xml:lang": "nl"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "c",
+                            "type": "literal",
+                            "xml:lang": "nl"
+                        }
+                    },
+                    "type": "triple"
+                }
+            },
+            {
+                "subject": {
+                    "value": "a",
+                    "type": "literal",
+                    "xml:lang": "nl",
+                    "its:dir": "ltr"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "b",
+                    "type": "literal",
+                    "xml:lang": "nl",
+                    "its:dir": "ltr"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "c",
+                    "type": "literal",
+                    "xml:lang": "nl",
+                    "its:dir": "ltr"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "c",
+                            "type": "literal",
+                            "xml:lang": "nl",
+                            "its:dir": "ltr"
+                        }
+                    },
+                    "type": "triple"
+                }
+            }
+        ]
+    }
+}

--- a/test/w3c/fixtures/sparql12/expression/triple-on-triple-terms.rq
+++ b/test/w3c/fixtures/sparql12/expression/triple-on-triple-terms.rq
@@ -1,0 +1,15 @@
+PREFIX : <http://example/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?subject ?predicate ?object ?triple {
+  VALUES (?subject ?predicate ?object) {
+    (:a :b :c)
+    (<<(:x :y :z)>> :b :c)
+    (:a <<(:x :y :z)>> :c)
+    (:a :b <<(:x :y :z)>>)
+    (<<(:x a :z)>> :b :c)
+    (:a <<(:x a :z)>> :c)
+    (:a :b <<(:x a :z)>>)
+  }
+  BIND(TRIPLE(?subject, ?predicate, ?object) AS ?triple)
+}

--- a/test/w3c/fixtures/sparql12/expression/triple-on-triple-terms.srj
+++ b/test/w3c/fixtures/sparql12/expression/triple-on-triple-terms.srj
@@ -1,0 +1,267 @@
+{
+    "head": {
+        "vars": [
+            "subject",
+            "predicate",
+            "object",
+            "triple"
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "http://example/c",
+                            "type": "uri"
+                        }
+                    },
+                    "type": "triple"
+                }
+            },
+            {
+                "subject": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/x",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/y",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "http://example/z",
+                            "type": "uri"
+                        }
+                    },
+                    "type": "triple"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/x",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/y",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "http://example/z",
+                            "type": "uri"
+                        }
+                    },
+                    "type": "triple"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/x",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/y",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "http://example/z",
+                            "type": "uri"
+                        }
+                    },
+                    "type": "triple"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": {
+                                "subject": {
+                                    "value": "http://example/x",
+                                    "type": "uri"
+                                },
+                                "predicate": {
+                                    "value": "http://example/y",
+                                    "type": "uri"
+                                },
+                                "object": {
+                                    "value": "http://example/z",
+                                    "type": "uri"
+                                }
+                            },
+                            "type": "triple"
+                        }
+                    },
+                    "type": "triple"
+                }
+            },
+            {
+                "subject": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/x",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "http://example/z",
+                            "type": "uri"
+                        }
+                    },
+                    "type": "triple"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/x",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "http://example/z",
+                            "type": "uri"
+                        }
+                    },
+                    "type": "triple"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/x",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "http://example/z",
+                            "type": "uri"
+                        }
+                    },
+                    "type": "triple"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": {
+                                "subject": {
+                                    "value": "http://example/x",
+                                    "type": "uri"
+                                },
+                                "predicate": {
+                                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                                    "type": "uri"
+                                },
+                                "object": {
+                                    "value": "http://example/z",
+                                    "type": "uri"
+                                }
+                            },
+                            "type": "triple"
+                        }
+                    },
+                    "type": "triple"
+                }
+            }
+        ]
+    }
+}

--- a/test/w3c/fixtures/sparql12/expression/triple-on-undefs.rq
+++ b/test/w3c/fixtures/sparql12/expression/triple-on-undefs.rq
@@ -1,0 +1,12 @@
+PREFIX : <http://example/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?subject ?predicate ?object ?triple {
+  VALUES (?subject ?predicate ?object) {
+    (:a :b :c)
+    (UNDEF :b :c)
+    (:a UNDEF :c)
+    (:a :b UNDEF)
+  }
+  BIND(TRIPLE(?subject, ?predicate, ?object) AS ?triple)
+}

--- a/test/w3c/fixtures/sparql12/expression/triple-on-undefs.srj
+++ b/test/w3c/fixtures/sparql12/expression/triple-on-undefs.srj
@@ -1,0 +1,75 @@
+{
+    "head": {
+        "vars": [
+            "subject",
+            "predicate",
+            "object",
+            "triple"
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                },
+                "triple": {
+                    "value": {
+                        "subject": {
+                            "value": "http://example/a",
+                            "type": "uri"
+                        },
+                        "predicate": {
+                            "value": "http://example/b",
+                            "type": "uri"
+                        },
+                        "object": {
+                            "value": "http://example/c",
+                            "type": "uri"
+                        }
+                    },
+                    "type": "triple"
+                }
+            },
+            {
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "object": {
+                    "value": "http://example/c",
+                    "type": "uri"
+                }
+            },
+            {
+                "subject": {
+                    "value": "http://example/a",
+                    "type": "uri"
+                },
+                "predicate": {
+                    "value": "http://example/b",
+                    "type": "uri"
+                }
+            }
+        ]
+    }
+}

--- a/test/w3c/sparql12-gap.ts
+++ b/test/w3c/sparql12-gap.ts
@@ -218,6 +218,7 @@ function srjValueToCanonical(raw: unknown): CanonicalTerm {
     type: string;
     value: unknown;
     "xml:lang"?: string;
+    "its:dir"?: string;
     datatype?: string;
   };
   switch (value.type) {
@@ -230,8 +231,10 @@ function srjValueToCanonical(raw: unknown): CanonicalTerm {
         termType: "Literal",
         value: String(value.value),
       };
-      if (value["xml:lang"]) canonical.language = value["xml:lang"];
-      else if (value.datatype && value.datatype !== XSD_STRING) {
+      if (value["xml:lang"]) {
+        canonical.language = value["xml:lang"];
+        if (value["its:dir"]) canonical.direction = value["its:dir"];
+      } else if (value.datatype && value.datatype !== XSD_STRING) {
         canonical.datatype = value.datatype;
       }
       return canonical;


### PR DESCRIPTION
## Summary

RDF 1.2 directional literals (`"abc"@en--ltr`, datatype `rdf:dirLangString`) were modeled in the term layer in #58 but the SPARQL **query and expression layers** still treated direction as part of the language tag (or ignored it). This PR wires direction through the parser and evaluator to match the SPARQL 1.2 grammar and function definitions, verified against the W3C spec (`[141] BuiltInCall`, `[135] UnaryExpression`) and Comunica's traqula parser (the parity reference).

### Grammar (sparql.jison, regenerated)
- `hasLang` / `hasLangDir` are **unary** term tests (were arity 2/3) and `STRLANGDIR` is **ternary** `(lexicalForm, langTag, baseDirection)` (was arity 2) — per production [141]. Native previously rejected every spec form Comunica accepts; that was a parity gap.
- `LANGTAG` now accepts the `@en--ltr` direction suffix (produces `rdf:dirLangString` query literals).
- Unary `!` is recursive per [135], so `!!x` double negation parses.

### Evaluator
- `LANGDIR` returns the literal's **base direction** (`ltr`/`rtl`, `""` when absent) instead of `"ltr"` for any tagged literal.
- `hasLang` / `hasLangDir` test presence of language / direction per spec.
- `STRLANGDIR` builds an `rdf:dirLangString` literal; errors on empty tags or non-`ltr`/`rtl` directions.
- `STRLANG` rejects empty tags; `STRDT` rejects `rdf:langString` / `rdf:dirLangString` as datatype IRIs.
- `=` / `!=` compare the base direction, so `"x"@en--ltr`, `"x"@en`, and `"x"@en--rtl` are three distinct terms in filters.
- `CONCAT`, `UCASE`, `LCASE`, `SUBSTR`, `STRBEFORE`, `STRAFTER`, `REPLACE` preserve direction when inputs agree on it (mixed directions collapse to a plain string).

### Fixtures
Refreshed the stale SPARQL 1.2 `expression/` directory: the early-draft `hasLang`/`STRLANGDIR`/`hasLangDir` tests were removed upstream; the current `QueryEvaluationTest`s (`not-not` — which is what exposed the `!!` grammar gap — and the `TRIPLE`-on-* tests) now gate.

## Verification
- `deno task ci` green — **352 tests** (was 349); SPARQL 1.2 gate at **249/249** (threshold 247).
- `deno task test:w3c` (Comunica SPARQL 1.1 parity) green — **345/345**, native conforms on all 68 conformance-checked cases.
- `parser:check` confirms the generated parsers are in sync.
