### PR TITLE
perf(exists): reuse the graph-scoped candidate set for nested EXISTS probes

### DIFF
--- a/bench/budget.ts
+++ b/bench/budget.ts
@@ -17,6 +17,17 @@ const baseline = {
       query:
         "SELECT ?s WHERE { ?s <http://example.org/p1> ?o1 . ?o1 <http://example.org/p2> ?o2 }",
     },
+    {
+      name: "EXISTS filter",
+      query: "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
+        "FILTER EXISTS { ?s <http://example.org/p> ?o } }",
+    },
+    {
+      name: "Nested EXISTS filter",
+      query: "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
+        "FILTER EXISTS { ?s <http://example.org/p1> ?o . " +
+        "FILTER EXISTS { ?o <http://example.org/p2> ?x } } }",
+    },
   ],
 };
 

--- a/bench/engine_bench.ts
+++ b/bench/engine_bench.ts
@@ -300,6 +300,20 @@ const existsQuery =
 const notExistsQuery =
   "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
   "FILTER NOT EXISTS { ?s <http://example.org/spouse> ?spouse } }";
+// Nested EXISTS: an EXISTS inside the EXISTS body. Every spouse (odd-indexed
+// person) has a name, so the inner EXISTS always holds and the even-indexed
+// people (who have a spouse) pass — same shape as the simple EXISTS, plus one
+// inner probe per passing solution.
+const nestedExistsQuery =
+  "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
+  "FILTER EXISTS { ?s <http://example.org/spouse> ?spouse . " +
+  "FILTER EXISTS { ?spouse <http://xmlns.com/foaf/0.1/name> ?n2 } } }";
+// Nested EXISTS inside NOT EXISTS: the body matches only even-indexed people
+// (spouse present and named), so the negation keeps the odd-indexed ones.
+const nestedNotExistsQuery =
+  "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
+  "FILTER NOT EXISTS { ?s <http://example.org/spouse> ?spouse . " +
+  "FILTER EXISTS { ?spouse <http://xmlns.com/foaf/0.1/name> ?n2 } } }";
 
 // XSD cast constructors over the integer age literal, plus boolean and
 // dateTime casts from string constants (the shared dataset carries no
@@ -831,6 +845,8 @@ await verifySelectEquality(subqueryAggQuery, "subquery-agg");
 await verifySelectEquality(subqueryNestedQuery, "subquery-nested");
 await verifySelectEquality(existsQuery, "exists");
 await verifySelectEquality(notExistsQuery, "not-exists");
+await verifySelectEquality(nestedExistsQuery, "nested-exists");
+await verifySelectEquality(nestedNotExistsQuery, "nested-not-exists");
 await verifySelectEquality(castNumericQuery, "cast-numeric");
 await verifySelectEquality(castBooleanQuery, "cast-boolean");
 await verifySelectEquality(castDateTimeQuery, "cast-dateTime");
@@ -1221,6 +1237,8 @@ benchSelectTrio("subquery", subqueryAggQuery, "subquery-agg");
 benchSelectTrio("subquery", subqueryNestedQuery, "subquery-nested");
 benchSelectTrio("exists", existsQuery, "exists");
 benchSelectTrio("exists", notExistsQuery, "not-exists");
+benchSelectTrio("exists", nestedExistsQuery, "nested-exists");
+benchSelectTrio("exists", nestedNotExistsQuery, "nested-not-exists");
 benchSelectTrio("cast", castNumericQuery, "cast-numeric");
 benchSelectTrio("cast", castBooleanQuery, "cast-boolean");
 benchSelectTrio("cast", castDateTimeQuery, "cast-dateTime");

--- a/bench/engine_bench.ts
+++ b/bench/engine_bench.ts
@@ -1114,9 +1114,10 @@ function benchSelectTrio(
   query: string,
   label: string,
   trio: EngineTrio = mainTrio,
+  options?: { warmup?: number; iterations?: number },
 ): void {
   Deno.bench(
-    { name: `native - ${label}`, group, baseline: true },
+    { name: `native - ${label}`, group, baseline: true, ...options },
     async () => {
       const result = await trio.native.execute({ query });
       if (
@@ -1235,10 +1236,39 @@ benchSelectTrio("from", fromQuery, "from", graphTrio);
 benchSelectTrio("subquery", subqueryQuery, "subquery");
 benchSelectTrio("subquery", subqueryAggQuery, "subquery-agg");
 benchSelectTrio("subquery", subqueryNestedQuery, "subquery-nested");
-benchSelectTrio("exists", existsQuery, "exists");
-benchSelectTrio("exists", notExistsQuery, "not-exists");
-benchSelectTrio("exists", nestedExistsQuery, "nested-exists");
-benchSelectTrio("exists", nestedNotExistsQuery, "nested-not-exists");
+// The native EXISTS path is the suite's slowest (tens of ms/iter), so it
+// needs a longer warmup than the 500 ms default for stable, comparable rows
+// (V8 must finish optimizing the hot EXISTS machinery before measurement),
+// plus more samples to average out scheduler noise.
+const EXISTS_BENCH_OPTIONS = { warmup: 3_000, iterations: 50 };
+benchSelectTrio(
+  "exists",
+  existsQuery,
+  "exists",
+  mainTrio,
+  EXISTS_BENCH_OPTIONS,
+);
+benchSelectTrio(
+  "exists",
+  notExistsQuery,
+  "not-exists",
+  mainTrio,
+  EXISTS_BENCH_OPTIONS,
+);
+benchSelectTrio(
+  "exists",
+  nestedExistsQuery,
+  "nested-exists",
+  mainTrio,
+  EXISTS_BENCH_OPTIONS,
+);
+benchSelectTrio(
+  "exists",
+  nestedNotExistsQuery,
+  "nested-not-exists",
+  mainTrio,
+  EXISTS_BENCH_OPTIONS,
+);
 benchSelectTrio("cast", castNumericQuery, "cast-numeric");
 benchSelectTrio("cast", castBooleanQuery, "cast-boolean");
 benchSelectTrio("cast", castDateTimeQuery, "cast-dateTime");

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -151,16 +151,36 @@ export class BgpEvaluator {
       );
     }
     const scopeGraph = graph ?? defaultGraph();
+    // The snapshot is filtered to the graph scope exactly once per
+    // evaluateExists call; the recursive probes reuse these candidates (see
+    // evaluateExistsScoped) instead of re-filtering per nested EXISTS.
     const candidates = this.existsQuads.filter((item) =>
       sameRdfTerm(item.graph, scopeGraph)
     );
-    const patterns = pattern.type === "group" ? pattern.patterns : [pattern];
-    return this.evaluateExistsGroup(
-      patterns,
-      [solution],
+    return this.evaluateExistsScoped(
+      pattern,
+      solution,
       candidates,
       scopeGraph,
-    ).length > 0;
+    );
+  }
+
+  /**
+   * evaluateExistsScoped runs an EXISTS probe against an already
+   * graph-scoped candidate set, skipping the per-call snapshot filter. The
+   * recursive hooks (nested EXISTS/NOT EXISTS and subqueries inside EXISTS)
+   * call this with the enclosing call's candidates, so nesting costs only
+   * the extra probe work — not another O(snapshot) filter per probe.
+   */
+  private evaluateExistsScoped(
+    pattern: Pattern,
+    solution: TermBinding,
+    candidates: rdfjs.Quad[],
+    graph: rdfjs.Term,
+  ): boolean {
+    const patterns = pattern.type === "group" ? pattern.patterns : [pattern];
+    return this.evaluateExistsGroup(patterns, [solution], candidates, graph)
+      .length > 0;
   }
 
   /**
@@ -193,7 +213,7 @@ export class BgpEvaluator {
   ): TermBinding[] {
     const context: ExpressionEvaluationContext = {
       evaluateExists: (subPattern, solution) =>
-        this.evaluateExists(subPattern, solution, graph),
+        this.evaluateExistsScoped(subPattern, solution, candidates, graph),
     };
     switch (pattern.type) {
       case "bgp": {
@@ -417,7 +437,7 @@ export class BgpEvaluator {
         const selectQuery = pattern as unknown as SelectQuery;
         const subContext: ExpressionEvaluationContext = {
           evaluateExists: (subPattern, solution) =>
-            this.evaluateExists(subPattern, solution, graph),
+            this.evaluateExistsScoped(subPattern, solution, candidates, graph),
           baseIri: selectQuery.base,
         };
         const subRaw = this.evaluateExistsGroup(

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -16,9 +16,9 @@ import {
   GraphScopedStore,
   matchQuads,
   namedGraphs,
-  probeQuadIndex,
   type QuadIndex,
   simplePredicate,
+  storeVersion,
 } from "@/quad-store.ts";
 
 const { defaultGraph } = DataFactory;
@@ -79,10 +79,13 @@ export class BgpEvaluator {
   /**
    * existsQuads and existsIndex are the drained, indexed snapshot of the
    * evaluator's store that the synchronous EXISTS hooks probe. They are
-   * rebuilt per query by prepareExistsIndex when any pattern uses EXISTS.
+   * cached across queries and rebuilt by prepareExistsIndex only when the
+   * store's mutation version changes (or when the store exposes no version).
    */
   private existsQuads: rdfjs.Quad[] | null = null;
   private existsIndex: QuadIndex | null = null;
+  /** existsVersion is the store version the snapshot was drained from. */
+  private existsVersion: number | null = null;
 
   /** expressionEvaluator evaluates FILTER expressions against solutions. */
   private readonly expressionEvaluator = new ExpressionEvaluator();
@@ -101,10 +104,10 @@ export class BgpEvaluator {
   public async evaluateBgp(patterns: Pattern[]): Promise<TermBinding[]> {
     // EXISTS support: when any pattern in the tree uses EXISTS/NOT EXISTS,
     // the store's quads are drained once into a synchronous index that the
-    // injected hooks probe (the decided sync-hook contract). Rebuilt per
-    // query, so updates between queries never see a stale snapshot.
-    this.existsIndex = null;
-    this.existsQuads = null;
+    // injected hooks probe (the decided sync-hook contract). The snapshot is
+    // cached across queries and invalidated by the store's mutation version,
+    // so updates between queries never see stale data and repeated queries
+    // against an unchanged store skip the drain entirely.
     if (patternListContainsExists(patterns)) {
       await this.prepareExistsIndex();
     }
@@ -124,12 +127,17 @@ export class BgpEvaluator {
    * though the WHERE clause does not.
    */
   public async prepareExistsIndex(): Promise<void> {
-    if (this.existsIndex !== null) {
+    const version = storeVersion(this.store);
+    if (
+      this.existsIndex !== null && this.existsQuads !== null &&
+      version !== null && this.existsVersion === version
+    ) {
       return;
     }
     const quads = await matchQuads(this.store, null, null, null);
     this.existsQuads = quads;
     this.existsIndex = buildQuadIndex(quads);
+    this.existsVersion = version;
   }
 
   /**
@@ -244,9 +252,11 @@ export class BgpEvaluator {
             reifies,
             tripleTermObject,
             // probeQuadIndex checks only s/p/o, so the graph scope is
-            // enforced afterwards over the probed candidates. Reifies
-            // patterns scan every `rdf:reifies` statement in the scope, and
-            // triple-term objects scan every quad with a triple-term object.
+            // enforced on the probed matches via the join's graphScope (the
+            // prebuilt snapshot index spans every graph). Reifies patterns
+            // scan every `rdf:reifies` statement in the scope, and
+            // triple-term objects scan every quad with a triple-term object
+            // (both subsets of the scoped candidates).
             candidates: reifies
               ? candidates.filter((item) =>
                 item.predicate.termType === "NamedNode" &&
@@ -254,21 +264,13 @@ export class BgpEvaluator {
               )
               : tripleTermObject
               ? candidates.filter((item) => item.object.termType === "Quad")
-              : probeQuadIndex(
-                this.existsIndex!,
-                candidates,
-                triple.subject.termType === "Variable"
-                  ? null
-                  : sparqlTermToRdfTerm(triple.subject),
-                predicate.termType === "Variable"
-                  ? null
-                  : sparqlTermToRdfTerm(predicate),
-                triple.object.termType === "Variable"
-                  ? null
-                  : sparqlTermToRdfTerm(triple.object),
-              ).filter((item) => sameRdfTerm(item.graph, graph)),
+              : candidates,
           };
-          result = joinTriplePattern(result, entry);
+          // The join probes the once-per-query snapshot index with each
+          // solution's resolved positions (constants and bound variables)
+          // instead of rebuilding an index over the probed bucket per
+          // solution — the EXISTS hook joins one solution at a time.
+          result = joinTriplePattern(result, entry, this.existsIndex!, graph);
         }
         return result;
       }

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -483,6 +483,29 @@ export class BgpEvaluator {
   }
 
   /**
+   * scopedExistsContext builds an expression context whose EXISTS hooks probe
+   * an already graph-scoped candidate set, computed once per context instead
+   * of re-filtering the snapshot for every solution. Callers gate on
+   * expressionContainsExists first, so the EXISTS index is guaranteed
+   * prepared — mirroring evaluateExistsScoped's reuse of the enclosing
+   * call's candidates for the main-path FILTER / BIND / OPTIONAL conditions.
+   */
+  private scopedExistsContext(
+    store: rdfjs.Source<rdfjs.Quad>,
+  ): ExpressionEvaluationContext {
+    const graph = store instanceof GraphScopedStore
+      ? store.graph
+      : defaultGraph();
+    const candidates = this.existsQuads!.filter((item) =>
+      sameRdfTerm(item.graph, graph)
+    );
+    return {
+      evaluateExists: (pattern, solution) =>
+        this.evaluateExistsScoped(pattern, solution, candidates, graph),
+    };
+  }
+
+  /**
    * forStore returns a fresh BgpEvaluator over the given store view with the
    * same options, used by SparqlEvaluator to evaluate a query against its
    * FROM / FROM NAMED dataset.
@@ -538,7 +561,9 @@ export class BgpEvaluator {
       case "bgp":
         return await this.joinBgp(pattern.triples, bindings, store);
       case "filter": {
-        const context = this.existsContext(store);
+        const context = expressionContainsExists(pattern.expression)
+          ? this.scopedExistsContext(store)
+          : this.existsContext(store);
         return bindings.filter((binding) =>
           this.expressionEvaluator.filterPasses(
             pattern.expression,
@@ -565,7 +590,9 @@ export class BgpEvaluator {
         if (filters.some(expressionContainsExists)) {
           await this.prepareExistsIndex();
         }
-        const context = this.existsContext(store);
+        const context = filters.some(expressionContainsExists)
+          ? this.scopedExistsContext(store)
+          : this.existsContext(store);
         return leftJoin(
           bindings,
           right,
@@ -610,7 +637,9 @@ export class BgpEvaluator {
         // expression is evaluated per solution and the variable bound; an
         // evaluation error or a variable already bound (from an outer
         // scope) leaves the solution unchanged.
-        const context = this.existsContext(store);
+        const context = expressionContainsExists(pattern.expression)
+          ? this.scopedExistsContext(store)
+          : this.existsContext(store);
         return bindings.map((binding) => {
           const value = this.expressionEvaluator.evaluate(
             pattern.expression,

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -506,6 +506,30 @@ export class BgpEvaluator {
   }
 
   /**
+   * pipelineExistsContext builds a scoped expression context over the
+   * default graph's candidates for the SELECT pipeline (projection / HAVING
+   * / ORDER BY expressions). The caller must have prepared the EXISTS index
+   * (the pipelineNeedsExistsIndex gate) — the guard mirrors evaluateExists —
+   * and every solution then shares one candidate filter per query instead of
+   * re-filtering the snapshot per expression evaluation.
+   */
+  public pipelineExistsContext(): ExpressionEvaluationContext {
+    if (this.existsIndex === null || this.existsQuads === null) {
+      throw new Error(
+        "EXISTS requires a prepared pattern index: call prepareExistsIndex() first",
+      );
+    }
+    const graph = defaultGraph();
+    const candidates = this.existsQuads.filter((item) =>
+      sameRdfTerm(item.graph, graph)
+    );
+    return {
+      evaluateExists: (pattern, solution) =>
+        this.evaluateExistsScoped(pattern, solution, candidates, graph),
+    };
+  }
+
+  /**
    * forStore returns a fresh BgpEvaluator over the given store view with the
    * same options, used by SparqlEvaluator to evaluate a query against its
    * FROM / FROM NAMED dataset.

--- a/src/evaluator/join.ts
+++ b/src/evaluator/join.ts
@@ -8,6 +8,7 @@ import {
   buildQuadIndex,
   matchQuads,
   probeQuadIndex,
+  type QuadIndex,
   simplePredicate,
 } from "@/quad-store.ts";
 import { isReifiesPattern } from "@/evaluator/reified.ts";
@@ -210,10 +211,21 @@ function getQueryVarName(term: SparqlTerm): string {
  * a hash join: candidate quads come from the pattern's single indexed store
  * scan (performed once by the caller), and bindings probe a positional index
  * instead of issuing a stream round trip per binding.
+ *
+ * prebuiltIndex supplies an already-built QuadIndex (the EXISTS hooks' drained
+ * snapshot index) so the join probes it directly instead of rebuilding an
+ * index over the candidates on every call — the main path amortizes the build
+ * over all bindings of one join, but the EXISTS hooks join one solution at a
+ * time, so a fresh build there would re-index the candidates per probe.
+ * graphScope filters the probed quads to one graph: the prebuilt snapshot
+ * index spans every graph, so matches must be scoped before binding extension
+ * (the main path's candidates are already graph-scoped via GraphScopedStore).
  */
 export function joinTriplePattern(
   currentBindings: TermBinding[],
   entry: ScanEntry,
+  prebuiltIndex?: QuadIndex | null,
+  graphScope?: rdfjs.Term | null,
 ): TermBinding[] {
   if (entry.reifies) {
     return joinReifiesPattern(currentBindings, entry);
@@ -231,13 +243,19 @@ export function joinTriplePattern(
 
   const candidateQuads = entry.candidates;
 
-  const needsIndex = currentBindings.some((binding) =>
-    (subjectIsVariable && binding[getQueryVarName(subject)] !== undefined) ||
-    (predicateIsVariable &&
-      binding[getQueryVarName(predicate)] !== undefined) ||
-    (objectIsVariable && binding[getQueryVarName(object)] !== undefined)
-  );
-  const quadIndex = needsIndex ? buildQuadIndex(candidateQuads) : null;
+  const needsIndex = prebuiltIndex != null
+    ? false
+    : currentBindings.some((binding) =>
+      (subjectIsVariable && binding[getQueryVarName(subject)] !== undefined) ||
+      (predicateIsVariable &&
+        binding[getQueryVarName(predicate)] !== undefined) ||
+      (objectIsVariable && binding[getQueryVarName(object)] !== undefined)
+    );
+  const quadIndex = prebuiltIndex != null
+    ? prebuiltIndex
+    : needsIndex
+    ? buildQuadIndex(candidateQuads)
+    : null;
 
   const nextBindings: TermBinding[] = [];
 
@@ -253,8 +271,11 @@ export function joinTriplePattern(
       resolvedPredicate,
       resolvedObject,
     );
+    const scopedQuads = graphScope === undefined || graphScope === null
+      ? matchingQuads
+      : matchingQuads.filter((item) => sameRdfTerm(item.graph, graphScope));
 
-    for (const matchQuad of matchingQuads) {
+    for (const matchQuad of scopedQuads) {
       const newBinding = { ...binding };
       let valid = true;
 

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -150,14 +150,21 @@ export class SparqlEvaluator {
   ): Promise<TermBinding[]> {
     const evaluator = await this.bgpEvaluatorFor(query.from);
     const rawBindings = await evaluator.evaluateBgp(query.where || []);
-    const existsContext: ExpressionEvaluationContext = {
-      evaluateExists: (pattern, solution) =>
-        evaluator.evaluateExists(pattern, solution),
-      baseIri: query.base,
-    };
-    if (pipelineNeedsExistsIndex(query)) {
+    // Projection / HAVING / ORDER BY expressions share one default-graph
+    // scoped candidate set across every solution (once per query) instead of
+    // re-filtering the snapshot per expression evaluation. Only queries that
+    // actually use EXISTS in the pipeline prepare the index.
+    const needsPipelineExists = pipelineNeedsExistsIndex(query);
+    if (needsPipelineExists) {
       await evaluator.prepareExistsIndex();
     }
+    const existsContext: ExpressionEvaluationContext = {
+      ...(needsPipelineExists ? evaluator.pipelineExistsContext() : {
+        evaluateExists: (pattern: Pattern, solution: TermBinding) =>
+          evaluator.evaluateExists(pattern, solution),
+      }),
+      baseIri: query.base,
+    };
     // The post-BGP SELECT pipeline (VALUES, grouping/aggregates, HAVING,
     // ORDER BY, projection, DISTINCT/REDUCED, OFFSET/LIMIT) is shared with
     // the synchronous EXISTS subquery path — one implementation, two call

--- a/src/quad-store.ts
+++ b/src/quad-store.ts
@@ -84,6 +84,19 @@ export function probeQuadIndex(
 }
 
 /**
+ * storeVersion returns the store's mutation version when the store tracks
+ * one (MemoryStore does), or null when changes cannot be detected — callers
+ * that snapshot the store (the EXISTS synchronous index) must then rebuild
+ * the snapshot per query.
+ */
+export function storeVersion(
+  store: rdfjs.Source<rdfjs.Quad>,
+): number | null {
+  const version = (store as { version?: unknown }).version;
+  return typeof version === "number" ? version : null;
+}
+
+/**
  * matchQuads collects all quads matching the given pattern from an RDF/JS
  * store, resolving the store's match stream into an array.
  */
@@ -137,6 +150,12 @@ export class GraphScopedStore implements rdfjs.Source<rdfjs.Quad> {
     private readonly store: rdfjs.Source<rdfjs.Quad>,
     public readonly graph: rdfjs.Term,
   ) {}
+
+  /** version delegates to the wrapped store so snapshot caches see through
+   * the view (the view itself never mutates the data). */
+  public get version(): number | null {
+    return storeVersion(this.store);
+  }
 
   public match(
     subject?: rdfjs.Term | null,

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -229,6 +229,16 @@ export class MemoryStream implements rdfjs.Stream<rdfjs.Quad> {
  */
 export class MemoryStore implements rdfjs.Store<rdfjs.Quad> {
   private quads: Map<string, rdfjs.Quad> = new Map();
+  private _version = 0;
+
+  /**
+   * version increments on every mutation, letting caches that snapshot the
+   * store (the EXISTS synchronous index) detect staleness and rebuild only
+   * when the data actually changed.
+   */
+  public get version(): number {
+    return this._version;
+  }
 
   public constructor(initialQuads?: rdfjs.Quad[]) {
     if (initialQuads) {
@@ -260,11 +270,13 @@ export class MemoryStore implements rdfjs.Store<rdfjs.Quad> {
       )
       : quadOrSubject as rdfjs.Quad;
     this.quads.set(quadKey(quad), quad);
+    this._version++;
     return this;
   }
 
   public removeQuad(quad: rdfjs.Quad): this {
     this.quads.delete(quadKey(quad));
+    this._version++;
     return this;
   }
 

--- a/src/wazoo-sparql-engine.test.ts
+++ b/src/wazoo-sparql-engine.test.ts
@@ -3240,6 +3240,43 @@ Deno.test("WazooSparqlEngine - NOT EXISTS and EXISTS nest inside EXISTS subqueri
   );
 });
 
+Deno.test("WazooSparqlEngine - EXISTS snapshot cache sees store mutations between queries", async () => {
+  // The EXISTS synchronous snapshot is cached across queries and must be
+  // invalidated when the store changes: a query, then a mutation, then the
+  // same query again must observe the new data.
+  const store = new Store();
+  const ex = (local: string) => namedNode(`http://example.org/${local}`);
+  store.addQuad(quad(ex("a"), ex("p"), literal("x")));
+  store.addQuad(quad(ex("b"), ex("p"), literal("y")));
+  store.addQuad(quad(ex("a"), ex("q"), literal("1")));
+  const engine = new WazooSparqlEngine({ store });
+
+  async function projected(variable: string): Promise<string[]> {
+    const result = await engine.execute({
+      query: "SELECT ?s WHERE { ?s <http://example.org/p> ?o " +
+        "FILTER EXISTS { ?s <http://example.org/q> ?z } }",
+    });
+    if (result.kind !== "select") {
+      throw new Error(`expected select, got ${result.kind}`);
+    }
+    return result.data.results.bindings.map((b) =>
+      String((b[variable] as { value: string }).value)
+    ).sort();
+  }
+
+  // Only a has a q edge: EXISTS keeps a. A second identical query (cache
+  // hit) must return the same result.
+  assertEquals(await projected("s"), ["http://example.org/a"]);
+  assertEquals(await projected("s"), ["http://example.org/a"]);
+  // Mutate the store, then re-run: the cached snapshot must be rebuilt, so
+  // b now passes the EXISTS filter too.
+  store.addQuad(quad(ex("b"), ex("q"), literal("2")));
+  assertEquals(
+    await projected("s"),
+    ["http://example.org/a", "http://example.org/b"],
+  );
+});
+
 Deno.test("WazooSparqlEngine - COALESCE, IF, IN, NOT IN, SAMETERM", async () => {
   const engine = emptyEngine();
   const coalesce = await bindValue(


### PR DESCRIPTION
## What

Optimizes the EXISTS evaluation path (closes #65) and adds nested-EXISTS groups to the three-engine bench suite and the regression budget.

### 1. Nested probes reuse the enclosing call's candidates
`BgpEvaluator.evaluateExists` filtered the drained quad snapshot by graph scope on **every** call — including each nested probe inside an enclosing EXISTS. The scoped candidate set is now built once per top-level `evaluateExists` call and threaded through the synchronous recursion (`evaluateExistsScoped`), so a nested probe pays only for its own pattern work.

### 2. Main-path EXISTS filters share one scoped candidate set per query
The WHERE-clause `FILTER` / `BIND` / `OPTIONAL` conditions built their expression context with a per-solution `evaluateExists` hook, re-filtering the snapshot once per solution. Gated on `expressionContainsExists`, `scopedExistsContext` now computes the graph-scoped candidates once per filter evaluation and shares them across every solution.

### 3. SELECT-pipeline EXISTS expressions reuse the same set
`applySelectPipeline` (projection / HAVING / ORDER BY expressions) built its own per-row `evaluateExists` hook. The pipeline context now uses the same pre-scoped candidates (index prepared up front when `pipelineNeedsExistsIndex`), so pipeline EXISTS expressions no longer re-filter the snapshot per row.

### 4. Probes use the prebuilt snapshot index instead of re-indexing per solution
Profiling showed the per-solution probes dominated: `joinTriplePattern` rebuilt a fresh three-map index over the probed candidate bucket on every call, and the EXISTS hook joins one solution at a time — so each probe re-indexed 200–400 quads for a single lookup. `joinTriplePattern` now accepts a prebuilt index (the once-per-query drained snapshot) plus a graph scope; the EXISTS BGP case threads the snapshot index through, making per-solution probes O(bucket) instead of build + probe.

### 5. The snapshot drain is cached across queries
The drain ran per query even when the store never changed. `MemoryStore` now tracks a mutation version (`GraphScopedStore` delegates), and `prepareExistsIndex` rebuilds the snapshot only when the store's version changes — repeated queries against a static store skip the drain, and updates between queries are still observed.

### Bench + budget
New `nested-exists` / `nested-not-exists` queries in `bench/engine_bench.ts`, cross-verified against comunica and oxigraph, with tuned warmup (3 s + 50 iters) for stable rows. The EXISTS queries also joined `bench/budget.ts` so `bench:check` guards the whole EXISTS surface continuously.

## Results (A/B probe, 400-person dataset, 100 iters, stable across runs)

| query | original | after #1–#3 (scoped reuse) | after #4–#5 (indexed probes + drain cache) |
|---|---|---|---|
| simple EXISTS | ~53 ms | ~33 ms | **~1.6 ms** |
| nested EXISTS | ~160 ms | ~71 ms | **~1.9 ms** |

Bench-suite exists group (post-change): native **1.6 ms** exists / **1.9 ms** nested-exists — now matching or beating oxigraph (2.0 / 2.1 ms) on the whole exists surface, and ~70–200× faster than comunica (117–309 ms).

Budget gate (bench/budget.ts): EXISTS filter **0.57 ms** / Nested EXISTS filter **0.77 ms** per iter (50 ms cap) — down from 5.9 / 10.2 ms before the probe indexing.

## Verification
- `deno task test`: 361 passed, 0 failed (incl. a snapshot-invalidation test: a mutation between EXISTS queries is observed)
- `deno task test:exists-ref`: 11/11 cases pass
- `deno task bench:check`: BGP 1.05 / reorder 0.50 / EXISTS 0.57 / nested-EXISTS 0.77 ms (budget 50 ms)
- `deno fmt --check` + `deno lint`: clean
