### PR TITLE
Per-test budgets in bench/budget.ts, re-baselined to post-optimization EXISTS numbers

### DIFF
--- a/bench/budget.ts
+++ b/bench/budget.ts
@@ -8,22 +8,21 @@ interface BudgetTest {
   name: string;
   query: string;
   /**
-   * Per-test ceiling in ms/iter. Calibrated to ~3x the steady-state baseline on a
-   * quiet machine, so a ~3x regression on any row trips the gate while shared-CI
-   * noise (typically 2-3x slower runners) still passes.
+   * Per-test ceiling in ms/iter, calibrated to ~2.5x the baseline measured on the
+   * GitHub Actions runner (the environment bench:check actually gates in), so a
+   * ~3x regression on any row trips the gate while run-to-run CI noise passes.
    *
-   * Baselines (ms/iter, 50-iteration loop after 5-iteration warmup, quiet machine):
-   *   BGP 2-pattern join: 0.34-0.44 (noisiest row) -> budget 2.0 (~4.5x)
-   *   Reorder chain join: 0.29-0.39               -> budget 1.0 (~2.6-3.4x)
-   *   EXISTS filter:      0.33-0.39               -> budget 1.0 (~2.6-3.0x)
-   *   Nested EXISTS:      0.46-0.52               -> budget 1.6 (~3.1-3.5x)
+   * CI-runner baselines (ms/iter, 50-iteration loop after 5-iteration warmup):
+   *   BGP 2-pattern join: 1.30 -> budget 3.5 (~2.7x)
+   *   Reorder chain join: 0.82 -> budget 2.0 (~2.4x)
+   *   EXISTS filter:      1.16 -> budget 3.0 (~2.6x)
+   *   Nested EXISTS:      1.61 -> budget 4.0 (~2.5x)
    *
-   * A regression of ~3x trips the chain/exists/nested rows; the join row needs
-   * ~4.5x (it shows the most run-to-run variance, so it gets extra headroom).
-   * Note: at this sub-ms scale, per-iteration cost is partly fixed parse/setup
-   * overhead, so a small multiplicative filter regression lands under 3x and
-   * correctly stays under budget - the gate catches the algorithmic regressions
-   * that matter (e.g. EXISTS per-probe re-indexing was 480x at its worst).
+   * Note: GitHub runners are ~3x slower than a quiet dev machine (this machine
+   * measures the same rows at 0.3-0.5 ms), so budgets must not be calibrated
+   * locally. A regression of ~2.5-3x trips the gate; catastrophic algorithmic
+   * regressions (e.g. EXISTS per-probe re-indexing was ~480x at its worst) trip
+   * instantly.
    */
   budgetMs: number;
 }
@@ -36,26 +35,26 @@ const tests: BudgetTest[] = [
     name: "BGP 2-pattern join",
     query:
       "SELECT ?s ?name WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?name . ?s <http://example.org/p> ?o }",
-    budgetMs: 2.0,
+    budgetMs: 3.5,
   },
   {
     name: "Reorder chain join",
     query:
       "SELECT ?s WHERE { ?s <http://example.org/p1> ?o1 . ?o1 <http://example.org/p2> ?o2 }",
-    budgetMs: 1.0,
+    budgetMs: 2.0,
   },
   {
     name: "EXISTS filter",
     query: "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
       "FILTER EXISTS { ?s <http://example.org/p> ?o } }",
-    budgetMs: 1.0,
+    budgetMs: 3.0,
   },
   {
     name: "Nested EXISTS filter",
     query: "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
       "FILTER EXISTS { ?s <http://example.org/p1> ?o . " +
       "FILTER EXISTS { ?o <http://example.org/p2> ?x } } }",
-    budgetMs: 1.6,
+    budgetMs: 4.0,
   },
 ];
 

--- a/bench/budget.ts
+++ b/bench/budget.ts
@@ -4,32 +4,60 @@ import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
 
 const { namedNode, literal, quad } = DataFactory;
 
-const baseline = {
-  maxAllowedMs: 50.0,
-  tests: [
-    {
-      name: "BGP 2-pattern join",
-      query:
-        "SELECT ?s ?name WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?name . ?s <http://example.org/p> ?o }",
-    },
-    {
-      name: "Reorder chain join",
-      query:
-        "SELECT ?s WHERE { ?s <http://example.org/p1> ?o1 . ?o1 <http://example.org/p2> ?o2 }",
-    },
-    {
-      name: "EXISTS filter",
-      query: "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
-        "FILTER EXISTS { ?s <http://example.org/p> ?o } }",
-    },
-    {
-      name: "Nested EXISTS filter",
-      query: "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
-        "FILTER EXISTS { ?s <http://example.org/p1> ?o . " +
-        "FILTER EXISTS { ?o <http://example.org/p2> ?x } } }",
-    },
-  ],
-};
+interface BudgetTest {
+  name: string;
+  query: string;
+  /**
+   * Per-test ceiling in ms/iter. Calibrated to ~3x the steady-state baseline on a
+   * quiet machine, so a ~3x regression on any row trips the gate while shared-CI
+   * noise (typically 2-3x slower runners) still passes.
+   *
+   * Baselines (ms/iter, 50-iteration loop after 5-iteration warmup, quiet machine):
+   *   BGP 2-pattern join: 0.34-0.44 (noisiest row) -> budget 2.0 (~4.5x)
+   *   Reorder chain join: 0.29-0.39               -> budget 1.0 (~2.6-3.4x)
+   *   EXISTS filter:      0.33-0.39               -> budget 1.0 (~2.6-3.0x)
+   *   Nested EXISTS:      0.46-0.52               -> budget 1.6 (~3.1-3.5x)
+   *
+   * A regression of ~3x trips the chain/exists/nested rows; the join row needs
+   * ~4.5x (it shows the most run-to-run variance, so it gets extra headroom).
+   * Note: at this sub-ms scale, per-iteration cost is partly fixed parse/setup
+   * overhead, so a small multiplicative filter regression lands under 3x and
+   * correctly stays under budget - the gate catches the algorithmic regressions
+   * that matter (e.g. EXISTS per-probe re-indexing was 480x at its worst).
+   */
+  budgetMs: number;
+}
+
+const WARMUP_ITERATIONS = 5;
+const MEASURED_ITERATIONS = 50;
+
+const tests: BudgetTest[] = [
+  {
+    name: "BGP 2-pattern join",
+    query:
+      "SELECT ?s ?name WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?name . ?s <http://example.org/p> ?o }",
+    budgetMs: 2.0,
+  },
+  {
+    name: "Reorder chain join",
+    query:
+      "SELECT ?s WHERE { ?s <http://example.org/p1> ?o1 . ?o1 <http://example.org/p2> ?o2 }",
+    budgetMs: 1.0,
+  },
+  {
+    name: "EXISTS filter",
+    query: "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
+      "FILTER EXISTS { ?s <http://example.org/p> ?o } }",
+    budgetMs: 1.0,
+  },
+  {
+    name: "Nested EXISTS filter",
+    query: "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
+      "FILTER EXISTS { ?s <http://example.org/p1> ?o . " +
+      "FILTER EXISTS { ?o <http://example.org/p2> ?x } } }",
+    budgetMs: 1.6,
+  },
+];
 
 async function main() {
   const store = new Store();
@@ -65,25 +93,30 @@ async function main() {
   let failed = false;
 
   console.log("Running performance regression budget checks...");
-  for (const testCase of baseline.tests) {
+  for (const test of tests) {
+    // Warm up first: lets V8 optimize the hot path and pays the one-time
+    // EXISTS snapshot drain before the timed loop, so measurements are stable.
+    for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+      await engine.execute({ query: test.query });
+    }
+
     const start = performance.now();
-    const iterations = 50;
-    for (let i = 0; i < iterations; i++) {
-      await engine.execute({ query: testCase.query });
+    for (let i = 0; i < MEASURED_ITERATIONS; i++) {
+      await engine.execute({ query: test.query });
     }
     const elapsed = performance.now() - start;
-    const avgMs = elapsed / iterations;
+    const avgMs = elapsed / MEASURED_ITERATIONS;
     console.log(
-      `- ${testCase.name}: ${
+      `- ${test.name}: ${
         avgMs.toFixed(3)
-      } ms/iter (budget: <= ${baseline.maxAllowedMs} ms/iter)`,
+      } ms/iter (budget: <= ${test.budgetMs} ms/iter)`,
     );
 
-    if (avgMs > baseline.maxAllowedMs) {
+    if (avgMs > test.budgetMs) {
       console.error(
-        `  FAIL: ${testCase.name} exceeded performance budget (${
+        `  FAIL: ${test.name} exceeded performance budget (${
           avgMs.toFixed(3)
-        } ms > ${baseline.maxAllowedMs} ms)`,
+        } ms > ${test.budgetMs} ms)`,
       );
       failed = true;
     }


### PR DESCRIPTION
## What

Closes #67. Replaces the single global 50 ms cap in `bench/budget.ts` with a
per-test `budgetMs`, and adds a 5-iteration warmup phase before the timed
50-iteration loop.

## Calibration

Budgets are calibrated to **GitHub Actions runner baselines** (the environment
`bench:check` gates in), at ~2.5x the slowest observed sample so a ~3x
regression trips while runner-to-runner noise passes:

| row | CI baseline (ms/iter) | budget (ms) | headroom |
|---|---|---|---|
| BGP 2-pattern join | 0.94-1.30 | 3.5 | 2.7-3.7x |
| Reorder chain join | 0.49-0.82 | 2.0 | 2.4-4.0x |
| EXISTS filter | 0.61-1.16 | 3.0 | 2.6-4.9x |
| Nested EXISTS filter | 0.87-1.61 | 4.0 | 2.5-4.6x |

Key finding: GH runners are ~3x slower than a quiet dev machine (same rows
measure 0.3-0.5 ms locally), and runner-to-runner variance is ~2x — the first
locally-calibrated commit failed CI on the EXISTS rows, which is exactly why
the budgets must be CI-calibrated. The old single 50 ms cap gave the EXISTS
rows ~60-85x headroom and would have let the pre-#66 per-probe re-indexing
regression (~480x) go unnoticed.

## Why warmup

The native EXISTS path needs V8 JIT + the one-time snapshot drain settled
before timing (see the warmup finding in #66's commit e3c3ad7). Warmup also
removes the cold-start outlier that made the join row swing on first run.

## Verification

- `deno task bench:check` passes on CI (`ci` job, commit f488665): 0.49-1.30
  ms/iter across rows, 2.4-4.9x margins
- FAIL path verified locally: a row exceeding its budget prints the per-row
  error and exits 1
- A simulated sub-3x regression (3 correlated EXISTS filters) correctly stays
  under budget; a catastrophic regression (e.g. per-probe re-indexing, ~480x)
  trips instantly
- `deno fmt --check` and `deno lint` clean; full suite 361 tests pass