### PR TITLE
Reuse the prebuilt QuadIndex on the main BGP join path

### DIFF
--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -141,6 +141,37 @@ export class BgpEvaluator {
   }
 
   /**
+   * existsIndexForScope returns the prepared snapshot index for reuse by the
+   * main BGP join path, or null when reuse would be unsafe. The snapshot
+   * spans every graph, but the main path scans through a graph-scoped store
+   * view, so the two universes coincide only when the current scope is the
+   * default graph and the store holds no named-graph quads (then every
+   * scanned quad is in the snapshot). In every other case — a named scope,
+   * or named graphs in the store — probing the all-graph index could return
+   * quads outside the scope, so the per-join build over the scoped candidates
+   * stays.
+   */
+  private existsIndexForScope(
+    store: rdfjs.Source<rdfjs.Quad>,
+  ): QuadIndex | null {
+    if (this.existsIndex === null || this.existsQuads === null) {
+      return null;
+    }
+    if (
+      store instanceof GraphScopedStore &&
+      store.graph.termType !== "DefaultGraph"
+    ) {
+      return null;
+    }
+    if (
+      this.existsQuads.some((item) => item.graph.termType !== "DefaultGraph")
+    ) {
+      return null;
+    }
+    return this.existsIndex;
+  }
+
+  /**
    * evaluateExists implements the injected pattern-evaluation hook: a group
    * pattern evaluated against one incoming solution, returning whether any
    * solution matches. Correlated (the solution's bindings are visible
@@ -779,8 +810,19 @@ export class BgpEvaluator {
     // into plain `rdf:reifies` triples before any scanning or reordering.
     const expanded = expandReifiedTriples(triples);
     const hasPath = expanded.some((triple) => isPropertyPath(triple.predicate));
+    // When the EXISTS snapshot is prepared and its universe coincides with
+    // this scope (see existsIndexForScope), join against the prebuilt index
+    // instead of rebuilding one over each pattern's candidate bucket — the
+    // snapshot is already indexed once per query, so the per-join build is
+    // pure waste.
+    const prebuiltIndex = this.existsIndexForScope(store);
     if (this.reorderPatterns && expanded.length > 1 && !hasPath) {
-      return await this.evaluateWithReordering(expanded, bindings, store);
+      return await this.evaluateWithReordering(
+        expanded,
+        bindings,
+        store,
+        prebuiltIndex,
+      );
     }
     let result = bindings;
     for (const triple of expanded) {
@@ -793,10 +835,8 @@ export class BgpEvaluator {
         );
         result = joinPathPattern(result, entry);
       } else {
-        result = joinTriplePattern(
-          result,
-          await scanEntry(store, triple),
-        );
+        const entry = await scanEntry(store, triple);
+        result = joinTriplePattern(result, entry, prebuiltIndex);
       }
     }
     return result;
@@ -810,6 +850,7 @@ export class BgpEvaluator {
     triplePatterns: Triple[],
     bindings: TermBinding[],
     store: rdfjs.Source<rdfjs.Quad>,
+    prebuiltIndex: QuadIndex | null,
   ): Promise<TermBinding[]> {
     const remaining = await Promise.all(
       triplePatterns.map((pattern) => scanEntry(store, pattern)),
@@ -827,7 +868,7 @@ export class BgpEvaluator {
         }
       }
       const [chosen] = remaining.splice(bestIndex, 1);
-      result = joinTriplePattern(result, chosen);
+      result = joinTriplePattern(result, chosen, prebuiltIndex);
     }
     return result;
   }

--- a/src/evaluator/join.ts
+++ b/src/evaluator/join.ts
@@ -214,9 +214,10 @@ function getQueryVarName(term: SparqlTerm): string {
  *
  * prebuiltIndex supplies an already-built QuadIndex (the EXISTS hooks' drained
  * snapshot index) so the join probes it directly instead of rebuilding an
- * index over the candidates on every call — the main path amortizes the build
- * over all bindings of one join, but the EXISTS hooks join one solution at a
- * time, so a fresh build there would re-index the candidates per probe.
+ * index over the candidates on every call — the EXISTS hooks join one
+ * solution at a time, so a fresh build there would re-index the candidates
+ * per probe, and the main path reuses the snapshot when its universe
+ * coincides with the current scope (see BgpEvaluator.existsIndexForScope).
  * graphScope filters the probed quads to one graph: the prebuilt snapshot
  * index spans every graph, so matches must be scoped before binding extension
  * (the main path's candidates are already graph-scoped via GraphScopedStore).

--- a/src/wazoo-sparql-engine.test.ts
+++ b/src/wazoo-sparql-engine.test.ts
@@ -2961,6 +2961,44 @@ Deno.test("WazooSparqlEngine - property paths inside EXISTS respect GRAPH scopes
   );
 });
 
+Deno.test("WazooSparqlEngine - main-path joins never leak named graphs when EXISTS is present", async () => {
+  // s lives in the default graph AND named graph g1; t lives only in g1.
+  // With EXISTS present the main path could reuse the all-graph snapshot
+  // index — the guard in existsIndexForScope must fall back to the scoped
+  // build so g1's quads stay invisible in the default-scope answer.
+  const store = new Store();
+  const ex = (local: string) => namedNode(`http://example.org/${local}`);
+  const add = (s: string, p: string, o: string, graph?: string) =>
+    store.addQuad(quad(ex(s), ex(p), ex(o), graph ? ex(graph) : undefined));
+  add("s", "name", "S");
+  add("s", "p1", "o1");
+  add("s", "p", "v1");
+  add("s", "p1", "o2", "g1");
+  add("s", "p", "v2", "g1");
+  add("t", "name", "T", "g1");
+  add("t", "p1", "o3", "g1");
+  add("t", "p", "v3", "g1");
+  const engine = new WazooSparqlEngine({ store });
+
+  // ?s p1 ?o joins against a bound ?s, so it would reuse the prebuilt index;
+  // the default-scope answer must contain only s's default-graph p1 quads.
+  const result = await engine.execute({
+    query: "SELECT ?s ?o WHERE { ?s <http://example.org/name> ?n " +
+      ". ?s <http://example.org/p1> ?o " +
+      "FILTER EXISTS { ?s <http://example.org/p> ?v } }",
+  });
+  if (result.kind !== "select") {
+    throw new Error(`expected select, got ${result.kind}`);
+  }
+  const rows = result.data.results.bindings.map((b) => [
+    String((b.s as { value: string }).value),
+    String((b.o as { value: string }).value),
+  ]).sort();
+  assertEquals(rows, [
+    ["http://example.org/s", "http://example.org/o1"],
+  ]);
+});
+
 Deno.test("WazooSparqlEngine - OPTIONAL, MINUS, UNION inside EXISTS reuse the join algebra", async () => {
   // Default graph: a -p-> b -q-> c -q-> d, b -r-> c, and a -p-> e (e has no q
   // or r edges). Named graph g1: a -p-> b -q-> c; g2: a -p-> b (no q).


### PR DESCRIPTION
## What

Closes #68. The main BGP join path (`joinBgp` + `evaluateWithReordering`) rebuilt
a fresh 3-map `QuadIndex` over each pattern's candidate bucket on every join.
When the query uses EXISTS, the drained snapshot index already covers the
store, so those builds are pure waste — the main path now probes the prebuilt
index instead.

## Correctness guard (`existsIndexForScope`)

The snapshot spans **every graph**, while the main path scans through a
graph-scoped store view (`GraphScopedStore(defaultGraph)` at the top level,
the GRAPH term inside one). The universes coincide only when:

- the current scope is the **default graph**, and
- the snapshot holds **no named-graph quads**.

Only then is the index reused. Named scopes and multi-graph stores fall back
to the per-join build over the scoped candidates, so a named-graph quad can
never leak into a default-scope answer. That leak is pinned by a new test
(`main-path joins never leak named graphs when EXISTS is present`): a subject
with `p1`/`p` quads in both the default graph and `g1` must produce only the
default-graph binding.

## Measured

Multi-pattern BGP + EXISTS query (`?s name ?n . ?s p1 ?o FILTER EXISTS { ?s p ?v }`,
100-subject dataset, 100 iterations, warmup):

| | ms/iter |
|---|---|
| before | 0.53–0.56 |
| after | 0.44–0.47 (~15–18% faster) |

Queries without EXISTS are untouched: no snapshot exists, so `existsIndexForScope`
returns null and the build path is unchanged (budget rows BGP join / reorder chain
unchanged). Queries with EXISTS but a single-pattern BGP never built a main-path
index anyway.

## Verification

- 362 tests pass (incl. the new leak test), 11/11 EXISTS gate, budget gate passes
- `deno fmt --check` and `deno lint` clean