### PR TITLE
Index MemoryStore by position + cache parsed queries (pre-#69 perf batch)

### DIFF
--- a/src/store/memory-store.test.ts
+++ b/src/store/memory-store.test.ts
@@ -227,3 +227,48 @@ Deno.test("MemoryStream - once fires a single time", async () => {
   // Re-emitting end is a no-op because the stream is already ended.
   assertEquals(count, 1);
 });
+
+Deno.test("MemoryStore - positional indexes stay exact across mutations", () => {
+  const store = new MemoryStore();
+  const s1 = ex("s1");
+  const s2 = ex("s2");
+  const p = ex("p");
+  const o1 = ex("o1");
+  const o2 = ex("o2");
+
+  store.addQuad(quad(s1, p, o1));
+  store.addQuad(quad(s2, p, o1));
+  store.addQuad(quad(s1, p, o2));
+  store.addQuad(quad(s1, p, o1, graphA));
+
+  // Every constrained combination resolves through the smallest bucket.
+  assertEquals(store.countQuads(s1), 3);
+  assertEquals(store.countQuads(null, p), 4);
+  assertEquals(store.countQuads(null, null, o1), 3);
+  assertEquals(store.countQuads(s1, p, o1, graphA), 1);
+  assertEquals(store.countQuads(s2, p, o1), 1);
+  assertEquals(store.countQuads(s1, p, o2), 1);
+  assertEquals(store.countQuads(s1, null, o1, graphA), 1);
+  assertEquals(store.countQuads(null, null, null, defaultGraph()), 3);
+
+  // Re-adding an existing quad must not duplicate any bucket entry.
+  store.addQuad(quad(s1, p, o1));
+  assertEquals(store.countQuads(s1), 3);
+  assertEquals(store.countQuads(s1, p, o1), 2);
+  assertEquals(store.size, 4);
+
+  // Removing one quad unindexes it from every bucket; the rest survive.
+  store.removeQuad(quad(s1, p, o1));
+  assertEquals(store.countQuads(s1), 2);
+  assertEquals(store.countQuads(null, null, o1), 2);
+  assertEquals(store.countQuads(s1, p, o1), 1); // the named-graph copy
+  assertEquals(store.countQuads(s1, p, o1, graphA), 1);
+
+  // deleteGraph removes the whole graph bucket, leaving the default graph.
+  store.deleteGraph(graphA);
+  assertEquals(store.size, 2);
+  assertEquals(store.countQuads(null, null, null, graphA), 0);
+  assertEquals(store.countQuads(s1, p, o1), 0);
+  assertEquals(store.countQuads(s1), 1);
+  assertEquals(store.countQuads(s2, p, o1), 1);
+});

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -223,12 +223,60 @@ export class MemoryStream implements rdfjs.Stream<rdfjs.Quad> {
 }
 
 /**
+ * indexPosition appends a quad to the bucket for the given term key.
+ */
+function indexPosition(
+  index: Map<string, rdfjs.Quad[]>,
+  key: string,
+  quad: rdfjs.Quad,
+): void {
+  const bucket = index.get(key);
+  if (bucket) {
+    bucket.push(quad);
+  } else {
+    index.set(key, [quad]);
+  }
+}
+
+/**
+ * unindexPosition removes a quad from the bucket for the given term key,
+ * dropping the key once its bucket empties. Buckets never hold a quad more
+ * than once, and the removal matches structurally (quadKey) because callers
+ * pass a freshly constructed quad rather than the stored instance.
+ */
+function unindexPosition(
+  index: Map<string, rdfjs.Quad[]>,
+  key: string,
+  quad: rdfjs.Quad,
+): void {
+  const bucket = index.get(key);
+  if (bucket === undefined) {
+    return;
+  }
+  const targetKey = quadKey(quad);
+  const position = bucket.findIndex((item) => quadKey(item) === targetKey);
+  if (position >= 0) {
+    bucket.splice(position, 1);
+    if (bucket.length === 0) {
+      index.delete(key);
+    }
+  }
+}
+
+/**
  * MemoryStore is a minimal, zero-dependency in-memory RDF/JS Store used to
  * materialize FROM and FROM NAMED datasets (and transient update
- * materializations) inside the engine.
+ * materializations) inside the engine. Every quad is held once in a canonical
+ * map keyed by all four positions and mirrored into four positional indexes
+ * (subject / predicate / object / graph), so match scans only the smallest
+ * constrained bucket instead of the whole store.
  */
 export class MemoryStore implements rdfjs.Store<rdfjs.Quad> {
   private quads: Map<string, rdfjs.Quad> = new Map();
+  private bySubject: Map<string, rdfjs.Quad[]> = new Map();
+  private byPredicate: Map<string, rdfjs.Quad[]> = new Map();
+  private byObject: Map<string, rdfjs.Quad[]> = new Map();
+  private byGraph: Map<string, rdfjs.Quad[]> = new Map();
   private _version = 0;
 
   /**
@@ -269,13 +317,28 @@ export class MemoryStore implements rdfjs.Store<rdfjs.Quad> {
         graph,
       )
       : quadOrSubject as rdfjs.Quad;
-    this.quads.set(quadKey(quad), quad);
+    const key = quadKey(quad);
+    // Re-adding an existing quad keeps the canonical map (and the indexes)
+    // unchanged; only genuinely new quads are indexed.
+    if (!this.quads.has(key)) {
+      this.quads.set(key, quad);
+      indexPosition(this.bySubject, termKey(quad.subject), quad);
+      indexPosition(this.byPredicate, termKey(quad.predicate), quad);
+      indexPosition(this.byObject, termKey(quad.object), quad);
+      indexPosition(this.byGraph, termKey(quad.graph), quad);
+    }
     this._version++;
     return this;
   }
 
   public removeQuad(quad: rdfjs.Quad): this {
-    this.quads.delete(quadKey(quad));
+    const key = quadKey(quad);
+    if (this.quads.delete(key)) {
+      unindexPosition(this.bySubject, termKey(quad.subject), quad);
+      unindexPosition(this.byPredicate, termKey(quad.predicate), quad);
+      unindexPosition(this.byObject, termKey(quad.object), quad);
+      unindexPosition(this.byGraph, termKey(quad.graph), quad);
+    }
     this._version++;
     return this;
   }
@@ -296,23 +359,47 @@ export class MemoryStore implements rdfjs.Store<rdfjs.Quad> {
     object?: rdfjs.Term | null,
     graph?: rdfjs.Term | null,
   ): rdfjs.Quad[] {
-    const matches: rdfjs.Quad[] = [];
-    for (const quad of this.quads.values()) {
-      if (subject != null && !sameRdfTerm(quad.subject, subject)) {
-        continue;
-      }
-      if (predicate != null && !sameRdfTerm(quad.predicate, predicate)) {
-        continue;
-      }
-      if (object != null && !sameRdfTerm(quad.object, object)) {
-        continue;
-      }
-      if (graph != null && !sameRdfTerm(quad.graph, graph)) {
-        continue;
-      }
-      matches.push(quad);
+    // A constrained position with no indexed quads means nothing can match.
+    if (
+      (subject != null && !this.bySubject.has(termKey(subject))) ||
+      (predicate != null && !this.byPredicate.has(termKey(predicate))) ||
+      (object != null && !this.byObject.has(termKey(object))) ||
+      (graph != null && !this.byGraph.has(termKey(graph)))
+    ) {
+      return [];
     }
-    return matches;
+    // Probe the smallest constrained bucket, then filter the rest positionally
+    // (buckets are never empty: unindexPosition drops empty keys).
+    const constrained: rdfjs.Quad[][] = [];
+    if (subject != null) {
+      constrained.push(this.bySubject.get(termKey(subject))!);
+    }
+    if (predicate != null) {
+      constrained.push(this.byPredicate.get(termKey(predicate))!);
+    }
+    if (object != null) {
+      constrained.push(this.byObject.get(termKey(object))!);
+    }
+    if (graph != null) {
+      constrained.push(this.byGraph.get(termKey(graph))!);
+    }
+
+    if (constrained.length === 0) {
+      // No constraints: every quad matches, in insertion order.
+      return [...this.quads.values()];
+    }
+    let bucket = constrained[0];
+    for (const candidate of constrained) {
+      if (candidate.length < bucket.length) {
+        bucket = candidate;
+      }
+    }
+    return bucket.filter((quad) =>
+      (subject == null || sameRdfTerm(quad.subject, subject)) &&
+      (predicate == null || sameRdfTerm(quad.predicate, predicate)) &&
+      (object == null || sameRdfTerm(quad.object, object)) &&
+      (graph == null || sameRdfTerm(quad.graph, graph))
+    );
   }
 
   public countQuads(

--- a/src/wazoo-sparql-engine.ts
+++ b/src/wazoo-sparql-engine.ts
@@ -5,6 +5,7 @@ import type {
   SparqlResponse,
 } from "@/sparql-engine-interface.ts";
 import { SparqlParser } from "@/parser/sparql-parser.ts";
+import type { SparqlQuery } from "@/parser/ast.ts";
 import { SparqlEvaluator } from "@/evaluator/sparql-evaluator.ts";
 import { UpdateEvaluator } from "@/evaluator/update-evaluator.ts";
 
@@ -57,6 +58,14 @@ export class WazooSparqlEngine implements SparqlEngineInterface {
   private readonly parser: SparqlParser;
   private readonly evaluator: SparqlEvaluator;
   private readonly updateEvaluator: UpdateEvaluator;
+  /**
+   * Bounded cache of parsed queries keyed by the exact request string.
+   * Parsing measured ~40% of a sub-millisecond execute, and the AST is only
+   * ever read by the evaluators (never mutated), so repeated queries reuse
+   * the parse. Map preserves insertion order, giving cheap FIFO eviction.
+   */
+  private readonly queryCache = new Map<string, SparqlQuery>();
+  private static readonly QUERY_CACHE_MAX = 128;
 
   public constructor(
     private readonly options: WazooSparqlEngineOptions,
@@ -78,7 +87,17 @@ export class WazooSparqlEngine implements SparqlEngineInterface {
     if (!raw) {
       throw new Error("SparqlRequest must specify either query or update");
     }
-    const ast = this.parser.parse(raw);
+    let ast = this.queryCache.get(raw);
+    if (ast === undefined) {
+      ast = this.parser.parse(raw);
+      this.queryCache.set(raw, ast);
+      if (this.queryCache.size > WazooSparqlEngine.QUERY_CACHE_MAX) {
+        const oldest = this.queryCache.keys().next().value;
+        if (oldest !== undefined) {
+          this.queryCache.delete(oldest);
+        }
+      }
+    }
     if (ast.type === "update") {
       await this.updateEvaluator.executeUpdate(ast);
       return { kind: "void" };


### PR DESCRIPTION
## What

Two contained optimizations identified before #69 (the 10k-subject exists
bench), so the bench measures probe scaling rather than store scans:

**1. MemoryStore positional indexes** (commit f6b6d91) — `getQuads` was a
linear scan of every stored quad, making every BGP scan, property-path step,
`namedGraphs` call, dataset build, and the EXISTS drain O(N) over the whole
store. Quads are now mirrored into four index maps (s/p/o/g) maintained on
every mutation; `getQuads` probes the smallest constrained bucket and filters
the rest, falling back to a full iteration only when nothing is constrained.
Re-adds are index no-ops; removals unindex structurally (callers pass fresh
quad objects, not stored instances — `indexOf` by identity missed them, caught
by the new test). New store test pins exact matches across all position
combinations, duplicate re-adds, `removeQuad`, and `deleteGraph`.

**2. Query-string → AST cache** (commit 55e3b68) — `execute()` re-parsed on
every call; parsing measured **~40% of a sub-ms execute** on the EXISTS budget
row. Bounded FIFO cache (128 entries, Map insertion order for cheap eviction).
Safe: verified no AST mutation sites in the evaluator or parser.

## Measured (budget rows, ms/iter)

| row | before | after |
|---|---|---|
| BGP 2-pattern join | 0.307 | **0.161** |
| Reorder chain join | 0.255 | **0.194** |
| EXISTS filter | 0.271 | **0.156** |
| Nested EXISTS filter | 0.394 | **0.282** |

## Verification

- 363 tests pass (14 store tests incl. the new index test); EXISTS gate
  (11/11 vs Oxigraph) passes; budget gate passes with wide margins
- `deno fmt --check` and `deno lint` clean
- RDF/JS store API unchanged; `MemoryStream` still only ever receives copies
  (bucket arrays are never handed out by reference)