### PR TITLE
Add 10k-subject EXISTS bench group + README benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,48 +106,47 @@ deno task bench
 
 ### Results
 
-A snapshot measured on a Windows desktop with Deno 2.9.5 (native engine as
-the per-group baseline). Each cell is the per-iteration average; every query
-is cross-verified to return identical results on all three engines before
-timing. Timings are machine-specific — run `deno task bench` for your own
-numbers.
+A snapshot measured on a Windows desktop with Deno 2.9.5 (native engine as the
+per-group baseline). Each cell is the per-iteration average; every query is
+cross-verified to return identical results on all three engines before timing.
+Timings are machine-specific — run `deno task bench` for your own numbers.
 
 Core joins, 400-person graph (~2,200 quads):
 
-| query | native | comunica | oxigraph |
-| --- | --- | --- | --- |
-| full scan | 1.3 ms | 7.6 ms | 12.2 ms |
-| join (knows × name) | 1.0 ms | 5.2 ms | 2.6 ms |
-| asymmetric join | 1.4 ms | 29.2 ms | 15.1 ms |
-| reorder chain, written order | 136.5 ms | 193.2 ms | 3.2 ms |
-| reorder chain, planner on | 1.5 ms | — | — |
+| query                        | native   | comunica | oxigraph |
+| ---------------------------- | -------- | -------- | -------- |
+| full scan                    | 1.3 ms   | 7.6 ms   | 12.2 ms  |
+| join (knows × name)          | 1.0 ms   | 5.2 ms   | 2.6 ms   |
+| asymmetric join              | 1.4 ms   | 29.2 ms  | 15.1 ms  |
+| reorder chain, written order | 136.5 ms | 193.2 ms | 3.2 ms   |
+| reorder chain, planner on    | 1.5 ms   | —        | —        |
 
 EXISTS surface, 400-person graph:
 
-| query | native | comunica | oxigraph |
-| --- | --- | --- | --- |
-| `FILTER EXISTS` | 0.81 ms | 29.2 ms | 1.0 ms |
-| `FILTER NOT EXISTS` | 0.88 ms | 33.3 ms | 1.3 ms |
-| nested `EXISTS` | 1.1 ms | 134.6 ms | 1.3 ms |
-| nested `NOT EXISTS` | 1.1 ms | 134.1 ms | 1.2 ms |
+| query               | native  | comunica | oxigraph |
+| ------------------- | ------- | -------- | -------- |
+| `FILTER EXISTS`     | 0.81 ms | 29.2 ms  | 1.0 ms   |
+| `FILTER NOT EXISTS` | 0.88 ms | 33.3 ms  | 1.3 ms   |
+| nested `EXISTS`     | 1.1 ms  | 134.6 ms | 1.3 ms   |
+| nested `NOT EXISTS` | 1.1 ms  | 134.1 ms | 1.2 ms   |
 
 EXISTS surface, 10,000-person graph (~55,000 quads):
 
-| query | native | comunica | oxigraph |
-| --- | --- | --- | --- |
-| `FILTER EXISTS` | 27.8 ms | 729.5 ms | 27.0 ms |
-| `FILTER NOT EXISTS` | 26.8 ms | 835.9 ms | 30.7 ms |
-| nested `EXISTS` | 41.3 ms | 3.1 s | 43.3 ms |
-| nested `NOT EXISTS` | 39.6 ms | 3.2 s | 32.3 ms |
+| query               | native  | comunica | oxigraph |
+| ------------------- | ------- | -------- | -------- |
+| `FILTER EXISTS`     | 27.8 ms | 729.5 ms | 27.0 ms  |
+| `FILTER NOT EXISTS` | 26.8 ms | 835.9 ms | 30.7 ms  |
+| nested `EXISTS`     | 41.3 ms | 3.1 s    | 43.3 ms  |
+| nested `NOT EXISTS` | 39.6 ms | 3.2 s    | 32.3 ms  |
 
-Scaling the data 25x (400 → 10,000 people) grows native's EXISTS cost
-~35-40x while the nested-vs-simple ratio *shrinks* (1.45x → 1.12x): the
-snapshot is drained and indexed once per query, and each probe touches only
-its candidate bucket, so nesting stays cheap relative to the dataset. Across
-the exists surface native is 20-180x faster than comunica and roughly at
-parity with oxigraph (a compiled Rust/WASM engine with native indexes, which
-remains ahead on the reorder-chain row); on the core scan/join rows native is
-the fastest of the three.
+Scaling the data 25x (400 → 10,000 people) grows native's EXISTS cost ~35-40x
+while the nested-vs-simple ratio _shrinks_ (1.45x → 1.12x): the snapshot is
+drained and indexed once per query, and each probe touches only its candidate
+bucket, so nesting stays cheap relative to the dataset. Across the exists
+surface native is 20-180x faster than comunica and roughly at parity with
+oxigraph (a compiled Rust/WASM engine with native indexes, which remains ahead
+on the reorder-chain row); on the core scan/join rows native is the fastest of
+the three.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -94,15 +94,60 @@ that they produce identical final store contents after mutating fresh stores (a
 move update, which a broken engine that ignores updates cannot pass). The timed
 update is a self-restoring delete+insert rewrite, so iterations never drift the
 benchmark stores. The reorder-chain group demonstrates the dynamic join
-ordering: a three-pattern chain written in worst-case order runs ~32x faster
-with reordering enabled (and at parity with Oxigraph), because the planner scans
-each pattern once and joins in order of estimated cost, preferring patterns
-whose variables are already bound. Timings use Deno's built-in bench runner with
-the native engine as the per-group baseline:
+ordering: a three-pattern chain written in worst-case order runs ~90x faster
+with reordering enabled, because the planner scans each pattern once and joins
+in order of estimated cost, preferring patterns whose variables are already
+bound. Timings use Deno's built-in bench runner with the native engine as the
+per-group baseline:
 
 ```bash
 deno task bench
 ```
+
+### Results
+
+A snapshot measured on a Windows desktop with Deno 2.9.5 (native engine as
+the per-group baseline). Each cell is the per-iteration average; every query
+is cross-verified to return identical results on all three engines before
+timing. Timings are machine-specific — run `deno task bench` for your own
+numbers.
+
+Core joins, 400-person graph (~2,200 quads):
+
+| query | native | comunica | oxigraph |
+| --- | --- | --- | --- |
+| full scan | 1.3 ms | 7.6 ms | 12.2 ms |
+| join (knows × name) | 1.0 ms | 5.2 ms | 2.6 ms |
+| asymmetric join | 1.4 ms | 29.2 ms | 15.1 ms |
+| reorder chain, written order | 136.5 ms | 193.2 ms | 3.2 ms |
+| reorder chain, planner on | 1.5 ms | — | — |
+
+EXISTS surface, 400-person graph:
+
+| query | native | comunica | oxigraph |
+| --- | --- | --- | --- |
+| `FILTER EXISTS` | 0.81 ms | 29.2 ms | 1.0 ms |
+| `FILTER NOT EXISTS` | 0.88 ms | 33.3 ms | 1.3 ms |
+| nested `EXISTS` | 1.1 ms | 134.6 ms | 1.3 ms |
+| nested `NOT EXISTS` | 1.1 ms | 134.1 ms | 1.2 ms |
+
+EXISTS surface, 10,000-person graph (~55,000 quads):
+
+| query | native | comunica | oxigraph |
+| --- | --- | --- | --- |
+| `FILTER EXISTS` | 27.8 ms | 729.5 ms | 27.0 ms |
+| `FILTER NOT EXISTS` | 26.8 ms | 835.9 ms | 30.7 ms |
+| nested `EXISTS` | 41.3 ms | 3.1 s | 43.3 ms |
+| nested `NOT EXISTS` | 39.6 ms | 3.2 s | 32.3 ms |
+
+Scaling the data 25x (400 → 10,000 people) grows native's EXISTS cost
+~35-40x while the nested-vs-simple ratio *shrinks* (1.45x → 1.12x): the
+snapshot is drained and indexed once per query, and each probe touches only
+its candidate bucket, so nesting stays cheap relative to the dataset. Across
+the exists surface native is 20-180x faster than comunica and roughly at
+parity with oxigraph (a compiled Rust/WASM engine with native indexes, which
+remains ahead on the reorder-chain row); on the core scan/join rows native is
+the fastest of the three.
 
 ## Development
 

--- a/bench/engine_bench.ts
+++ b/bench/engine_bench.ts
@@ -26,6 +26,7 @@ import type { CanonicalTerm } from "@/term/mod.ts";
 const { blankNode, literal, namedNode, quad } = DataFactory;
 
 const PERSON_COUNT = 400;
+const LARGE_PERSON_COUNT = 10_000;
 const foafName = namedNode("http://xmlns.com/foaf/0.1/name");
 const foafKnows = namedNode("http://xmlns.com/foaf/0.1/knows");
 const foafAge = namedNode("http://xmlns.com/foaf/0.1/age");
@@ -40,12 +41,15 @@ const g1Graph = namedNode("http://example.org/g1");
 const g2Graph = namedNode("http://example.org/g2");
 
 /**
- * buildDataset generates the shared benchmark graph: a ring of people, each
- * with a name, an integer age, a blank node pet, and a knows edge.
+ * buildPeopleDataset generates a ring of people, each with a name, an integer
+ * age, a blank node pet, a knows edge, a city tag (5 distinct values), and a
+ * spouse edge on even-indexed people only. The 400-person shared benchmark
+ * graph and the 10k-subject scaling graph are the same shape at different
+ * sizes, so EXISTS rows compare like for like.
  */
-function buildDataset(): rdfjs.Quad[] {
+function buildPeopleDataset(count: number): rdfjs.Quad[] {
   const quads: rdfjs.Quad[] = [];
-  for (let index = 0; index < PERSON_COUNT; index++) {
+  for (let index = 0; index < count; index++) {
     const person = examplePerson(index);
     quads.push(quad(person, foafName, literal(`Person ${index}`)));
     quads.push(
@@ -60,7 +64,7 @@ function buildDataset(): rdfjs.Quad[] {
       quad(
         person,
         foafKnows,
-        examplePerson((index + 1) % PERSON_COUNT),
+        examplePerson((index + 1) % count),
       ),
     );
     // City tag (5 distinct values) — grouping/filter/distinct material.
@@ -71,6 +75,13 @@ function buildDataset(): rdfjs.Quad[] {
     }
   }
   return quads;
+}
+
+/**
+ * buildDataset generates the shared 400-person benchmark graph.
+ */
+function buildDataset(): rdfjs.Quad[] {
+  return buildPeopleDataset(PERSON_COUNT);
 }
 
 /**
@@ -186,6 +197,14 @@ const nativeEngineNoReorder = new WazooSparqlEngine({
   reorderPatterns: false,
 });
 const comunicaEngine = getComunicaEngine();
+
+// 10k-subject scaling group: the same person-ring shape at 25x the main
+// dataset, to validate that EXISTS probe cost stays proportional to the
+// candidate bucket rather than the dataset size.
+const largeDataset = buildPeopleDataset(LARGE_PERSON_COUNT);
+const largeMemoryStore = seedStore(largeDataset);
+const largeOxigraphStore = seedOxigraphStore(largeDataset);
+const largeNativeEngine = new WazooSparqlEngine({ store: largeMemoryStore });
 
 // GRAPH / FROM groups run against their own named-graph stores; the update
 // verification keeps the main dataset default-graph-only so its graph-blind
@@ -593,6 +612,11 @@ const mainTrio: EngineTrio = {
   comunicaStore: memoryStore,
   oxigraph: oxigraphStore,
 };
+const largeTrio: EngineTrio = {
+  native: largeNativeEngine,
+  comunicaStore: largeMemoryStore,
+  oxigraph: largeOxigraphStore,
+};
 const graphTrio: EngineTrio = {
   native: graphNativeEngine,
   comunicaStore: graphMemoryStore,
@@ -847,6 +871,16 @@ await verifySelectEquality(existsQuery, "exists");
 await verifySelectEquality(notExistsQuery, "not-exists");
 await verifySelectEquality(nestedExistsQuery, "nested-exists");
 await verifySelectEquality(nestedNotExistsQuery, "nested-not-exists");
+// The same EXISTS queries must agree on the 10k-subject dataset before the
+// scaling timings compare equivalent work across engines.
+await verifySelectEquality(existsQuery, "exists-large", largeTrio);
+await verifySelectEquality(notExistsQuery, "not-exists-large", largeTrio);
+await verifySelectEquality(nestedExistsQuery, "nested-exists-large", largeTrio);
+await verifySelectEquality(
+  nestedNotExistsQuery,
+  "nested-not-exists-large",
+  largeTrio,
+);
 await verifySelectEquality(castNumericQuery, "cast-numeric");
 await verifySelectEquality(castBooleanQuery, "cast-boolean");
 await verifySelectEquality(castDateTimeQuery, "cast-dateTime");
@@ -1268,6 +1302,37 @@ benchSelectTrio(
   "nested-not-exists",
   mainTrio,
   EXISTS_BENCH_OPTIONS,
+);
+// 10k-subject scaling rows: each iteration is ~25x heavier than the 400-person
+// rows, so fewer samples suffice for stable numbers.
+const LARGE_EXISTS_BENCH_OPTIONS = { warmup: 2_000, iterations: 10 };
+benchSelectTrio(
+  "exists-large",
+  existsQuery,
+  "exists",
+  largeTrio,
+  LARGE_EXISTS_BENCH_OPTIONS,
+);
+benchSelectTrio(
+  "exists-large",
+  notExistsQuery,
+  "not-exists",
+  largeTrio,
+  LARGE_EXISTS_BENCH_OPTIONS,
+);
+benchSelectTrio(
+  "exists-large",
+  nestedExistsQuery,
+  "nested-exists",
+  largeTrio,
+  LARGE_EXISTS_BENCH_OPTIONS,
+);
+benchSelectTrio(
+  "exists-large",
+  nestedNotExistsQuery,
+  "nested-not-exists",
+  largeTrio,
+  LARGE_EXISTS_BENCH_OPTIONS,
 );
 benchSelectTrio("cast", castNumericQuery, "cast-numeric");
 benchSelectTrio("cast", castBooleanQuery, "cast-boolean");


### PR DESCRIPTION
## What

Closes #69. Adds a 10k-subject EXISTS/NOT EXISTS bench group validating
indexed-probe scaling, and documents the benchmark results in the README.

## Bench group

The 400-person exists rows validated correctness but not scaling. The new
`exists-large` group reuses the same person-ring shape at 25x the data
(~55,000 quads) for all four EXISTS queries, cross-verified against comunica
and oxigraph before timing (10 iterations, 2s warmup — each iteration is ~25x
heavier, so fewer samples stay stable). The dataset builder was parameterized
(`buildPeopleDataset(count)`) so both sizes share one shape.

## What the 10k numbers show (native, per-iteration avg)

| query | 400 people | 10k people | scale |
|---|---|---|---|
| EXISTS | 0.81 ms | 27.8 ms | 34x |
| NOT EXISTS | 0.88 ms | 26.8 ms | 30x |
| nested EXISTS | 1.1 ms | 41.3 ms | 37x |
| nested NOT EXISTS | 1.1 ms | 39.6 ms | 36x |

The nested-vs-simple ratio **shrinks** from 1.45x (400) to 1.12x (10k): the
snapshot is drained and indexed once per query (version-cached across
iterations), and each probe is O(bucket) — the acceptance criterion of #69.
Comunica's nested EXISTS degrades to 3.1s at 10k, oxigraph to 43ms; native is
at parity with oxigraph on the exists surface and 20-180x faster than
comunica.

## README

New "Results" subsection under Benchmarking: core scan/join/asym rows, the
reorder-chain row (the stale ~32x planner claim updated to the current ~90x),
and the exists surface at both sizes — framed humbly: marked as a
machine-specific snapshot (Deno 2.9.5, Windows), oxigraph's compiled-Rust
advantage acknowledged explicitly, and the reorder-chain row where oxigraph
leads shown rather than hidden.

## Verification

- `deno task bench` runs green end-to-end with all cross-engine verifications
  passing (both exists groups agree across native/comunica/oxigraph)
- `deno task bench:check` passes; `deno fmt --check` and `deno lint` clean