### PR TITLE
Release 0.2.0: ship the full surface + fail publish on stale versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,4 +17,15 @@ jobs:
           deno-version: v2.x
       - run: deno task ci
       - run: deno task publish:dry
-      - run: deno publish
+      # deno publish exits 0 when the version is already on JSR, so a stale
+      # version would otherwise make this workflow a silent no-op (which is
+      # how 0.1.0 shipped without the MemoryStore export). Fail loudly instead:
+      # bump deno.json version before merging to main.
+      - name: Publish to JSR
+        run: |
+          output=$(deno publish 2>&1)
+          echo "$output"
+          if echo "$output" | grep -q "already published"; then
+            echo "::error::deno publish skipped: version already on JSR. Bump the version in deno.json before merging to main."
+            exit 1
+          fi

--- a/deno.json
+++ b/deno.json
@@ -6,6 +6,10 @@
   "exports": {
     ".": "./src/mod.ts"
   },
+  "publish": {
+    "include": ["src/", "README.md", "LICENSE"],
+    "exclude": ["src/**/*.test.ts"]
+  },
   "imports": {
     "@/": "./src/",
     "@comunica/query-sparql-rdfjs-lite": "npm:@comunica/query-sparql-rdfjs-lite@^5.1.3",

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@wazoo/sparql-engine",
   "description": "Zero-dependency SPARQL 1.1 & 1.2 query and update engine over RDF/JS Quad Stores.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts"


### PR DESCRIPTION
## The bug

The published `@wazoo/sparql-engine@0.1.0` does not export `MemoryStore`
(that's the README import that fails). Root cause, verified end to end:

- `meta.json` shows **only 0.1.0 exists**, published 2026-08-13 06:13 UTC —
  about **2.5 hours before** commit `8833581` (#30) added the
  `MemoryStore, MemoryStream` export to `src/mod.ts`.
- `deno publish` **skips already-published versions and exits 0**
  ("Warning: Skipping, already published @wazoo/sparql-engine@0.1.0").
- So the Publish workflow has been a **silent no-op on every main push
  since** — the published artifact is frozen at 0.1.0 and missing not just
  MemoryStore but everything shipped after #30 (EXISTS support, directional
  literals, the perf work, ...).

## The fix

1. **Bump the version to 0.2.0** in `deno.json` — the public API is additive
   since 0.1.0 (`MemoryStore`, `MemoryStream`, `DataFactory`, `dataFactory`),
   so a minor bump fits. Merging this triggers a real publish of the full
   current surface.
2. **Harden `publish.yml`**: the publish step now captures `deno publish`
   output and **fails the job when it reports "already published"**, so a
   stale version can never pass CI silently again.
3. **Trim the artifact**: a `publish.include` allowlist ships only `src/`
   (excluding co-located `*.test.ts`), `README.md`, and `LICENSE` — the
   previous artifact carried the whole repo tree (test fixtures, `docs/`,
   `bench/`, workflow files). Verified: `deno publish --dry-run` goes from
   46 → 38 files, no test files, dry run succeeds.

## Verification

- `deno publish --dry-run` succeeds on the current tree (38 files: src/,
  README.md, LICENSE)
- After merge, the Publish workflow should publish 0.2.0; the JSR mod.ts will
  then include the `MemoryStore` export