### PR TITLE
ci: upgrade actions/checkout@v4 to v5 (drop deprecated Node 20 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
@@ -26,7 +26,7 @@ jobs:
   w3c-parity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x


### PR DESCRIPTION
## Context

Every CI run carried the annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4

`actions/checkout@v4` is pinned to the Node 20 runtime in all three call sites (`.github/workflows/ci.yml` ×2, `.github/workflows/publish.yml` ×1). Issue #82.

## Change

Bump all three to `actions/checkout@v5`, which uses the node24 runtime (requires Actions Runner v2.327.1+, satisfied by `ubuntu-latest`).

## Acceptance criteria (from #82)

- [x] `grep actions/checkout .github/workflows/*.yml` shows only `@v5`
- [ ] A CI run completes with no "Node.js 20 is deprecated" annotation

Closes #82