### PR TITLE
perf: hash-join innerJoin / leftJoin / minus on shared variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,44 @@ same shape (~60-80x).
 deno task ci
 ```
 
+## Query design notes
+
+Most performance work is the engine's job and happens automatically: greedy join
+reordering, hash joins over shared variables, the positional store index, and
+the once-per-query EXISTS snapshot with indexed probes. The query shapes below
+are expensive **by semantics** — the cost is proportional to the result the
+query itself asks for, so no engine can make them cheap without changing the
+answer. Treat them as the operator's responsibility:
+
+- **Joins with no shared variables.** A join (BGP patterns, UNION branches,
+  OPTIONAL, MINUS) over disjoint variable sets is a cross product — n·m rows by
+  definition, per SPARQL §18.2.2's natural join on an empty key. The hash join
+  does not change this: the result size _is_ the cost. Correlate the sides on a
+  shared variable (typically the subject). The same trap applies to
+  `OPTIONAL { ?x <pet> ?p }` whose group shares nothing with the outer query —
+  every outer row merges with every group row; bind the group to the outer
+  solution instead.
+- **Property paths with both endpoints unbound.** `?a <knows>+ ?b` walks the
+  path forward from every graph node, because the reachable-set has to be
+  computed before any solution can be formed. Binding one endpoint
+  (`<person1> <knows>+ ?b`) turns it into one anchored walk; reflexive forms
+  (`?`, `*`) additionally materialize the (node, node) pair.
+- **Queries whose result is the whole store.** `SELECT * WHERE { ?s ?p ?o }`
+  over 55k quads materializes 55k rows; the positional index makes each pattern
+  scan O(bucket) instead of O(store), but the result materialization is
+  inherent. Bind a selective subject, push FILTERs down, or use LIMIT — the
+  engine evaluates everything before slicing, so a small LIMIT over a huge scan
+  still pays the scan (streaming is tracked as #74).
+- **Correlated EXISTS over broad scopes.** EXISTS snapshots drain and index once
+  per query, and probes touch only the candidate bucket — but a correlated
+  `FILTER EXISTS { ?s <knows> ?who }` whose correlation variable is bound
+  _outside_ the EXISTS still runs once per outer solution. Bind the correlation
+  variable in the outer query.
+- **Non-selective data shapes.** If every node is connected to every node, the
+  compatible-candidate set for a join _is_ the whole right side, and no join
+  strategy beats scanning it. Prefer selective predicates on the hot path —
+  indexes help only when buckets are smaller than the full set.
+
 ## Releases
 
 Every merge to `main` runs the Publish workflow. Following the standard JSR

--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ oxigraph (a compiled Rust/WASM engine with native indexes, which remains ahead
 on the reorder-chain row); on the core scan/join rows native is the fastest of
 the three.
 
+Join surface, 10,000-person graph (~55,000 quads) — UNION joins 10k x 20k
+bindings on the shared subject (~200M candidate pairs); OPTIONAL and MINUS join
+10k x 5k (~50M pairs). The native engine's hash join probes an indexed right
+side per left binding instead of scanning it:
+
+| query               | native  | comunica | oxigraph |
+| ------------------- | ------- | -------- | -------- |
+| UNION (10k x 20k)   | 45.1 ms | 106.6 ms | 107.5 ms |
+| OPTIONAL (10k x 5k) | 22.1 ms | 587.9 ms | 56.5 ms  |
+| MINUS (10k x 5k)    | 18.0 ms | 41.7 ms  | 23.1 ms  |
+
+On this surface native leads all three engines, and the fan-out join scaling is
+sub-quadratic: the nested-loop before-state for the same UNION was ~7 s/iter
+versus 45 ms with the hash join (~150x), with OPTIONAL and MINUS showing the
+same shape (~60-80x).
+
 ## Development
 
 ```bash

--- a/bench/engine_bench.ts
+++ b/bench/engine_bench.ts
@@ -271,6 +271,21 @@ const minusQuery =
 const unionQuery =
   "SELECT ?s WHERE { { ?s <http://xmlns.com/foaf/0.1/name> ?n } " +
   "UNION { ?s <http://example.org/pet> ?p } }";
+// 10k join-scaling queries: each joins a large accumulated binding set
+// against a large right side on the shared subject variable, so the rows
+// measure the join machinery (hash join for the native engine) rather than
+// the element evaluation. UNION joins 10k x 20k (~200M candidate pairs),
+// OPTIONAL and MINUS join 10k x 5k (~50M pairs).
+const unionJoinQuery =
+  "SELECT ?s ?a ?n WHERE { ?s <http://xmlns.com/foaf/0.1/age> ?a . " +
+  "{ ?s <http://xmlns.com/foaf/0.1/name> ?n } " +
+  "UNION { ?s <http://example.org/city> ?c } }";
+const optionalJoinQuery =
+  "SELECT ?s ?n ?sp WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n . " +
+  "OPTIONAL { ?s <http://example.org/spouse> ?sp } }";
+const minusJoinQuery =
+  "SELECT ?s ?n WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n . " +
+  "MINUS { ?s <http://example.org/spouse> ?sp } }";
 const pathSeqQuery =
   "SELECT ?person ?grand WHERE { ?person <http://xmlns.com/foaf/0.1/knows>/" +
   "<http://xmlns.com/foaf/0.1/knows> ?grand }";
@@ -881,6 +896,10 @@ await verifySelectEquality(
   "nested-not-exists-large",
   largeTrio,
 );
+// The 10k join-scaling queries must also agree across engines before timing.
+await verifySelectEquality(unionJoinQuery, "union-join-large", largeTrio);
+await verifySelectEquality(optionalJoinQuery, "optional-join-large", largeTrio);
+await verifySelectEquality(minusJoinQuery, "minus-join-large", largeTrio);
 await verifySelectEquality(castNumericQuery, "cast-numeric");
 await verifySelectEquality(castBooleanQuery, "cast-boolean");
 await verifySelectEquality(castDateTimeQuery, "cast-dateTime");
@@ -1333,6 +1352,31 @@ benchSelectTrio(
   "nested-not-exists",
   largeTrio,
   LARGE_EXISTS_BENCH_OPTIONS,
+);
+// 10k join-scaling rows: the same shared-subject join surface as the
+// 400-person rows but at 10k subjects, where the native engine's hash join
+// probes instead of scanning the whole right side per left binding.
+const LARGE_JOIN_BENCH_OPTIONS = { warmup: 2_000, iterations: 10 };
+benchSelectTrio(
+  "join-large",
+  unionJoinQuery,
+  "union",
+  largeTrio,
+  LARGE_JOIN_BENCH_OPTIONS,
+);
+benchSelectTrio(
+  "join-large",
+  optionalJoinQuery,
+  "optional",
+  largeTrio,
+  LARGE_JOIN_BENCH_OPTIONS,
+);
+benchSelectTrio(
+  "join-large",
+  minusJoinQuery,
+  "minus",
+  largeTrio,
+  LARGE_JOIN_BENCH_OPTIONS,
 );
 benchSelectTrio("cast", castNumericQuery, "cast-numeric");
 benchSelectTrio("cast", castBooleanQuery, "cast-boolean");

--- a/src/evaluator/join.test.ts
+++ b/src/evaluator/join.test.ts
@@ -1,0 +1,231 @@
+import { assertEquals } from "@std/assert";
+import { DataFactory, termKey } from "@/term/mod.ts";
+import {
+  bindingsCompatible,
+  innerJoin,
+  leftJoin,
+  minus,
+  type TermBinding,
+} from "@/evaluator/join.ts";
+
+const { namedNode, literal } = DataFactory;
+
+const p = (n: number) => namedNode(`http://example.org/p${n}`);
+const lit = (n: number) => literal(`v${n}`);
+
+/** Nested-loop reference implementations (the pre-hash-join semantics). */
+function innerJoinRef(
+  left: TermBinding[],
+  right: TermBinding[],
+): TermBinding[] {
+  const result: TermBinding[] = [];
+  for (const l of left) {
+    for (const r of right) {
+      if (bindingsCompatible(l, r)) {
+        result.push({ ...l, ...r });
+      }
+    }
+  }
+  return result;
+}
+
+function leftJoinRef(
+  left: TermBinding[],
+  right: TermBinding[],
+  filters: ((b: TermBinding) => boolean)[] = [],
+): TermBinding[] {
+  const result: TermBinding[] = [];
+  for (const l of left) {
+    let matched = false;
+    for (const r of right) {
+      if (!bindingsCompatible(l, r)) {
+        continue;
+      }
+      const merged = { ...l, ...r };
+      if (filters.every((filter) => filter(merged))) {
+        result.push(merged);
+        matched = true;
+      }
+    }
+    if (!matched) {
+      result.push(l);
+    }
+  }
+  return result;
+}
+
+function minusRef(left: TermBinding[], right: TermBinding[]): TermBinding[] {
+  return left.filter((l) =>
+    !right.some((r) =>
+      Object.keys(l).some((k) => r[k] !== undefined) &&
+      bindingsCompatible(l, r)
+    )
+  );
+}
+
+/** Multiset equality: same bindings (up to key order) with the same counts. */
+function assertMultisetEqual(
+  actual: TermBinding[],
+  expected: TermBinding[],
+  label: string,
+): void {
+  const canon = (b: TermBinding): string =>
+    Object.keys(b).sort().map((k) => `${k}=${termKey(b[k])}`).join("|");
+  const counts = new Map<string, number>();
+  for (const b of expected) {
+    const key = canon(b);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  for (const b of actual) {
+    const key = canon(b);
+    const n = counts.get(key);
+    if (n === undefined) {
+      throw new Error(`${label}: unexpected binding ${key}`);
+    }
+    if (n === 1) {
+      counts.delete(key);
+    } else {
+      counts.set(key, n - 1);
+    }
+  }
+  assertEquals(
+    counts.size,
+    0,
+    `${label}: missing ${[...counts.keys()].join(", ")}`,
+  );
+}
+
+Deno.test("innerJoin - homogeneous join on a shared variable", () => {
+  const left = [0, 1, 2].map((n) => ({ s: p(n), a: lit(n) }));
+  const right = [0, 1, 2].map((n) => ({ s: p(n), b: lit(n + 10) }));
+  const result = innerJoin(left, right);
+  assertEquals(result.length, 3);
+  assertMultisetEqual(result, innerJoinRef(left, right), "innerJoin");
+});
+
+Deno.test("innerJoin - duplicates survive (multiset semantics)", () => {
+  const left = [{ s: p(0), a: lit(0) }, { s: p(0), a: lit(0) }];
+  const right = [{ s: p(0), b: lit(1) }, { s: p(0), b: lit(1) }];
+  const result = innerJoin(left, right);
+  assertEquals(result.length, 4);
+  assertMultisetEqual(result, innerJoinRef(left, right), "innerJoin");
+});
+
+Deno.test("innerJoin - partial left binding is a wildcard on the shared variable", () => {
+  // The left binding {b: v0} does not bind ?s, so it is compatible with
+  // every right binding (they cannot disagree on ?s).
+  const left: TermBinding[] = [{ b: lit(0) }, { s: p(1), b: lit(1) }];
+  const right = [{ s: p(0), c: lit(0) }, { s: p(1), c: lit(1) }];
+  const result = innerJoin(left, right);
+  assertMultisetEqual(result, innerJoinRef(left, right), "innerJoin");
+});
+
+Deno.test("leftJoin - unmatched bindings survive unextended", () => {
+  const left = [0, 1, 2, 3].map((n) => ({ s: p(n) }));
+  const right = [0, 2].map((n) => ({ s: p(n), b: lit(n) }));
+  const result = leftJoin(left, right);
+  assertEquals(result.length, 4);
+  assertMultisetEqual(result, leftJoinRef(left, right), "leftJoin");
+});
+
+Deno.test("leftJoin - filters apply to the merged binding", () => {
+  const left = [0, 1].map((n) => ({ s: p(n) }));
+  const right = [0, 1].map((n) => ({ s: p(n), b: lit(n) }));
+  const keepHigh = (b: TermBinding) => b.b !== undefined && b.b.value === "v1";
+  const result = leftJoin(left, right, [keepHigh]);
+  // Only s1 matches the filter; s0 survives unextended.
+  assertEquals(result.length, 2);
+  assertMultisetEqual(
+    result,
+    leftJoinRef(left, right, [keepHigh]),
+    "leftJoin-filter",
+  );
+});
+
+Deno.test("leftJoin - heterogeneous left (chained OPTIONAL) probes wildcards", () => {
+  // First OPTIONAL succeeded for s0 and s2, failed for s1 and s3.
+  const left: TermBinding[] = [
+    { s: p(0), a: lit(0), o1: lit(0) },
+    { s: p(1), a: lit(1) },
+    { s: p(2), a: lit(2), o1: lit(2) },
+    { s: p(3), a: lit(3) },
+  ];
+  const right = [0, 2].map((n) => ({ s: p(n), o2: lit(n + 100) }));
+  const result = leftJoin(left, right);
+  assertEquals(result.length, 4);
+  assertMultisetEqual(result, leftJoinRef(left, right), "leftJoin-chain");
+});
+
+Deno.test("minus - eliminates on shared-variable compatibility", () => {
+  const left = [0, 1, 2].map((n) => ({ s: p(n) }));
+  const right = [0, 2].map((n) => ({ s: p(n), b: lit(n) }));
+  const result = minus(left, right);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].s, p(1));
+});
+
+Deno.test("minus - no shared variables means no elimination", () => {
+  const left = [0, 1].map((n) => ({ s: p(n) }));
+  const right = [{ t: p(0), b: lit(0) }, { t: p(1), b: lit(1) }];
+  const result = minus(left, right);
+  assertEquals(result.length, 2);
+});
+
+Deno.test("minus - partial left binding sharing nothing is not eliminated", () => {
+  // The left binding {x: v0} shares no variable with any right binding.
+  const left: TermBinding[] = [{ x: lit(0) }, { s: p(1), x: lit(1) }];
+  const right = [{ s: p(0), b: lit(0) }, { s: p(1), b: lit(1) }];
+  const result = minus(left, right);
+  assertMultisetEqual(result, minusRef(left, right), "minus-partial");
+});
+
+// Large inputs force the hash-join dispatch (product > JOIN_PRODUCT_THRESHOLD
+// = 4096); pin the hash path against the nested-loop reference.
+const LARGE = 100;
+
+function largeLeft(): TermBinding[] {
+  const out: TermBinding[] = [];
+  for (let i = 0; i < LARGE; i++) {
+    // Every third binding misses the shared variable ?s — wildcards.
+    const b: TermBinding = { a: lit(i % 20) };
+    if (i % 3 !== 0) {
+      b.s = p(i % 50);
+    }
+    out.push(b);
+  }
+  return out;
+}
+
+function largeRight(): TermBinding[] {
+  const out: TermBinding[] = [];
+  for (let i = 0; i < LARGE; i++) {
+    out.push({ s: p(i % 50), b: lit(i % 20), c: lit(i) });
+  }
+  return out;
+}
+
+Deno.test("hash join - large innerJoin matches the nested reference", () => {
+  const left = largeLeft();
+  const right = largeRight();
+  const result = innerJoin(left, right);
+  assertMultisetEqual(result, innerJoinRef(left, right), "hash-inner");
+});
+
+Deno.test("hash join - large leftJoin matches the nested reference", () => {
+  const left = largeLeft();
+  const right = largeRight();
+  const filter = (b: TermBinding) => (b.c === undefined || b.c.value !== "v99");
+  const result = leftJoin(left, right, [filter]);
+  assertMultisetEqual(
+    result,
+    leftJoinRef(left, right, [filter]),
+    "hash-left",
+  );
+});
+
+Deno.test("hash join - large minus matches the nested reference", () => {
+  const left = largeLeft();
+  const right = largeRight();
+  const result = minus(left, right);
+  assertMultisetEqual(result, minusRef(left, right), "hash-minus");
+});

--- a/src/evaluator/join.ts
+++ b/src/evaluator/join.ts
@@ -76,8 +76,48 @@ export function bindingsCompatible(
  * filters; when nothing matches, the left binding survives unextended. The
  * filters are the OPTIONAL group's own FILTER expressions, evaluated against
  * the merged binding so they can reference outer variables.
+ *
+ * Large joins dispatch to the hash join (compatibleCandidates); small joins
+ * keep the nested loop, which is faster below the hash-setup overhead.
  */
 export function leftJoin(
+  left: TermBinding[],
+  right: TermBinding[],
+  filters: BindingFilter[] = [],
+): TermBinding[] {
+  if (left.length === 0) {
+    return [];
+  }
+  if (right.length === 0) {
+    return left.slice();
+  }
+  if (left.length * right.length <= JOIN_PRODUCT_THRESHOLD) {
+    return leftJoinNested(left, right, filters);
+  }
+  const joinVars = sharedVars(left, right);
+  if (joinVars.length === 0) {
+    // No variable is bound on both sides: every pair is compatible.
+    return leftJoinNested(left, right, filters);
+  }
+  const index = buildHashIndex(right, joinVars);
+  const result: TermBinding[] = [];
+  for (const l of left) {
+    let matched = false;
+    for (const r of compatibleCandidates(l, joinVars, index, right)) {
+      const merged = { ...l, ...r };
+      if (filters.every((filter) => filter(merged))) {
+        result.push(merged);
+        matched = true;
+      }
+    }
+    if (!matched) {
+      result.push(l);
+    }
+  }
+  return result;
+}
+
+function leftJoinNested(
   left: TermBinding[],
   right: TermBinding[],
   filters: BindingFilter[] = [],
@@ -108,8 +148,36 @@ export function leftJoin(
  * multiset semantics. It threads a group element's independently evaluated
  * solutions (e.g. UNION branches) into the incoming solutions, matching the
  * Join(P, Union(Q1, Q2)) algebra translation.
+ *
+ * Large joins dispatch to the hash join; small joins keep the nested loop,
+ * which is faster below the hash-setup overhead.
  */
 export function innerJoin(
+  left: TermBinding[],
+  right: TermBinding[],
+): TermBinding[] {
+  if (left.length === 0 || right.length === 0) {
+    return [];
+  }
+  if (left.length * right.length <= JOIN_PRODUCT_THRESHOLD) {
+    return innerJoinNested(left, right);
+  }
+  const joinVars = sharedVars(left, right);
+  if (joinVars.length === 0) {
+    // No variable is bound on both sides: the result is a cross product.
+    return innerJoinNested(left, right);
+  }
+  const index = buildHashIndex(right, joinVars);
+  const result: TermBinding[] = [];
+  for (const l of left) {
+    for (const r of compatibleCandidates(l, joinVars, index, right)) {
+      result.push({ ...l, ...r });
+    }
+  }
+  return result;
+}
+
+function innerJoinNested(
   left: TermBinding[],
   right: TermBinding[],
 ): TermBinding[] {
@@ -129,14 +197,242 @@ export function innerJoin(
  * when some right binding shares at least one variable with it and is
  * compatible on all of them. Right bindings sharing no variables with a
  * left binding never eliminate it, per SPARQL 1.1 §18.2.2.9.
+ *
+ * Large joins dispatch to the hash join; small joins keep the nested loop.
  */
 export function minus(
+  left: TermBinding[],
+  right: TermBinding[],
+): TermBinding[] {
+  if (left.length === 0 || right.length === 0) {
+    return left.slice();
+  }
+  if (left.length * right.length <= JOIN_PRODUCT_THRESHOLD) {
+    return minusNested(left, right);
+  }
+  const joinVars = sharedVars(left, right);
+  if (joinVars.length === 0) {
+    // No variable is bound on both sides: no right binding shares a variable
+    // with any left binding, so nothing is eliminated.
+    return left.slice();
+  }
+  const index = buildHashIndex(right, joinVars);
+  const result: TermBinding[] = [];
+  for (const l of left) {
+    let eliminated = false;
+    for (const r of compatibleCandidates(l, joinVars, index, right)) {
+      if (sharesVariable(l, r)) {
+        eliminated = true;
+        break;
+      }
+    }
+    if (!eliminated) {
+      result.push(l);
+    }
+  }
+  return result;
+}
+
+function minusNested(
   left: TermBinding[],
   right: TermBinding[],
 ): TermBinding[] {
   return left.filter((l) =>
     !right.some((r) => sharesVariable(l, r) && bindingsCompatible(l, r))
   );
+}
+
+/* ------------------------------------------------------------------ */
+/* Hash join (issue #73)                                              */
+/*                                                                    */
+/* innerJoin / leftJoin / minus above dispatch large joins here. The  */
+/* right side is indexed once by the shared variables; each left      */
+/* binding probes only its compatible candidates instead of scanning  */
+/* the whole right side, turning the O(n·m) nested loop into a probe  */
+/* of O(n) buckets. Multiset semantics are preserved: every compatible */
+/* pair still produces its merged binding, duplicates included.       */
+/* ------------------------------------------------------------------ */
+
+/**
+ * JOIN_PRODUCT_THRESHOLD is the pair count below which the nested loop is
+ * kept: hash-setup (indexing the right side) costs more than the scan it
+ * saves for tiny joins.
+ */
+const JOIN_PRODUCT_THRESHOLD = 4096;
+
+/**
+ * sharedVars returns the sorted variables bound on both sides — the join
+ * key dimensions. Bindings missing a shared variable are wildcards on it
+ * (compatible with any value), which the candidate machinery handles.
+ */
+function sharedVars(
+  left: TermBinding[],
+  right: TermBinding[],
+): string[] {
+  const rightVars = new Set<string>();
+  for (const binding of right) {
+    for (const key of Object.keys(binding)) {
+      rightVars.add(key);
+    }
+  }
+  const shared: string[] = [];
+  for (const binding of left) {
+    for (const key of Object.keys(binding)) {
+      if (rightVars.has(key) && !shared.includes(key)) {
+        shared.push(key);
+      }
+    }
+  }
+  return shared.sort();
+}
+
+/**
+ * joinKey renders the hash key of a binding over the shared variables:
+ * the term keys of the values it binds, with null for unbound positions.
+ * JSON.stringify keeps the tuple collision-free for any term content.
+ */
+function joinKey(
+  binding: TermBinding,
+  joinVars: string[],
+): string {
+  return JSON.stringify(joinVars.map((v) => {
+    const t = binding[v];
+    return t === undefined ? null : termKey(t);
+  }));
+}
+
+/**
+ * HashIndex is the right side indexed for probing:
+ * - exact buckets total bindings (those binding every shared variable) by
+ *   their full key, so identical keys are compatible by construction;
+ * - byVar buckets every binding by each shared variable it binds, for
+ *   partial left bindings to probe their most selective variable;
+ * - partials holds the right bindings missing at least one shared variable
+ *   (OPTIONAL failures), which are wildcards and need per-probe checks.
+ */
+interface HashIndex {
+  exact: Map<string, TermBinding[]>;
+  byVar: Map<string, Map<string, TermBinding[]>>;
+  partials: TermBinding[];
+}
+
+function buildHashIndex(
+  right: TermBinding[],
+  joinVars: string[],
+): HashIndex {
+  const exact = new Map<string, TermBinding[]>();
+  const byVar = new Map<string, Map<string, TermBinding[]>>();
+  const partials: TermBinding[] = [];
+  for (const binding of right) {
+    let total = true;
+    for (const v of joinVars) {
+      if (binding[v] === undefined) {
+        total = false;
+        break;
+      }
+    }
+    if (total) {
+      const key = joinKey(binding, joinVars);
+      const bucket = exact.get(key);
+      if (bucket) {
+        bucket.push(binding);
+      } else {
+        exact.set(key, [binding]);
+      }
+    } else {
+      partials.push(binding);
+    }
+    for (const v of joinVars) {
+      const t = binding[v];
+      if (t === undefined) {
+        continue;
+      }
+      let varMap = byVar.get(v);
+      if (varMap === undefined) {
+        varMap = new Map();
+        byVar.set(v, varMap);
+      }
+      const tk = termKey(t);
+      const bucket = varMap.get(tk);
+      if (bucket) {
+        bucket.push(binding);
+      } else {
+        varMap.set(tk, [binding]);
+      }
+    }
+  }
+  return { exact, byVar, partials };
+}
+
+/**
+ * compatibleCandidates returns the right bindings compatible with l — those
+ * agreeing with l on every variable both bind. A total l (binding every
+ * shared variable) probes the exact bucket, which is compatible by
+ * construction, plus the (usually few) partial rights it agrees with. A
+ * partial l probes the bucket of its most selective bound variable and
+ * verifies, plus partial rights that do not bind that variable.
+ */
+function compatibleCandidates(
+  l: TermBinding,
+  joinVars: string[],
+  index: HashIndex,
+  right: TermBinding[],
+): TermBinding[] {
+  let total = true;
+  for (const v of joinVars) {
+    if (l[v] === undefined) {
+      total = false;
+      break;
+    }
+  }
+  if (total) {
+    const exactHits = index.exact.get(joinKey(l, joinVars)) ?? [];
+    if (index.partials.length === 0) {
+      return exactHits;
+    }
+    const out = exactHits.slice();
+    for (const r of index.partials) {
+      if (bindingsCompatible(l, r)) {
+        out.push(r);
+      }
+    }
+    return out;
+  }
+  // Partial l: pick the shared variable it binds with the smallest right
+  // bucket (most selective), probe it, and verify the rest of the agreement.
+  let bestVar: string | null = null;
+  let bestKey = "";
+  let bestSize = Infinity;
+  for (const v of joinVars) {
+    const t = l[v];
+    if (t === undefined) {
+      continue;
+    }
+    const tk = termKey(t);
+    const size = index.byVar.get(v)?.get(tk)?.length ?? 0;
+    if (size < bestSize) {
+      bestSize = size;
+      bestVar = v;
+      bestKey = tk;
+    }
+  }
+  if (bestVar === null) {
+    // l binds none of the shared variables: compatible with every right
+    // binding (they cannot disagree on any shared position).
+    return right;
+  }
+  const out: TermBinding[] = [];
+  for (const r of index.byVar.get(bestVar)?.get(bestKey) ?? []) {
+    if (bindingsCompatible(l, r)) {
+      out.push(r);
+    }
+  }
+  for (const r of index.partials) {
+    if (r[bestVar] === undefined && bindingsCompatible(l, r)) {
+      out.push(r);
+    }
+  }
+  return out;
 }
 
 /**


### PR DESCRIPTION
## What

Issue #73: replaces the O(n·m) nested-loop merges in `innerJoin` (UNION branch joins), `leftJoin` (OPTIONAL), and `minus` with a **hash join** keyed on the shared variables (`src/evaluator/join.ts`).

## How it works

- The right side is indexed once (`buildHashIndex`): total bindings by their full key over the shared variables, plus per-variable buckets and a short list for partial bindings (OPTIONAL failures missing a shared variable — wildcards).
- Each left binding probes only its compatible candidates: total left bindings hit the exact bucket; partial left bindings probe their most selective bound variable's bucket and verify. SPARQL §18.2.2 multiset semantics are preserved (every compatible pair still merges; duplicates survive), and MINUS keeps the per-pair "shares a variable" rule — bindings sharing nothing are never eliminated.
- Joins with ≤ 4096 candidate pairs keep the nested loop — below that, hash-setup costs more than the scan it saves (existing small-query rows are unchanged).

## Measurements (10k-person dataset, 20 iterations + warmup)

| surface        | before    | after    | speedup |
| -------------- | --------- | -------- | ------- |
| UNION 10k×20k  | 7017 ms   | 59.4 ms  | ~118x   |
| OPTIONAL 10k×5k| 1841 ms   | 30.6 ms  | ~60x    |
| MINUS 10k×5k   | 1583 ms   | 20.5 ms  | ~77x    |

New `join-large` bench group tracks the same surface continuously in `deno task bench` (cross-verified vs comunica + oxigraph before timing); README Results gained the 10k join table.

## Verification

- New unit tests (`src/evaluator/join.test.ts`, 12 tests): homogeneous joins, multiset duplicates, wildcard compatibility, filters, chained-OPTIONAL heterogeneity, MINUS shares-rule — plus a property test forcing the hash path (100×100, product ≫ threshold) against a nested-loop reference.
- Full suite: **377 tests pass**; EXISTS gate 11/11; **W3C differential gate 345/345 (100%)**; budget gate passes; fmt/lint clean.

Closes #73