### PR TITLE
fix(test): fully substitute repeated blank-node placeholders in canonicalStoreQuads

### DIFF
--- a/test/parity/canonical-store.test.ts
+++ b/test/parity/canonical-store.test.ts
@@ -1,0 +1,55 @@
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { DataFactory } from "@/term/mod.ts";
+import { MemoryStore as Store } from "@/store/memory-store.ts";
+import { canonicalStoreQuads } from "./parity-harness.ts";
+
+const { blankNode, namedNode, quad } = DataFactory;
+const p = namedNode("http://example.org/p");
+const q = namedNode("http://example.org/q");
+const o = namedNode("http://example.org/o");
+
+function storeWith(...quads: ReturnType<typeof quad>[]): Store {
+  const store = new Store();
+  for (const item of quads) {
+    store.addQuad(item);
+  }
+  return store;
+}
+
+Deno.test("canonicalStoreQuads - repeated blank node in one quad is fully substituted", () => {
+  // The same blank node bound as subject and object renders the same
+  // placeholder twice; every occurrence must get the canonical id.
+  const a = storeWith(quad(blankNode("x"), p, blankNode("x")));
+  const b = storeWith(quad(blankNode("y"), p, blankNode("y")));
+  assertEquals(canonicalStoreQuads(a), canonicalStoreQuads(b));
+});
+
+Deno.test("canonicalStoreQuads - distinct nodes in one quad stay distinct", () => {
+  const a = storeWith(quad(blankNode("x"), p, blankNode("x")));
+  const b = storeWith(quad(blankNode("x"), p, blankNode("y")));
+  assertNotEquals(canonicalStoreQuads(a), canonicalStoreQuads(b));
+});
+
+Deno.test("canonicalStoreQuads - isomorphic multi-quad stores with relabeled blanks agree", () => {
+  const a = storeWith(
+    quad(blankNode("x"), p, blankNode("x")),
+    quad(blankNode("x"), q, o),
+  );
+  const b = storeWith(
+    quad(blankNode("zz"), p, blankNode("zz")),
+    quad(blankNode("zz"), q, o),
+  );
+  assertEquals(canonicalStoreQuads(a), canonicalStoreQuads(b));
+});
+
+Deno.test("canonicalStoreQuads - shared blank node across quads canonicalizes consistently", () => {
+  const a = storeWith(
+    quad(blankNode("x"), p, o),
+    quad(blankNode("x"), q, blankNode("x")),
+  );
+  const b = storeWith(
+    quad(blankNode("u"), p, o),
+    quad(blankNode("u"), q, blankNode("u")),
+  );
+  assertEquals(canonicalStoreQuads(a), canonicalStoreQuads(b));
+});

--- a/test/parity/parity-harness.ts
+++ b/test/parity/parity-harness.ts
@@ -442,7 +442,11 @@ export function canonicalStoreQuads(store: Store): string[] {
         id = `_:c${nextId++}`;
         canonicalIds.set(label, id);
       }
-      canonical = canonical.replace(`_:b${index}`, id);
+      // replaceAll (not replace): a quad may bind the same blank node in
+      // several positions (e.g. subject and object), rendering the same
+      // `_:b<index>` placeholder more than once — every occurrence must be
+      // substituted with the canonical id.
+      canonical = canonical.replaceAll(`_:b${index}`, id);
     }
     return canonical;
   });


### PR DESCRIPTION
## Audit find

Auditing the test harnesses after the inverted assertion in `join.test.ts` (`assertEquals(n, undefined)` asserting *presence*) surfaced one more latent issue in the same family: `canonicalStoreQuads` (`test/parity/parity-harness.ts`) substituted blank-node placeholders with `replace()`, which rewrites only the **first** occurrence. A quad binding the same blank node in several positions (e.g. subject **and** object) renders the same `_:b<index>` placeholder twice, so one occurrence stayed as a literal `_:b<index>` residue in the canonical string.

Behaviorally harmless today — the residue is deterministic per structure, so isomorphic stores still canonicalize identically — but incorrect by construction and a trap if the placeholder scheme ever changes. `replaceAll` substitutes every occurrence.

## Change

- `canonicalStoreQuads`: `replace` → `replaceAll` with a comment.
- New `test/parity/canonical-store.test.ts` (4 tests) pinning the contract: repeated-bnode full substitution, distinct nodes stay distinct, isomorphic multi-quad stores with relabeled blanks agree, and shared blank nodes across quads.

## Audit summary (what was checked and found sound)

- `compareMultisets`/`compareOrdered`/`compareVars` (parity) and `multisetEqual` (W3C runner): sorted-array / count-based multiset comparisons — correct.
- `canonicalizeBnodes` (W3C): Weisfeiler-Lehman partition refinement — an approximate isomorphism test, sound in practice for record sets.
- Bench `verifySelectEquality`: sorted-array multiset comparison; oxigraph canonicalization consistent with native.
- The `assertEquals(x, undefined)` sweep: every use is a legitimate *absence* assertion.
- SPARQL `REPLACE`: uses a global `RegExp` (`...g`), so all-occurrence semantics — not a bug.
- Documented-by-design difference (not changed): CONSTRUCT is compared as a **multiset** in the parity and bench harnesses but as a **set** in the W3C runner (spec: graphs are sets). The parity/bench layers are the stricter ones and catch spurious-duplicate regressions.

Verification: 381 tests pass, W3C gate 345/345, fmt/lint clean.