### PR TITLE
docs: fix site homepage and prev/next titles

### DIFF
--- a/docs/_includes/prev-next.html
+++ b/docs/_includes/prev-next.html
@@ -4,7 +4,8 @@
 {% for entry in nav %}
   {% if page.url == entry.url %}
     {% unless forloop.first %}
-      {% assign prev = nav[forloop.index0 | minus: 1] %}
+      {% assign prev_index = forloop.index0 | minus: 1 %}
+      {% assign prev = nav[prev_index] %}
     {% endunless %}
     {% unless forloop.last %}
       {% assign next = nav[forloop.index] %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+---
+title: Wiki Index
+layout: default
+---
+
+<meta http-equiv="refresh" content="0; url=README.html">
+
+The wiki index lives at [README.html](README.html).


### PR DESCRIPTION
Two live-site bugs found while verifying the published wiki:

1. **Homepage 404** — GitHub Pages did not enable `jekyll-readme-index` by default, so no `index.html` was generated and the site root returned 404. Added `docs/index.md` with an instant meta-refresh to the README index (no plugin dependency).

2. **Prev/next cards** — `nav[forloop.index0 | minus: 1]` is parsed by Liquid as `(nav[forloop.index0]) | minus: 1`, so every prev card rendered a bogus entry with an empty title. The index is now computed in a separate assign.

Verified: root → README index, all prev/next titles render, diagram rows stay tight, h1s have no number prefix.