### PR TITLE
docs: document library size and memory footprint with treemap diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,45 @@ sub-quadratic: the nested-loop before-state for the same UNION was ~7 s/iter
 versus 45 ms with the hash join (~150x), with OPTIONAL and MINUS showing the
 same shape (~60-80x).
 
+### Size & memory footprint
+
+The speed comparison is only half the story — engines also differ by orders of
+magnitude in what they cost to ship and to run. Two treemaps (area ∝ size)
+summarize both:
+
+**Library size on disk** — what a consumer must have installed:
+
+![Library size treemap](docs/assets/treemap-library-size.svg)
+
+| engine   | on disk      | contents                                                                                              |
+| -------- | ------------ | ----------------------------------------------------------------------------------------------------- |
+| native   | **0.67 MiB** | 38 source files (the whole JSR artifact: `src/` + `README.md` + `LICENSE`); zero runtime dependencies |
+| oxigraph | 7.9 MiB      | WASM runtime (7.8 MiB) + JS glue/types                                                                |
+| comunica | 28.3 MiB     | 368 npm packages in the transitive dependency closure                                                 |
+
+**Peak heap during execution** on the 10k-person graph (55k quads), measured in
+an isolated Deno subprocess per engine (peak `Deno.memoryUsage().heapUsed` over
+5 runs; all three share the same ~65 MB runtime baseline, so the comparison is
+symmetric):
+
+![Memory treemap](docs/assets/treemap-memory.svg)
+
+| workload             | native     | comunica | oxigraph |
+| -------------------- | ---------- | -------- | -------- |
+| full scan (55k rows) | **134 MB** | 214 MB   | 251 MB   |
+| nested EXISTS        | **82 MB**  | 271 MB   | 108 MB   |
+
+Native is the smallest on disk by 12-42x (0.67 vs 7.9 vs 28.3 MiB) and holds its
+speed advantage with the lowest peak heap on both workloads — including a peak
+roughly a third of comunica's on the nested-EXISTS surface the timings above
+highlight. Oxigraph's WASM runtime is compact on disk, but its result
+materialization peaks higher than native on both workloads.
+
+These are machine-specific snapshots (Deno 2.9.5, Windows), not guarantees.
+Regenerate them with `deno task bench:size` (library sizes, from the installed
+packages) and `deno task bench:memory` (peak memory, spawned per engine), which
+write the SVGs into `docs/assets/`.
+
 ## Development
 
 ```bash

--- a/bench/collect-memory.ts
+++ b/bench/collect-memory.ts
@@ -1,0 +1,64 @@
+// Runs the six per-engine memory probes (each in its own Deno process, so
+// only the target engine is loaded) and writes the merged bench/memory-data.json
+// consumed by bench/treemap.ts and the README.
+//
+// Run: deno run --allow-all --allow-write --allow-read bench/collect-memory.ts
+import { join } from "@std/path";
+
+const ENGINES = ["native", "comunica", "oxigraph"];
+const WORKLOADS = ["scan", "exists"] as const;
+
+const engines: Record<string, Record<string, unknown>> = {};
+for (const engine of ENGINES) {
+  engines[engine] = {};
+  for (const workload of WORKLOADS) {
+    const cmd = new Deno.Command(Deno.execPath(), {
+      args: [
+        "run",
+        "--allow-all",
+        join(Deno.cwd(), "bench", "memory-probe.ts"),
+        engine,
+        workload,
+      ],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const { code, stdout, stderr } = await cmd.output();
+    if (code !== 0) {
+      throw new Error(
+        `memory probe failed for ${engine}/${workload}:\n${
+          new TextDecoder().decode(stderr)
+        }`,
+      );
+    }
+    const probe = JSON.parse(new TextDecoder().decode(stdout)) as {
+      runs: number;
+      peak: { heapUsed: number; rss: number; external: number };
+    };
+    engines[engine][workload] = {
+      peakHeap: probe.peak.heapUsed,
+      peakRss: probe.peak.rss,
+      external: probe.peak.external,
+    };
+    console.error(
+      `${engine}/${workload}: peak heap ${
+        (probe.peak.heapUsed / 1048576).toFixed(1)
+      } MiB, ` +
+        `rss ${(probe.peak.rss / 1048576).toFixed(1)} MiB`,
+    );
+  }
+}
+
+const data = {
+  generatedAt: new Date().toISOString(),
+  runs: 5,
+  dataset: "10,000-person graph (~55,000 quads)",
+  measurement:
+    "isolated Deno subprocess per engine, Deno.memoryUsage() peak after each run",
+  engines,
+};
+Deno.writeTextFileSync(
+  join(Deno.cwd(), "bench", "memory-data.json"),
+  JSON.stringify(data, null, 2) + "\n",
+);
+console.error("wrote bench/memory-data.json");

--- a/bench/measure-libs.ts
+++ b/bench/measure-libs.ts
@@ -1,0 +1,258 @@
+// Library-size measurement for the README's size comparison. Measures what a
+// consumer must have on disk for each engine:
+//
+//   - native:  the JSR publish artifact (src/ + README.md + LICENSE), broken
+//              down by top-level module.
+//   - oxigraph: the installed npm package, broken down into the WASM binary
+//              vs the JS glue.
+//   - comunica: @comunica/query-sparql-rdfjs-lite plus its full transitive
+//              dependency closure, broken down by the root package's direct
+//              dependencies.
+//
+// Prints one JSON document to stdout; bench/treemap.ts consumes it.
+//
+// Run: deno run --allow-read bench/measure-libs.ts > bench/size-data.json
+import { join } from "@std/path";
+
+interface Sized {
+  name: string;
+  bytes: number;
+  children?: Sized[];
+}
+
+function dirBytes(dir: string): number {
+  let total = 0;
+  for (const entry of Deno.readDirSync(dir)) {
+    if (entry.isDirectory) {
+      total += dirBytes(join(dir, entry.name));
+    } else {
+      total += Deno.statSync(join(dir, entry.name)).size;
+    }
+  }
+  return total;
+}
+
+/* ------------------------------------------------------------------ */
+/* npm resolution through node_modules/.deno                          */
+/* ------------------------------------------------------------------ */
+
+const DENO_DIR = join(Deno.cwd(), "node_modules", ".deno");
+
+/** name -> highest installed version dir, from a scan of .deno. */
+const installed = new Map<string, string>();
+
+function scanInstalled(): void {
+  for (const entry of Deno.readDirSync(DENO_DIR)) {
+    // Key shape: `name@version` with scoped names flattened as `@scope+name`.
+    const at = entry.name.lastIndexOf("@");
+    if (at <= 0) {
+      continue;
+    }
+    const key = entry.name.slice(0, at);
+    const version = entry.name.slice(at + 1);
+    const name = key.includes("+") && key.startsWith("@")
+      ? key.replace("+", "/")
+      : key;
+    const dir = join(DENO_DIR, entry.name, "node_modules", name);
+    if (!dir.startsWith(DENO_DIR)) {
+      continue;
+    }
+    const existing = installed.get(name);
+    if (existing === undefined || version > existing.split("@").at(-1)!) {
+      installed.set(name, dir);
+    }
+  }
+}
+
+function measure(name: string): number {
+  const dir = installed.get(name);
+  if (dir === undefined) {
+    return 0;
+  }
+  const pkg = JSON.parse(Deno.readTextFileSync(join(dir, "package.json"))) as {
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+  const deps = [
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {}),
+  ];
+  return dirBytes(dir) + deps.reduce((sum, dep) => sum + measure(dep), 0);
+}
+
+function comunicaArtifact(): Sized {
+  const rootName = "@comunica/query-sparql-rdfjs-lite";
+  const rootDir = installed.get(rootName);
+  if (rootDir === undefined) {
+    throw new Error(`comunica not installed; run deno cache first`);
+  }
+  const rootPkg = JSON.parse(
+    Deno.readTextFileSync(join(rootDir, "package.json")),
+  ) as {
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+  };
+  const directDeps = [
+    ...Object.keys(rootPkg.dependencies ?? {}),
+    ...Object.keys(rootPkg.optionalDependencies ?? {}),
+  ];
+
+  // Cache each package's own bytes, then compute subtree sizes.
+  const self = new Map<string, number>();
+  const closure = new Set<string>();
+  const collect = (name: string): void => {
+    if (closure.has(name)) {
+      return;
+    }
+    closure.add(name);
+    const dir = installed.get(name);
+    if (dir === undefined) {
+      return;
+    }
+    self.set(name, dirBytes(dir));
+    const pkg = JSON.parse(
+      Deno.readTextFileSync(join(dir, "package.json")),
+    ) as {
+      dependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    };
+    for (
+      const dep of [
+        ...Object.keys(pkg.dependencies ?? {}),
+        ...Object.keys(pkg.optionalDependencies ?? {}),
+      ]
+    ) {
+      collect(dep);
+    }
+  };
+  collect(rootName);
+
+  const total = [...closure].reduce(
+    (sum, name) => sum + (self.get(name) ?? 0),
+    0,
+  );
+
+  // Exclusive attribution: each closure package belongs to the direct
+  // dependency that reaches it first (in directDeps order), so the child
+  // sets partition the closure — a valid treemap hierarchy that sums to
+  // the total.
+  const depsOf = new Map<string, string[]>();
+  for (const name of closure) {
+    const dir = installed.get(name);
+    if (dir === undefined) {
+      continue;
+    }
+    const pkg = JSON.parse(
+      Deno.readTextFileSync(join(dir, "package.json")),
+    ) as {
+      dependencies?: Record<string, string>;
+      optionalDependencies?: Record<string, string>;
+    };
+    depsOf.set(name, [
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.optionalDependencies ?? {}),
+    ]);
+  }
+  const attribution = new Map<string, string>(); // package -> owning direct dep
+  for (const dep of directDeps) {
+    const queue = [dep];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (attribution.has(current) || current === rootName) {
+        continue;
+      }
+      attribution.set(current, dep);
+      for (const next of depsOf.get(current) ?? []) {
+        queue.push(next);
+      }
+    }
+  }
+  const byOwner = new Map<string, number>();
+  for (const [name, owner] of attribution) {
+    byOwner.set(owner, (byOwner.get(owner) ?? 0) + (self.get(name) ?? 0));
+  }
+  const children = [...byOwner.entries()]
+    .map(([name, bytes]) => ({ name, bytes }))
+    .sort((a, b) => b.bytes - a.bytes);
+  console.error(
+    `comunica closure: ${closure.size} packages, ${total} bytes on disk`,
+  );
+  return { name: "comunica", bytes: total, children };
+}
+
+/* ------------------------------------------------------------------ */
+/* native + oxigraph                                                  */
+/* ------------------------------------------------------------------ */
+
+function nativeArtifact(): Sized {
+  const src = join(Deno.cwd(), "src");
+  const subtractTests = (dir: string): number => {
+    let sum = 0;
+    for (const entry of Deno.readDirSync(dir)) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory) {
+        sum += subtractTests(path);
+      } else if (entry.name.endsWith(".test.ts")) {
+        sum += Deno.statSync(path).size;
+      }
+    }
+    return sum;
+  };
+  const children: Sized[] = [];
+  let total = 0;
+  for (const entry of Deno.readDirSync(src)) {
+    if (!entry.isDirectory) {
+      continue;
+    }
+    const net = dirBytes(join(src, entry.name)) -
+      subtractTests(join(src, entry.name));
+    children.push({ name: entry.name, bytes: net });
+    total += net;
+  }
+  const readmeBytes = Deno.statSync(join(Deno.cwd(), "README.md")).size;
+  const licenseBytes = Deno.statSync(join(Deno.cwd(), "LICENSE")).size;
+  children.push({ name: "README.md", bytes: readmeBytes });
+  children.push({ name: "LICENSE", bytes: licenseBytes });
+  total += readmeBytes + licenseBytes;
+  return { name: "native", bytes: total, children };
+}
+
+function oxigraphArtifact(): Sized {
+  const dir = installed.get("oxigraph");
+  if (dir === undefined) {
+    throw new Error(`oxigraph not installed; run deno cache first`);
+  }
+  let wasm = 0;
+  let glue = 0;
+  const walk = (d: string): void => {
+    for (const entry of Deno.readDirSync(d)) {
+      const path = join(d, entry.name);
+      if (entry.isDirectory) {
+        walk(path);
+      } else {
+        const size = Deno.statSync(path).size;
+        if (entry.name.endsWith(".wasm")) {
+          wasm += size;
+        } else {
+          glue += size;
+        }
+      }
+    }
+  };
+  walk(dir);
+  return {
+    name: "oxigraph",
+    bytes: wasm + glue,
+    children: [
+      { name: "WASM runtime", bytes: wasm },
+      { name: "JS glue + types", bytes: glue },
+    ],
+  };
+}
+
+scanInstalled();
+const result = {
+  generatedAt: new Date().toISOString(),
+  engines: [nativeArtifact(), oxigraphArtifact(), comunicaArtifact()],
+};
+console.log(JSON.stringify(result, null, 2));

--- a/bench/memory-data.json
+++ b/bench/memory-data.json
@@ -1,0 +1,44 @@
+{
+  "generatedAt": "2026-08-14T17:05:36.921Z",
+  "runs": 5,
+  "dataset": "10,000-person graph (~55,000 quads)",
+  "measurement": "isolated Deno subprocess per engine, Deno.memoryUsage() peak after each run",
+  "engines": {
+    "native": {
+      "scan": {
+        "peakHeap": 140895480,
+        "peakRss": 263184384,
+        "external": 317663
+      },
+      "exists": {
+        "peakHeap": 85451920,
+        "peakRss": 185733120,
+        "external": 317663
+      }
+    },
+    "comunica": {
+      "scan": {
+        "peakHeap": 224656320,
+        "peakRss": 376680448,
+        "external": 1703597
+      },
+      "exists": {
+        "peakHeap": 284281656,
+        "peakRss": 418705408,
+        "external": 2735597
+      }
+    },
+    "oxigraph": {
+      "scan": {
+        "peakHeap": 262769344,
+        "peakRss": 506744832,
+        "external": 954855
+      },
+      "exists": {
+        "peakHeap": 113574760,
+        "peakRss": 290107392,
+        "external": 954855
+      }
+    }
+  }
+}

--- a/bench/memory-probe.ts
+++ b/bench/memory-probe.ts
@@ -1,0 +1,177 @@
+// Peak-memory measurement for the README's memory comparison. Each engine
+// runs in its own process (the probe is spawned per engine, so only the
+// target engine is loaded), executes the workload several times, and reports
+// the peak heap/RSS observed.
+//
+//   deno run --allow-all bench/memory-probe.ts <native|comunica|oxigraph> <scan|exists>
+//
+// Prints one JSON document to stdout.
+import type * as rdfjs from "@rdfjs/types";
+import { DataFactory } from "@/term/mod.ts";
+import { MemoryStore as Store } from "@/store/memory-store.ts";
+
+const { blankNode, literal, namedNode, quad } = DataFactory;
+
+const PERSON_COUNT = 10_000;
+const foafName = namedNode("http://xmlns.com/foaf/0.1/name");
+const foafAge = namedNode("http://xmlns.com/foaf/0.1/age");
+const examplePet = namedNode("http://example.org/pet");
+const exCity = namedNode("http://example.org/city");
+const exSpouse = namedNode("http://example.org/spouse");
+const examplePerson = (index: number) =>
+  namedNode(`http://example.org/person${index}`);
+
+function buildPeopleDataset(count: number): rdfjs.Quad[] {
+  const quads: rdfjs.Quad[] = [];
+  for (let index = 0; index < count; index++) {
+    const person = examplePerson(index);
+    quads.push(quad(person, foafName, literal(`Person ${index}`)));
+    quads.push(quad(person, foafAge, literal(`${20 + (index % 50)}`)));
+    quads.push(quad(person, examplePet, blankNode(`pet-${index}`)));
+    quads.push(
+      quad(
+        person,
+        namedNode("http://xmlns.com/foaf/0.1/knows"),
+        examplePerson((index + 1) % count),
+      ),
+    );
+    quads.push(quad(person, exCity, literal(`City ${index % 5}`)));
+    if (index % 2 === 0) {
+      quads.push(quad(person, exSpouse, examplePerson(index + 1)));
+    }
+  }
+  return quads;
+}
+
+const SCAN_QUERY = "SELECT ?s ?p ?o WHERE { ?s ?p ?o }";
+const NESTED_EXISTS_QUERY =
+  "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> ?n " +
+  "FILTER EXISTS { ?s <http://example.org/spouse> ?spouse . " +
+  "FILTER EXISTS { ?spouse <http://xmlns.com/foaf/0.1/name> ?n2 } } }";
+
+const engine = Deno.args[0];
+const workload = Deno.args[1];
+if (engine !== "native" && engine !== "comunica" && engine !== "oxigraph") {
+  throw new Error(`unknown engine: ${engine}`);
+}
+if (workload !== "scan" && workload !== "exists") {
+  throw new Error(`unknown workload: ${workload}`);
+}
+const query = workload === "scan" ? SCAN_QUERY : NESTED_EXISTS_QUERY;
+const RUNS = 5;
+
+const dataset = buildPeopleDataset(PERSON_COUNT);
+const baseline = Deno.memoryUsage();
+
+let peakHeap = baseline.heapUsed;
+let peakRss = baseline.rss;
+let peakExternal = baseline.external;
+const observe = (): void => {
+  const m = Deno.memoryUsage();
+  peakHeap = Math.max(peakHeap, m.heapUsed);
+  peakRss = Math.max(peakRss, m.rss);
+  peakExternal = Math.max(peakExternal, m.external);
+};
+
+async function runWorkload(): Promise<void> {
+  if (engine === "native") {
+    const store = new Store();
+    for (const q of dataset) {
+      store.addQuad(q);
+    }
+    const { WazooSparqlEngine } = await import("@/wazoo-sparql-engine.ts");
+    const nativeEngine = new WazooSparqlEngine({ store });
+    for (let i = 0; i < RUNS; i++) {
+      const result = await nativeEngine.execute({ query });
+      if (result.kind !== "select") {
+        throw new Error(`native returned ${result.kind}`);
+      }
+      observe();
+    }
+    return;
+  }
+  if (engine === "comunica") {
+    const store = new Store();
+    for (const q of dataset) {
+      store.addQuad(q);
+    }
+    const { QueryEngine } = await import(
+      "@comunica/query-sparql-rdfjs-lite"
+    );
+    const comunicaEngine = new QueryEngine();
+    for (let i = 0; i < RUNS; i++) {
+      const stream = await comunicaEngine.queryBindings(query, {
+        sources: [store],
+      });
+      const bindings = await stream.toArray();
+      if (bindings.length === 0) {
+        throw new Error(`comunica returned no bindings`);
+      }
+      observe();
+    }
+    return;
+  }
+  // oxigraph
+  const ox = await import("oxigraph");
+  const toOxigraphTerm = (term: rdfjs.Term): unknown => {
+    switch (term.termType) {
+      case "NamedNode":
+        return ox.namedNode(term.value);
+      case "BlankNode":
+        return ox.blankNode(term.value);
+      case "Literal": {
+        const literalTerm = term as rdfjs.Literal;
+        if (literalTerm.language) {
+          return ox.literal(literalTerm.value, literalTerm.language);
+        }
+        if (literalTerm.datatype) {
+          return ox.literal(
+            literalTerm.value,
+            ox.namedNode(literalTerm.datatype.value),
+          );
+        }
+        return ox.literal(literalTerm.value);
+      }
+      case "DefaultGraph":
+        return ox.defaultGraph();
+      default:
+        throw new Error(`unsupported term type: ${term.termType}`);
+    }
+  };
+  const toOxigraphQuad = (item: rdfjs.Quad): unknown =>
+    ox.quad(
+      toOxigraphTerm(item.subject) as never,
+      toOxigraphTerm(item.predicate) as never,
+      toOxigraphTerm(item.object) as never,
+      toOxigraphTerm(item.graph) as never,
+    );
+  const store = new ox.Store();
+  for (const q of dataset) {
+    store.add(toOxigraphQuad(q) as never);
+  }
+  for (let i = 0; i < RUNS; i++) {
+    const result = store.query(query) as unknown[];
+    if (result.length === 0) {
+      throw new Error(`oxigraph returned no bindings`);
+    }
+    observe();
+  }
+}
+
+await runWorkload();
+console.log(
+  JSON.stringify({
+    engine,
+    workload,
+    runs: RUNS,
+    baseline: {
+      heapUsed: baseline.heapUsed,
+      rss: baseline.rss,
+    },
+    peak: {
+      heapUsed: peakHeap,
+      rss: peakRss,
+      external: peakExternal,
+    },
+  }),
+);

--- a/bench/size-data.json
+++ b/bench/size-data.json
@@ -1,0 +1,783 @@
+{
+  "generatedAt": "2026-08-14T17:04:07.834Z",
+  "engines": [
+    {
+      "name": "native",
+      "bytes": 701090,
+      "children": [
+        {
+          "name": "evaluator",
+          "bytes": 231406
+        },
+        {
+          "name": "parser",
+          "bytes": 390015
+        },
+        {
+          "name": "store",
+          "bytes": 24159
+        },
+        {
+          "name": "term",
+          "bytes": 41277
+        },
+        {
+          "name": "README.md",
+          "bytes": 13158
+        },
+        {
+          "name": "LICENSE",
+          "bytes": 1075
+        }
+      ]
+    },
+    {
+      "name": "oxigraph",
+      "bytes": 8275583,
+      "children": [
+        {
+          "name": "WASM runtime",
+          "bytes": 8136195
+        },
+        {
+          "name": "JS glue + types",
+          "bytes": 139388
+        }
+      ]
+    },
+    {
+      "name": "comunica",
+      "bytes": 29693164,
+      "children": [
+        {
+          "name": "@comunica/actor-bindings-aggregator-factory-average",
+          "bytes": 14089783
+        },
+        {
+          "name": "@comunica/actor-init-query",
+          "bytes": 8283471
+        },
+        {
+          "name": "@comunica/actor-query-parse-sparql",
+          "bytes": 631259
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-addition",
+          "bytes": 527307
+        },
+        {
+          "name": "@comunica/actor-expression-evaluator-factory-default",
+          "bytes": 225179
+        },
+        {
+          "name": "@comunica/actor-query-operation-join",
+          "bytes": 181369
+        },
+        {
+          "name": "@comunica/actor-query-operation-path-alt",
+          "bytes": 175846
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-str-uuid",
+          "bytes": 164503
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-group-file-sources",
+          "bytes": 114610
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-filter-pushdown",
+          "bytes": 105850
+        },
+        {
+          "name": "@comunica/actor-query-source-identify-rdfjs",
+          "bytes": 80680
+        },
+        {
+          "name": "@comunica/actor-rdf-join-inner-hash",
+          "bytes": 77052
+        },
+        {
+          "name": "@comunica/actor-query-operation-update-clear",
+          "bytes": 76265
+        },
+        {
+          "name": "@comunica/actor-query-operation-orderby",
+          "bytes": 74012
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-sha1",
+          "bytes": 68025
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-md5",
+          "bytes": 65898
+        },
+        {
+          "name": "@comunica/actor-rdf-join-inner-multi-bind",
+          "bytes": 65397
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-query-source-skolemize",
+          "bytes": 64714
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-assign-sources-exhaustive",
+          "bytes": 57669
+        },
+        {
+          "name": "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings",
+          "bytes": 57116
+        },
+        {
+          "name": "@comunica/actor-rdf-join-selectivity-variable-counting",
+          "bytes": 56764
+        },
+        {
+          "name": "@comunica/actor-context-preprocess-convert-shortcuts",
+          "bytes": 55072
+        },
+        {
+          "name": "@comunica/actor-query-operation-group",
+          "bytes": 55069
+        },
+        {
+          "name": "@comunica/actor-query-operation-from-quad",
+          "bytes": 52497
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-prune-empty-source-operations",
+          "bytes": 51629
+        },
+        {
+          "name": "@comunica/actor-rdf-join-inner-multi-bind-source",
+          "bytes": 51341
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-query-source-identify",
+          "bytes": 49003
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-group-sources",
+          "bytes": 46261
+        },
+        {
+          "name": "@comunica/actor-hash-bindings-murmur",
+          "bytes": 46082
+        },
+        {
+          "name": "@comunica/actor-rdf-join-optional-hash",
+          "bytes": 43203
+        },
+        {
+          "name": "@comunica/actor-query-operation-construct",
+          "bytes": 42759
+        },
+        {
+          "name": "@comunica/actor-query-process-sequential",
+          "bytes": 42024
+        },
+        {
+          "name": "@comunica/actor-rdf-join-inner-multi-smallest",
+          "bytes": 40221
+        },
+        {
+          "name": "@comunica/actor-rdf-join-optional-bind",
+          "bytes": 40063
+        },
+        {
+          "name": "@comunica/actor-query-operation-path-one-or-more",
+          "bytes": 38833
+        },
+        {
+          "name": "@comunica/actor-term-comparator-factory-expression-evaluator",
+          "bytes": 38375
+        },
+        {
+          "name": "@comunica/actor-query-operation-path-zero-or-more",
+          "bytes": 38290
+        },
+        {
+          "name": "@comunica/actor-hash-quads-murmur",
+          "bytes": 38148
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-bnode",
+          "bytes": 35557
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-lesser-than",
+          "bytes": 35446
+        },
+        {
+          "name": "@comunica/actor-bindings-aggregator-factory-wildcard-count",
+          "bytes": 34961
+        },
+        {
+          "name": "@comunica/actor-query-operation-update-deleteinsert",
+          "bytes": 34198
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-regex",
+          "bytes": 34082
+        },
+        {
+          "name": "@comunica/actor-bindings-aggregator-factory-sum",
+          "bytes": 34040
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-distinct-terms-pushdown",
+          "bytes": 33887
+        },
+        {
+          "name": "@comunica/mediator-join-coefficients-fixed",
+          "bytes": 33671
+        },
+        {
+          "name": "@comunica/actor-bindings-aggregator-factory-group-concat",
+          "bytes": 32998
+        },
+        {
+          "name": "@comunica/actor-query-operation-path-zero-or-one",
+          "bytes": 32870
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-equality",
+          "bytes": 32390
+        },
+        {
+          "name": "@comunica/actor-bindings-aggregator-factory-max",
+          "bytes": 31899
+        },
+        {
+          "name": "@comunica/actor-bindings-aggregator-factory-min",
+          "bytes": 31897
+        },
+        {
+          "name": "@comunica/actor-rdf-join-minus-hash",
+          "bytes": 31825
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-replace",
+          "bytes": 31228
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-join-connected",
+          "bytes": 31043
+        },
+        {
+          "name": "@comunica/actor-rdf-update-quads-rdfjs-store",
+          "bytes": 30989
+        },
+        {
+          "name": "@comunica/actor-query-operation-distinct-identity",
+          "bytes": 30838
+        },
+        {
+          "name": "@comunica/actor-query-operation-update-load",
+          "bytes": 30667
+        },
+        {
+          "name": "@comunica/actor-query-operation-extend",
+          "bytes": 30266
+        },
+        {
+          "name": "@comunica/actor-query-operation-reduced-hash",
+          "bytes": 30082
+        },
+        {
+          "name": "@comunica/actor-query-operation-filter",
+          "bytes": 29352
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-subtraction",
+          "bytes": 29133
+        },
+        {
+          "name": "@comunica/actor-query-operation-project",
+          "bytes": 29018
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-lesser-than-equal",
+          "bytes": 28808
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-describe-to-constructs-subject",
+          "bytes": 28654
+        },
+        {
+          "name": "@comunica/actor-query-operation-path-seq",
+          "bytes": 28565
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-in",
+          "bytes": 28533
+        },
+        {
+          "name": "@comunica/actor-bindings-aggregator-factory-count",
+          "bytes": 28417
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-concat",
+          "bytes": 27588
+        },
+        {
+          "name": "@comunica/actor-query-operation-source",
+          "bytes": 27572
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-sub-str",
+          "bytes": 27539
+        },
+        {
+          "name": "@comunica/actor-query-operation-slice",
+          "bytes": 27536
+        },
+        {
+          "name": "@comunica/actor-rdf-join-inner-symmetrichash",
+          "bytes": 27149
+        },
+        {
+          "name": "@comunica/actor-bindings-aggregator-factory-sample",
+          "bytes": 27146
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-extensions",
+          "bytes": 27099
+        },
+        {
+          "name": "@comunica/actor-query-operation-leftjoin",
+          "bytes": 26987
+        },
+        {
+          "name": "@comunica/actor-query-operation-values",
+          "bytes": 26920
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown",
+          "bytes": 26917
+        },
+        {
+          "name": "@comunica/actor-context-preprocess-set-defaults",
+          "bytes": 26777
+        },
+        {
+          "name": "@comunica/actor-rdf-join-inner-none",
+          "bytes": 26314
+        },
+        {
+          "name": "@comunica/actor-query-operation-update-drop",
+          "bytes": 25922
+        },
+        {
+          "name": "@comunica/actor-query-operation-nop",
+          "bytes": 25907
+        },
+        {
+          "name": "@comunica/actor-rdf-metadata-accumulate-cardinality",
+          "bytes": 25808
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-not-in",
+          "bytes": 25433
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-langmatches",
+          "bytes": 25411
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-greater-than-equal",
+          "bytes": 25189
+        },
+        {
+          "name": "@comunica/actor-query-operation-minus",
+          "bytes": 25119
+        },
+        {
+          "name": "@comunica/actor-query-operation-update-create",
+          "bytes": 24753
+        },
+        {
+          "name": "@comunica/actor-query-operation-nodes",
+          "bytes": 24664
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-logical-and",
+          "bytes": 24643
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-inequality",
+          "bytes": 24627
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-greater-than",
+          "bytes": 24567
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-logical-or",
+          "bytes": 24535
+        },
+        {
+          "name": "@comunica/actor-rdf-join-entries-sort-selectivity",
+          "bytes": 24513
+        },
+        {
+          "name": "@comunica/actor-rdf-join-inner-multi-empty",
+          "bytes": 23865
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-year-month-duration",
+          "bytes": 23680
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-str-before",
+          "bytes": 23660
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-decimal",
+          "bytes": 23567
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-rewrite-move",
+          "bytes": 23556
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-str-after",
+          "bytes": 23547
+        },
+        {
+          "name": "@comunica/actor-rdf-join-optional-nestedloop",
+          "bytes": 23520
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-boolean",
+          "bytes": 23515
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-day-time-duration",
+          "bytes": 23458
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-integer",
+          "bytes": 23419
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-same-term",
+          "bytes": 23388
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-rewrite-copy",
+          "bytes": 23228
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-bound",
+          "bytes": 23187
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-rewrite-add",
+          "bytes": 23091
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-str-langdir",
+          "bytes": 23046
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-coalesce",
+          "bytes": 22983
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-timezone",
+          "bytes": 22926
+        },
+        {
+          "name": "@comunica/actor-query-operation-update-compositeupdate",
+          "bytes": 22920
+        },
+        {
+          "name": "@comunica/actor-rdf-join-inner-nestedloop",
+          "bytes": 22727
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-datetime",
+          "bytes": 22614
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-double",
+          "bytes": 22612
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-float",
+          "bytes": 22519
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-duration",
+          "bytes": 22449
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-iri",
+          "bytes": 22336
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-str-dt",
+          "bytes": 22314
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-triple",
+          "bytes": 22235
+        },
+        {
+          "name": "@comunica/actor-function-factory-expression-if",
+          "bytes": 22220
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-division",
+          "bytes": 22174
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-string",
+          "bytes": 22159
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-uuid",
+          "bytes": 22151
+        },
+        {
+          "name": "@comunica/actor-query-operation-path-nps",
+          "bytes": 22095
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-time",
+          "bytes": 22022
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-xsd-to-date",
+          "bytes": 21933
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-str-lang",
+          "bytes": 21849
+        },
+        {
+          "name": "@comunica/actor-query-operation-bgp-join",
+          "bytes": 21842
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-construct-distinct",
+          "bytes": 21831
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-str-starts",
+          "bytes": 21783
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-lcase",
+          "bytes": 21667
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-ucase",
+          "bytes": 21665
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-multiplication",
+          "bytes": 21615
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-encode-for-uri",
+          "bytes": 21477
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-seconds",
+          "bytes": 21443
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-minutes",
+          "bytes": 21431
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-has-langdir",
+          "bytes": 21337
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-is-numeric",
+          "bytes": 21311
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-now",
+          "bytes": 21305
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-hours",
+          "bytes": 21235
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-month",
+          "bytes": 21235
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-has-lang",
+          "bytes": 21196
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-is-literal",
+          "bytes": 21175
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-tz",
+          "bytes": 21168
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-year",
+          "bytes": 21130
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-is-triple",
+          "bytes": 21124
+        },
+        {
+          "name": "@comunica/actor-query-operation-ask",
+          "bytes": 21089
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-contains",
+          "bytes": 21082
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-predicate",
+          "bytes": 21077
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-sha256",
+          "bytes": 21040
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-sha384",
+          "bytes": 21040
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-sha512",
+          "bytes": 21040
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-str-ends",
+          "bytes": 21017
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-day",
+          "bytes": 21015
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-datatype",
+          "bytes": 21006
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-is-blank",
+          "bytes": 20969
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-unary-minus",
+          "bytes": 20920
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-langdir",
+          "bytes": 20895
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-str-len",
+          "bytes": 20884
+        },
+        {
+          "name": "@comunica/actor-rdf-join-inner-single",
+          "bytes": 20871
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-subject",
+          "bytes": 20861
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-is-iri",
+          "bytes": 20855
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-unary-plus",
+          "bytes": 20812
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-object",
+          "bytes": 20756
+        },
+        {
+          "name": "@comunica/actor-query-operation-path-link",
+          "bytes": 20697
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-join-bgp",
+          "bytes": 20692
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-floor",
+          "bytes": 20632
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-round",
+          "bytes": 20632
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-lang",
+          "bytes": 20596
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-rand",
+          "bytes": 20582
+        },
+        {
+          "name": "@comunica/actor-context-preprocess-source-to-destination",
+          "bytes": 20573
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-ceil",
+          "bytes": 20525
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-str",
+          "bytes": 20464
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-abs",
+          "bytes": 20416
+        },
+        {
+          "name": "@comunica/actor-rdf-metadata-accumulate-requesttime",
+          "bytes": 20386
+        },
+        {
+          "name": "@comunica/actor-query-operation-path-inv",
+          "bytes": 20311
+        },
+        {
+          "name": "@comunica/actor-function-factory-term-not",
+          "bytes": 20292
+        },
+        {
+          "name": "@comunica/actor-optimize-query-operation-bgp-to-join",
+          "bytes": 20173
+        },
+        {
+          "name": "@comunica/actor-rdf-join-entries-sort-cardinality",
+          "bytes": 20150
+        },
+        {
+          "name": "@comunica/actor-rdf-metadata-accumulate-pagesize",
+          "bytes": 20113
+        },
+        {
+          "name": "@comunica/mediator-all",
+          "bytes": 16374
+        },
+        {
+          "name": "@comunica/logger-void",
+          "bytes": 8003
+        }
+      ]
+    }
+  ]
+}

--- a/bench/treemap.ts
+++ b/bench/treemap.ts
@@ -1,0 +1,357 @@
+// Treemap SVG generator for the README's size & memory comparison.
+//
+// Reads bench/size-data.json (from bench/measure-libs.ts) and
+// bench/memory-data.json (from bench/memory-probe.ts) and writes:
+//
+//   docs/assets/treemap-library-size.svg
+//   docs/assets/treemap-memory.svg
+//
+// Run: deno run --allow-read --allow-write bench/treemap.ts
+import { join } from "@std/path";
+
+interface Sized {
+  name: string;
+  bytes: number;
+  children?: Sized[];
+}
+
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/* ------------------------------------------------------------------ */
+/* Squarified treemap layout (Bruls, Huizing, van Wijk 2000)          */
+/* ------------------------------------------------------------------ */
+
+interface Placed {
+  name: string;
+  rect: Rect;
+  color: string;
+  valueText: string;
+  children?: Placed[];
+  /** panel renders a titled container (no fill rect) around its children. */
+  panel?: string;
+}
+
+const COLORS = ["#2f9e44", "#1971c2", "#f08c00"]; // native, oxigraph, comunica
+
+function worst(row: { bytes: number }[], rect: Rect): number {
+  const total = row.reduce((s, i) => s + i.bytes, 0);
+  const rowW = total / rect.h; // strip width (vertical slice)
+  let worst = -Infinity;
+  for (const item of row) {
+    const w = item.bytes / rect.h;
+    const ratio = Math.max(w / rowW, rowW / w);
+    worst = Math.max(worst, ratio);
+  }
+  return worst;
+}
+
+function squarifyRow(
+  row: { bytes: number }[],
+  rect: Rect,
+): { placed: Rect[]; remainder: Rect } {
+  const total = row.reduce((s, i) => s + i.bytes, 0);
+  if (rect.w >= rect.h) {
+    const rowW = total / rect.h;
+    const placed: Rect[] = [];
+    let y = rect.y;
+    for (const item of row) {
+      const h = item.bytes / rowW;
+      placed.push({ x: rect.x, y, w: rowW, h });
+      y += h;
+    }
+    return {
+      placed,
+      remainder: { x: rect.x + rowW, y: rect.y, w: rect.w - rowW, h: rect.h },
+    };
+  }
+  const rowH = total / rect.w;
+  const placed: Rect[] = [];
+  let x = rect.x;
+  for (const item of row) {
+    const w = item.bytes / rowH;
+    placed.push({ x, y: rect.y, w, h: rowH });
+    x += w;
+  }
+  return {
+    placed,
+    remainder: { x: rect.x, y: rect.y + rowH, w: rect.w, h: rect.h - rowH },
+  };
+}
+
+function squarify(
+  items: { name: string; bytes: number }[],
+  rect: Rect,
+): { name: string; rect: Rect }[] {
+  // Normalize the item weights to the rect's pixel area so the squarified
+  // rows tile it exactly.
+  const total = items.reduce((s, i) => s + i.bytes, 0);
+  const scale = total === 0 ? 1 : (rect.w * rect.h) / total;
+  const scaled = items.map((item) => ({
+    name: item.name,
+    bytes: item.bytes * scale,
+  }));
+  const sorted = [...scaled].sort((a, b) => b.bytes - a.bytes);
+  const result: { name: string; rect: Rect }[] = [];
+  let remaining = { ...rect };
+  let index = 0;
+  while (index < sorted.length) {
+    const row: { name: string; bytes: number }[] = [];
+    row.push(sorted[index++]);
+    while (index < sorted.length) {
+      const current = worst(row, remaining);
+      const extended = worst([...row, sorted[index]], remaining);
+      if (extended <= current) {
+        row.push(sorted[index++]);
+      } else {
+        break;
+      }
+    }
+    const { placed, remainder } = squarifyRow(row, remaining);
+    for (let i = 0; i < row.length; i++) {
+      result.push({ name: row[i].name, rect: placed[i] });
+    }
+    remaining = remainder;
+  }
+  return result;
+}
+
+/* ------------------------------------------------------------------ */
+/* SVG rendering                                                      */
+/* ------------------------------------------------------------------ */
+
+function fmtBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${(bytes / 1048576).toFixed(2)} MiB`;
+  }
+  return `${(bytes / 1024).toFixed(0)} KiB`;
+}
+
+function esc(text: string): string {
+  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(
+    ">",
+    "&gt;",
+  );
+}
+
+function renderNode(
+  node: Placed,
+  depth: number,
+  parts: string[],
+): void {
+  const { x, y, w, h } = node.rect;
+  if (node.panel !== undefined) {
+    parts.push(
+      `<rect x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${w.toFixed(1)}" ` +
+        `height="${
+          h.toFixed(1)
+        }" fill="#f1f3f5" stroke="#dee2e6" stroke-width="1"/>`,
+    );
+    parts.push(
+      `<text x="${(x + 6).toFixed(1)}" y="${(y + 16).toFixed(1)}" ` +
+        `font-family="sans-serif" font-size="10" font-weight="bold" fill="#495057">` +
+        `${esc(node.panel)}</text>`,
+    );
+    for (const child of node.children ?? []) {
+      renderNode(child, depth + 1, parts);
+    }
+    return;
+  }
+  parts.push(
+    `<rect x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${w.toFixed(1)}" ` +
+      `height="${
+        h.toFixed(1)
+      }" fill="${node.color}" stroke="#ffffff" stroke-width="1"/>`,
+  );
+  const label = `${node.name} (${node.valueText})`;
+  const fits = w > label.length * 5.5 && h > 12;
+  if (fits) {
+    parts.push(
+      `<text x="${(x + w / 2).toFixed(1)}" y="${(y + h / 2 + 3).toFixed(1)}" ` +
+        `text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">` +
+        `${esc(node.name)}<tspan x="${(x + w / 2).toFixed(1)}" dy="12" ` +
+        `font-size="8" fill="#ffffffcc">${esc(node.valueText)}</tspan></text>`,
+    );
+  } else if (w > 2 && h > 2) {
+    parts.push(
+      `<text x="${(x + w / 2).toFixed(1)}" y="${(y - 3).toFixed(1)}" ` +
+        `text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">` +
+        `${esc(label)}</text>`,
+    );
+  }
+  for (const child of node.children ?? []) {
+    renderNode(child, depth + 1, parts);
+  }
+}
+
+function treemapSvg(
+  title: string,
+  subtitle: string,
+  roots: Placed[],
+  width = 720,
+  height = 320,
+): string {
+  const parts: string[] = [];
+  parts.push(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" ` +
+      `font-family="sans-serif"><rect width="${width}" height="${height}" fill="#f8f9fa"/>`,
+  );
+  parts.push(
+    `<text x="12" y="20" font-size="13" font-weight="bold" fill="#212529">` +
+      `${esc(title)}</text>`,
+  );
+  parts.push(
+    `<text x="12" y="34" font-size="9" fill="#868e96">${esc(subtitle)}</text>`,
+  );
+  for (const root of roots) {
+    renderNode(root, 0, parts);
+  }
+  parts.push("</svg>");
+  return parts.join("\n");
+}
+
+/* ------------------------------------------------------------------ */
+/* Data -> placed trees                                               */
+/* ------------------------------------------------------------------ */
+
+function sizeTree(): Placed[] {
+  const data = JSON.parse(
+    Deno.readTextFileSync(join(Deno.cwd(), "bench", "size-data.json")),
+  ) as { engines: Sized[] };
+  const rootRect: Rect = { x: 12, y: 44, w: 696, h: 264 };
+  const engines = [...data.engines].sort((a, b) => b.bytes - a.bytes);
+  const roots: Placed[] = [];
+  const top: Placed[] = [];
+  const laidOut = squarify(
+    engines.map((e) => ({ name: e.name, bytes: e.bytes })),
+    rootRect,
+  );
+  for (let i = 0; i < engines.length; i++) {
+    const engine = engines[i];
+    const rect = laidOut.find((l) => l.name === engine.name)!.rect;
+    const children = engine.children ?? [];
+    const capped = children.slice(0, 8);
+    const otherBytes = children
+      .slice(8)
+      .reduce((s, c) => s + c.bytes, 0);
+    const items = otherBytes > 0
+      ? [...capped, { name: "other deps", bytes: otherBytes }]
+      : capped;
+    const childLayout = squarify(items, {
+      x: rect.x + 2,
+      y: rect.y + 2,
+      w: Math.max(rect.w - 4, 1),
+      h: Math.max(rect.h - 4, 1),
+    });
+    const childPlaced: Placed[] = [];
+    for (const layout of childLayout) {
+      const item = items.find((it) => it.name === layout.name)!;
+      childPlaced.push({
+        name: layout.name,
+        rect: layout.rect,
+        color: shade(COLORS[i], 0.65),
+        valueText: fmtBytes(item.bytes),
+      });
+    }
+    roots.push({
+      name: engine.name,
+      rect,
+      color: COLORS[i],
+      valueText: fmtBytes(engine.bytes),
+      children: childPlaced,
+    });
+  }
+  void top;
+  return roots;
+}
+
+/** shade mixes a hex color toward white by `amount`. */
+function shade(hex: string, amount: number): string {
+  const n = parseInt(hex.slice(1), 16);
+  const r = Math.round(((n >> 16) & 255) + (255 - ((n >> 16) & 255)) * amount);
+  const g = Math.round(((n >> 8) & 255) + (255 - ((n >> 8) & 255)) * amount);
+  const b = Math.round((n & 255) + (255 - (n & 255)) * amount);
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, "0")}`;
+}
+
+function memoryTree(): Placed[] {
+  const data = JSON.parse(
+    Deno.readTextFileSync(join(Deno.cwd(), "bench", "memory-data.json")),
+  ) as {
+    engines: Record<
+      string,
+      { scan: { peakHeap: number }; exists: { peakHeap: number } }
+    >;
+  };
+  const names = ["native", "comunica", "oxigraph"];
+  const workloads = ["scan", "exists"] as const;
+  const labels: Record<string, string> = {
+    scan: "full scan (55k rows materialized)",
+    exists: "nested EXISTS",
+  };
+  const panelW = 348;
+  const roots: Placed[] = [];
+  for (let wi = 0; wi < workloads.length; wi++) {
+    const wl = workloads[wi];
+    const items = names.map((name, i) => ({
+      name,
+      bytes: data.engines[name][wl].peakHeap,
+      color: COLORS[i],
+    }));
+    const outer: Rect = { x: 12 + wi * panelW, y: 44, w: panelW - 6, h: 244 };
+    const inner: Rect = {
+      x: outer.x + 2,
+      y: outer.y + 24,
+      w: outer.w - 4,
+      h: outer.h - 26,
+    };
+    const layout = squarify(items, inner);
+    const children = layout.map((l) => ({
+      name: l.name,
+      rect: l.rect,
+      color: items.find((i) => i.name === l.name)!.color,
+      valueText: fmtBytes(data.engines[l.name][wl].peakHeap),
+    }));
+    roots.push({
+      name: labels[wl],
+      rect: outer,
+      color: "#f1f3f5",
+      valueText: "",
+      panel: labels[wl],
+      children,
+    });
+  }
+  return roots;
+}
+
+/* ------------------------------------------------------------------ */
+
+const sizeSvg = treemapSvg(
+  "Library size on disk",
+  "Engine package footprint, excluding the shared Deno runtime (native: JSR artifact; oxigraph: npm package; comunica: full transitive dependency closure)",
+  sizeTree(),
+);
+Deno.writeTextFileSync(
+  join(Deno.cwd(), "docs", "assets", "treemap-library-size.svg"),
+  sizeSvg,
+);
+
+const memSvg = treemapSvg(
+  "Peak heap during execution (10k-person graph)",
+  "Isolated Deno subprocess per engine; peak Deno.memoryUsage().heapUsed over 5 runs; ~65 MB runtime baseline excluded from comparison by symmetry",
+  memoryTree(),
+  720,
+  300,
+);
+Deno.writeTextFileSync(
+  join(Deno.cwd(), "docs", "assets", "treemap-memory.svg"),
+  memSvg,
+);
+
+console.log(
+  "wrote docs/assets/treemap-library-size.svg and treemap-memory.svg",
+);

--- a/deno.json
+++ b/deno.json
@@ -15,6 +15,7 @@
     "@comunica/query-sparql-rdfjs-lite": "npm:@comunica/query-sparql-rdfjs-lite@^5.1.3",
     "@rdfjs/types": "npm:@rdfjs/types@^2.0.1",
     "@std/assert": "jsr:@std/assert@^1.0.19",
+    "@std/path": "jsr:@std/path@^1",
     "oxigraph": "npm:oxigraph@^0.5.9",
     "@types/node": "npm:@types/node@^22.10.0"
   },
@@ -22,6 +23,8 @@
   "tasks": {
     "bench": "deno bench --allow-all",
     "bench:check": "deno run --allow-all bench/budget.ts",
+    "bench:size": "deno run --allow-read bench/measure-libs.ts > bench/size-data.json && deno run --allow-read --allow-write bench/treemap.ts",
+    "bench:memory": "deno run --allow-all bench/collect-memory.ts && deno run --allow-read --allow-write bench/treemap.ts",
     "check": "deno check",
     "ci": {
       "description": "Formats, lints, checks, and tests the code",

--- a/deno.json
+++ b/deno.json
@@ -23,8 +23,8 @@
   "tasks": {
     "bench": "deno bench --allow-all",
     "bench:check": "deno run --allow-all bench/budget.ts",
-    "bench:size": "deno run --allow-read bench/measure-libs.ts > bench/size-data.json && deno run --allow-read --allow-write bench/treemap.ts",
-    "bench:memory": "deno run --allow-all bench/collect-memory.ts && deno run --allow-read --allow-write bench/treemap.ts",
+    "bench:size": "deno run --allow-read bench/measure-libs.ts > bench/size-data.json && deno run --allow-read --allow-write bench/treemap.ts && deno fmt docs/assets/treemap-*.svg",
+    "bench:memory": "deno run --allow-all bench/collect-memory.ts && deno run --allow-read --allow-write bench/treemap.ts && deno fmt docs/assets/treemap-*.svg",
     "check": "deno check",
     "ci": {
       "description": "Formats, lints, checks, and tests the code",

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,8 @@
   "specifiers": {
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@1": "1.1.6",
     "npm:@comunica/query-sparql-rdfjs-lite@^5.1.3": "5.3.0",
     "npm:@rdfjs/types@^2.0.1": "2.0.1",
     "npm:@types/node@^22.10.0": "22.20.1",
@@ -16,11 +18,17 @@
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/internal@1.0.14": {
       "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
     }
   },
   "npm": {
@@ -3559,6 +3567,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^1.0.19",
+      "jsr:@std/path@1",
       "npm:@comunica/query-sparql-rdfjs-lite@^5.1.3",
       "npm:@rdfjs/types@^2.0.1",
       "npm:@types/node@^22.10.0",

--- a/docs/assets/treemap-library-size.svg
+++ b/docs/assets/treemap-library-size.svg
@@ -1,43 +1,98 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 320" font-family="sans-serif"><rect width="720" height="320" fill="#f8f9fa"/>
-<text x="12" y="20" font-size="13" font-weight="bold" fill="#212529">Library size on disk</text>
-<text x="12" y="34" font-size="9" fill="#868e96">Engine package footprint, excluding the shared Deno runtime (native: JSR artifact; oxigraph: npm package; comunica: full transitive dependency closure)</text>
-<rect x="12.0" y="44.0" width="534.4" height="264.0" fill="#2f9e44" stroke="#ffffff" stroke-width="1"/>
-<text x="279.2" y="179.0" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">comunica<tspan x="279.2" dy="12" font-size="8" fill="#ffffffcc">28.32 MiB</tspan></text>
-<rect x="14.0" y="46.0" width="253.2" height="260.0" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
-<text x="140.6" y="43.0" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-bindings-aggregator-factory-average (13.44 MiB)</text>
-<rect x="267.2" y="46.0" width="148.9" height="260.0" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
-<text x="341.6" y="43.0" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-init-query (7.90 MiB)</text>
-<rect x="416.1" y="46.0" width="128.4" height="190.6" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
-<text x="480.2" y="144.3" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">other deps<tspan x="480.2" dy="12" font-size="8" fill="#ffffffcc">5.00 MiB</tspan></text>
-<rect x="416.1" y="236.6" width="42.5" height="69.4" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
-<text x="437.3" y="233.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-query-parse-sparql (616 KiB)</text>
-<rect x="458.6" y="236.6" width="35.5" height="69.4" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
-<text x="476.4" y="233.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-function-factory-term-addition (515 KiB)</text>
-<rect x="494.1" y="236.6" width="50.3" height="20.9" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
-<text x="519.3" y="233.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-expression-evaluator-factory-default (220 KiB)</text>
-<rect x="494.1" y="257.6" width="17.5" height="48.4" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
-<text x="502.9" y="254.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-query-operation-join (177 KiB)</text>
-<rect x="511.6" y="257.6" width="32.8" height="25.0" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
-<text x="528.0" y="254.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-query-operation-path-alt (172 KiB)</text>
-<rect x="511.6" y="282.6" width="32.8" height="23.4" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
-<text x="528.0" y="279.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-function-factory-term-str-uuid (161 KiB)</text>
-<rect x="546.4" y="44.0" width="161.6" height="243.4" fill="#1971c2" stroke="#ffffff" stroke-width="1"/>
-<text x="627.2" y="168.7" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">oxigraph<tspan x="627.2" dy="12" font-size="8" fill="#ffffffcc">7.89 MiB</tspan></text>
-<rect x="548.4" y="46.0" width="157.6" height="235.3" fill="#afcdea" stroke="#ffffff" stroke-width="1"/>
-<text x="627.2" y="166.7" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">WASM runtime<tspan x="627.2" dy="12" font-size="8" fill="#ffffffcc">7.76 MiB</tspan></text>
-<rect x="548.4" y="281.3" width="157.6" height="4.0" fill="#afcdea" stroke="#ffffff" stroke-width="1"/>
-<text x="627.2" y="278.3" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">JS glue + types (136 KiB)</text>
-<rect x="546.4" y="287.4" width="161.6" height="20.6" fill="#f08c00" stroke="#ffffff" stroke-width="1"/>
-<text x="627.2" y="300.7" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">native<tspan x="627.2" dy="12" font-size="8" fill="#ffffffcc">685 KiB</tspan></text>
-<rect x="548.4" y="289.4" width="87.7" height="16.6" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
-<text x="592.3" y="286.4" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">parser (381 KiB)</text>
-<rect x="636.1" y="289.4" width="52.0" height="16.6" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
-<text x="662.1" y="286.4" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">evaluator (226 KiB)</text>
-<rect x="688.1" y="289.4" width="9.3" height="16.6" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
-<text x="692.7" y="286.4" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">term (40 KiB)</text>
-<rect x="697.4" y="289.4" width="8.6" height="10.5" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
-<text x="701.7" y="286.4" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">store (24 KiB)</text>
-<rect x="697.4" y="299.8" width="8.0" height="6.2" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
-<text x="701.4" y="296.8" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">README.md (13 KiB)</text>
-<rect x="705.3" y="299.8" width="0.7" height="6.2" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 320"
+  font-family="sans-serif">
+  <rect width="720" height="320" fill="#f8f9fa" />
+  <text x="12" y="20" font-size="13" font-weight="bold"
+    fill="#212529">Library size on disk</text>
+  <text x="12" y="34" font-size="9"
+    fill="#868e96">Engine package footprint, excluding the shared Deno runtime (native: JSR artifact; oxigraph: npm package; comunica: full transitive dependency closure)</text>
+  <rect x="12.0" y="44.0" width="534.4" height="264.0" fill="#2f9e44"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="279.2" y="179.0" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">comunica<tspan x="279.2" dy="12" font-size="8" fill="#ffffffcc">28.32 MiB</tspan></text>
+  <rect x="14.0" y="46.0" width="253.2" height="260.0" fill="#b6ddbe"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="140.6" y="43.0" text-anchor="middle" font-family="sans-serif"
+    font-size="8"
+    fill="#495057">@comunica/actor-bindings-aggregator-factory-average (13.44 MiB)</text>
+  <rect x="267.2" y="46.0" width="148.9" height="260.0" fill="#b6ddbe"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="341.6" y="43.0" text-anchor="middle" font-family="sans-serif"
+    font-size="8" fill="#495057">@comunica/actor-init-query (7.90 MiB)</text>
+  <rect x="416.1" y="46.0" width="128.4" height="190.6" fill="#b6ddbe"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="480.2" y="144.3" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">other deps<tspan x="480.2" dy="12" font-size="8" fill="#ffffffcc">5.00 MiB</tspan></text>
+  <rect x="416.1" y="236.6" width="42.5" height="69.4" fill="#b6ddbe"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="437.3" y="233.6" text-anchor="middle" font-family="sans-serif"
+    font-size="8"
+    fill="#495057">@comunica/actor-query-parse-sparql (616 KiB)</text>
+  <rect x="458.6" y="236.6" width="35.5" height="69.4" fill="#b6ddbe"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="476.4" y="233.6" text-anchor="middle" font-family="sans-serif"
+    font-size="8"
+    fill="#495057">@comunica/actor-function-factory-term-addition (515 KiB)</text>
+  <rect x="494.1" y="236.6" width="50.3" height="20.9" fill="#b6ddbe"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="519.3" y="233.6" text-anchor="middle" font-family="sans-serif"
+    font-size="8"
+    fill="#495057">@comunica/actor-expression-evaluator-factory-default (220 KiB)</text>
+  <rect x="494.1" y="257.6" width="17.5" height="48.4" fill="#b6ddbe"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="502.9" y="254.6" text-anchor="middle" font-family="sans-serif"
+    font-size="8"
+    fill="#495057">@comunica/actor-query-operation-join (177 KiB)</text>
+  <rect x="511.6" y="257.6" width="32.8" height="25.0" fill="#b6ddbe"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="528.0" y="254.6" text-anchor="middle" font-family="sans-serif"
+    font-size="8"
+    fill="#495057">@comunica/actor-query-operation-path-alt (172 KiB)</text>
+  <rect x="511.6" y="282.6" width="32.8" height="23.4" fill="#b6ddbe"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="528.0" y="279.6" text-anchor="middle" font-family="sans-serif"
+    font-size="8"
+    fill="#495057">@comunica/actor-function-factory-term-str-uuid (161 KiB)</text>
+  <rect x="546.4" y="44.0" width="161.6" height="243.4" fill="#1971c2"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="627.2" y="168.7" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">oxigraph<tspan x="627.2" dy="12" font-size="8" fill="#ffffffcc">7.89 MiB</tspan></text>
+  <rect x="548.4" y="46.0" width="157.6" height="235.3" fill="#afcdea"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="627.2" y="166.7" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">WASM runtime<tspan x="627.2" dy="12" font-size="8" fill="#ffffffcc">7.76 MiB</tspan></text>
+  <rect x="548.4" y="281.3" width="157.6" height="4.0" fill="#afcdea"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="627.2" y="278.3" text-anchor="middle" font-family="sans-serif"
+    font-size="8" fill="#495057">JS glue + types (136 KiB)</text>
+  <rect x="546.4" y="287.4" width="161.6" height="20.6" fill="#f08c00"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="627.2" y="300.7" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">native<tspan x="627.2" dy="12" font-size="8" fill="#ffffffcc">685 KiB</tspan></text>
+  <rect x="548.4" y="289.4" width="87.7" height="16.6" fill="#fad7a6"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="592.3" y="286.4" text-anchor="middle" font-family="sans-serif"
+    font-size="8" fill="#495057">parser (381 KiB)</text>
+  <rect x="636.1" y="289.4" width="52.0" height="16.6" fill="#fad7a6"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="662.1" y="286.4" text-anchor="middle" font-family="sans-serif"
+    font-size="8" fill="#495057">evaluator (226 KiB)</text>
+  <rect x="688.1" y="289.4" width="9.3" height="16.6" fill="#fad7a6"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="692.7" y="286.4" text-anchor="middle" font-family="sans-serif"
+    font-size="8" fill="#495057">term (40 KiB)</text>
+  <rect x="697.4" y="289.4" width="8.6" height="10.5" fill="#fad7a6"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="701.7" y="286.4" text-anchor="middle" font-family="sans-serif"
+    font-size="8" fill="#495057">store (24 KiB)</text>
+  <rect x="697.4" y="299.8" width="8.0" height="6.2" fill="#fad7a6"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="701.4" y="296.8" text-anchor="middle" font-family="sans-serif"
+    font-size="8" fill="#495057">README.md (13 KiB)</text>
+  <rect x="705.3" y="299.8" width="0.7" height="6.2" fill="#fad7a6"
+    stroke="#ffffff" stroke-width="1" />
 </svg>

--- a/docs/assets/treemap-library-size.svg
+++ b/docs/assets/treemap-library-size.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 320" font-family="sans-serif"><rect width="720" height="320" fill="#f8f9fa"/>
+<text x="12" y="20" font-size="13" font-weight="bold" fill="#212529">Library size on disk</text>
+<text x="12" y="34" font-size="9" fill="#868e96">Engine package footprint, excluding the shared Deno runtime (native: JSR artifact; oxigraph: npm package; comunica: full transitive dependency closure)</text>
+<rect x="12.0" y="44.0" width="534.4" height="264.0" fill="#2f9e44" stroke="#ffffff" stroke-width="1"/>
+<text x="279.2" y="179.0" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">comunica<tspan x="279.2" dy="12" font-size="8" fill="#ffffffcc">28.32 MiB</tspan></text>
+<rect x="14.0" y="46.0" width="253.2" height="260.0" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
+<text x="140.6" y="43.0" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-bindings-aggregator-factory-average (13.44 MiB)</text>
+<rect x="267.2" y="46.0" width="148.9" height="260.0" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
+<text x="341.6" y="43.0" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-init-query (7.90 MiB)</text>
+<rect x="416.1" y="46.0" width="128.4" height="190.6" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
+<text x="480.2" y="144.3" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">other deps<tspan x="480.2" dy="12" font-size="8" fill="#ffffffcc">5.00 MiB</tspan></text>
+<rect x="416.1" y="236.6" width="42.5" height="69.4" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
+<text x="437.3" y="233.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-query-parse-sparql (616 KiB)</text>
+<rect x="458.6" y="236.6" width="35.5" height="69.4" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
+<text x="476.4" y="233.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-function-factory-term-addition (515 KiB)</text>
+<rect x="494.1" y="236.6" width="50.3" height="20.9" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
+<text x="519.3" y="233.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-expression-evaluator-factory-default (220 KiB)</text>
+<rect x="494.1" y="257.6" width="17.5" height="48.4" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
+<text x="502.9" y="254.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-query-operation-join (177 KiB)</text>
+<rect x="511.6" y="257.6" width="32.8" height="25.0" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
+<text x="528.0" y="254.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-query-operation-path-alt (172 KiB)</text>
+<rect x="511.6" y="282.6" width="32.8" height="23.4" fill="#b6ddbe" stroke="#ffffff" stroke-width="1"/>
+<text x="528.0" y="279.6" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">@comunica/actor-function-factory-term-str-uuid (161 KiB)</text>
+<rect x="546.4" y="44.0" width="161.6" height="243.4" fill="#1971c2" stroke="#ffffff" stroke-width="1"/>
+<text x="627.2" y="168.7" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">oxigraph<tspan x="627.2" dy="12" font-size="8" fill="#ffffffcc">7.89 MiB</tspan></text>
+<rect x="548.4" y="46.0" width="157.6" height="235.3" fill="#afcdea" stroke="#ffffff" stroke-width="1"/>
+<text x="627.2" y="166.7" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">WASM runtime<tspan x="627.2" dy="12" font-size="8" fill="#ffffffcc">7.76 MiB</tspan></text>
+<rect x="548.4" y="281.3" width="157.6" height="4.0" fill="#afcdea" stroke="#ffffff" stroke-width="1"/>
+<text x="627.2" y="278.3" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">JS glue + types (136 KiB)</text>
+<rect x="546.4" y="287.4" width="161.6" height="20.6" fill="#f08c00" stroke="#ffffff" stroke-width="1"/>
+<text x="627.2" y="300.7" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">native<tspan x="627.2" dy="12" font-size="8" fill="#ffffffcc">685 KiB</tspan></text>
+<rect x="548.4" y="289.4" width="87.7" height="16.6" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
+<text x="592.3" y="286.4" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">parser (381 KiB)</text>
+<rect x="636.1" y="289.4" width="52.0" height="16.6" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
+<text x="662.1" y="286.4" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">evaluator (226 KiB)</text>
+<rect x="688.1" y="289.4" width="9.3" height="16.6" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
+<text x="692.7" y="286.4" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">term (40 KiB)</text>
+<rect x="697.4" y="289.4" width="8.6" height="10.5" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
+<text x="701.7" y="286.4" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">store (24 KiB)</text>
+<rect x="697.4" y="299.8" width="8.0" height="6.2" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
+<text x="701.4" y="296.8" text-anchor="middle" font-family="sans-serif" font-size="8" fill="#495057">README.md (13 KiB)</text>
+<rect x="705.3" y="299.8" width="0.7" height="6.2" fill="#fad7a6" stroke="#ffffff" stroke-width="1"/>
+</svg>

--- a/docs/assets/treemap-memory.svg
+++ b/docs/assets/treemap-memory.svg
@@ -1,20 +1,46 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 300" font-family="sans-serif"><rect width="720" height="300" fill="#f8f9fa"/>
-<text x="12" y="20" font-size="13" font-weight="bold" fill="#212529">Peak heap during execution (10k-person graph)</text>
-<text x="12" y="34" font-size="9" fill="#868e96">Isolated Deno subprocess per engine; peak Deno.memoryUsage().heapUsed over 5 runs; ~65 MB runtime baseline excluded from comparison by symmetry</text>
-<rect x="12.0" y="44.0" width="342.0" height="244.0" fill="#f1f3f5" stroke="#dee2e6" stroke-width="1"/>
-<text x="18.0" y="60.0" font-family="sans-serif" font-size="10" font-weight="bold" fill="#495057">full scan (55k rows materialized)</text>
-<rect x="14.0" y="68.0" width="141.4" height="218.0" fill="#f08c00" stroke="#ffffff" stroke-width="1"/>
-<text x="84.7" y="180.0" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">oxigraph<tspan x="84.7" dy="12" font-size="8" fill="#ffffffcc">250.60 MiB</tspan></text>
-<rect x="155.4" y="68.0" width="196.6" height="134.0" fill="#1971c2" stroke="#ffffff" stroke-width="1"/>
-<text x="253.7" y="138.0" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">comunica<tspan x="253.7" dy="12" font-size="8" fill="#ffffffcc">214.25 MiB</tspan></text>
-<rect x="155.4" y="202.0" width="196.6" height="84.0" fill="#2f9e44" stroke="#ffffff" stroke-width="1"/>
-<text x="253.7" y="247.0" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">native<tspan x="253.7" dy="12" font-size="8" fill="#ffffffcc">134.37 MiB</tspan></text>
-<rect x="360.0" y="44.0" width="342.0" height="244.0" fill="#f1f3f5" stroke="#dee2e6" stroke-width="1"/>
-<text x="366.0" y="60.0" font-family="sans-serif" font-size="10" font-weight="bold" fill="#495057">nested EXISTS</text>
-<rect x="362.0" y="68.0" width="198.8" height="218.0" fill="#1971c2" stroke="#ffffff" stroke-width="1"/>
-<text x="461.4" y="180.0" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">comunica<tspan x="461.4" dy="12" font-size="8" fill="#ffffffcc">271.11 MiB</tspan></text>
-<rect x="560.8" y="68.0" width="139.2" height="124.4" fill="#f08c00" stroke="#ffffff" stroke-width="1"/>
-<text x="630.4" y="133.2" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">oxigraph<tspan x="630.4" dy="12" font-size="8" fill="#ffffffcc">108.31 MiB</tspan></text>
-<rect x="560.8" y="192.4" width="139.2" height="93.6" fill="#2f9e44" stroke="#ffffff" stroke-width="1"/>
-<text x="630.4" y="242.2" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">native<tspan x="630.4" dy="12" font-size="8" fill="#ffffffcc">81.49 MiB</tspan></text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 300"
+  font-family="sans-serif">
+  <rect width="720" height="300" fill="#f8f9fa" />
+  <text x="12" y="20" font-size="13" font-weight="bold"
+    fill="#212529">Peak heap during execution (10k-person graph)</text>
+  <text x="12" y="34" font-size="9"
+    fill="#868e96">Isolated Deno subprocess per engine; peak Deno.memoryUsage().heapUsed over 5 runs; ~65 MB runtime baseline excluded from comparison by symmetry</text>
+  <rect x="12.0" y="44.0" width="342.0" height="244.0" fill="#f1f3f5"
+    stroke="#dee2e6" stroke-width="1" />
+  <text x="18.0" y="60.0" font-family="sans-serif" font-size="10"
+    font-weight="bold" fill="#495057">full scan (55k rows materialized)</text>
+  <rect x="14.0" y="68.0" width="141.4" height="218.0" fill="#f08c00"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="84.7" y="180.0" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">oxigraph<tspan x="84.7" dy="12" font-size="8" fill="#ffffffcc">250.60 MiB</tspan></text>
+  <rect x="155.4" y="68.0" width="196.6" height="134.0" fill="#1971c2"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="253.7" y="138.0" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">comunica<tspan x="253.7" dy="12" font-size="8" fill="#ffffffcc">214.25 MiB</tspan></text>
+  <rect x="155.4" y="202.0" width="196.6" height="84.0" fill="#2f9e44"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="253.7" y="247.0" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">native<tspan x="253.7" dy="12" font-size="8" fill="#ffffffcc">134.37 MiB</tspan></text>
+  <rect x="360.0" y="44.0" width="342.0" height="244.0" fill="#f1f3f5"
+    stroke="#dee2e6" stroke-width="1" />
+  <text x="366.0" y="60.0" font-family="sans-serif" font-size="10"
+    font-weight="bold" fill="#495057">nested EXISTS</text>
+  <rect x="362.0" y="68.0" width="198.8" height="218.0" fill="#1971c2"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="461.4" y="180.0" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">comunica<tspan x="461.4" dy="12" font-size="8" fill="#ffffffcc">271.11 MiB</tspan></text>
+  <rect x="560.8" y="68.0" width="139.2" height="124.4" fill="#f08c00"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="630.4" y="133.2" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">oxigraph<tspan x="630.4" dy="12" font-size="8" fill="#ffffffcc">108.31 MiB</tspan></text>
+  <rect x="560.8" y="192.4" width="139.2" height="93.6" fill="#2f9e44"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="630.4" y="242.2" text-anchor="middle" font-family="sans-serif"
+    font-size="10"
+    fill="#fff">native<tspan x="630.4" dy="12" font-size="8" fill="#ffffffcc">81.49 MiB</tspan></text>
 </svg>

--- a/docs/assets/treemap-memory.svg
+++ b/docs/assets/treemap-memory.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 300" font-family="sans-serif"><rect width="720" height="300" fill="#f8f9fa"/>
+<text x="12" y="20" font-size="13" font-weight="bold" fill="#212529">Peak heap during execution (10k-person graph)</text>
+<text x="12" y="34" font-size="9" fill="#868e96">Isolated Deno subprocess per engine; peak Deno.memoryUsage().heapUsed over 5 runs; ~65 MB runtime baseline excluded from comparison by symmetry</text>
+<rect x="12.0" y="44.0" width="342.0" height="244.0" fill="#f1f3f5" stroke="#dee2e6" stroke-width="1"/>
+<text x="18.0" y="60.0" font-family="sans-serif" font-size="10" font-weight="bold" fill="#495057">full scan (55k rows materialized)</text>
+<rect x="14.0" y="68.0" width="141.4" height="218.0" fill="#f08c00" stroke="#ffffff" stroke-width="1"/>
+<text x="84.7" y="180.0" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">oxigraph<tspan x="84.7" dy="12" font-size="8" fill="#ffffffcc">250.60 MiB</tspan></text>
+<rect x="155.4" y="68.0" width="196.6" height="134.0" fill="#1971c2" stroke="#ffffff" stroke-width="1"/>
+<text x="253.7" y="138.0" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">comunica<tspan x="253.7" dy="12" font-size="8" fill="#ffffffcc">214.25 MiB</tspan></text>
+<rect x="155.4" y="202.0" width="196.6" height="84.0" fill="#2f9e44" stroke="#ffffff" stroke-width="1"/>
+<text x="253.7" y="247.0" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">native<tspan x="253.7" dy="12" font-size="8" fill="#ffffffcc">134.37 MiB</tspan></text>
+<rect x="360.0" y="44.0" width="342.0" height="244.0" fill="#f1f3f5" stroke="#dee2e6" stroke-width="1"/>
+<text x="366.0" y="60.0" font-family="sans-serif" font-size="10" font-weight="bold" fill="#495057">nested EXISTS</text>
+<rect x="362.0" y="68.0" width="198.8" height="218.0" fill="#1971c2" stroke="#ffffff" stroke-width="1"/>
+<text x="461.4" y="180.0" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">comunica<tspan x="461.4" dy="12" font-size="8" fill="#ffffffcc">271.11 MiB</tspan></text>
+<rect x="560.8" y="68.0" width="139.2" height="124.4" fill="#f08c00" stroke="#ffffff" stroke-width="1"/>
+<text x="630.4" y="133.2" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">oxigraph<tspan x="630.4" dy="12" font-size="8" fill="#ffffffcc">108.31 MiB</tspan></text>
+<rect x="560.8" y="192.4" width="139.2" height="93.6" fill="#2f9e44" stroke="#ffffff" stroke-width="1"/>
+<text x="630.4" y="242.2" text-anchor="middle" font-family="sans-serif" font-size="10" fill="#fff">native<tspan x="630.4" dy="12" font-size="8" fill="#ffffffcc">81.49 MiB</tspan></text>
+</svg>


### PR DESCRIPTION
## What

Adds the size/memory half of the comparative story to the README's Results section — the speed tables now have their footprint companions.

## The numbers (measured, reproducible)

**Library size on disk** — native is 12-42x smaller:

| engine   | on disk      | contents |
| -------- | ------------ | -------- |
| native   | **0.67 MiB** | 38 source files, zero runtime deps (the whole JSR artifact) |
| oxigraph | 7.9 MiB      | WASM runtime (7.8 MiB) + JS glue/types |
| comunica | 28.3 MiB     | 368 npm packages in the transitive dependency closure |

**Peak heap, 10k-person graph, isolated subprocess per engine** — native lowest on both workloads:

| workload             | native | comunica | oxigraph |
| -------------------- | ------ | -------- | -------- |
| full scan (55k rows) | **134 MB** | 214 MB | 251 MB |
| nested EXISTS        | **82 MB**  | 271 MB | 108 MB |

## The diagrams

Two squarified treemaps (area ∝ size), generated into `docs/assets/` and embedded in the README:

- **`treemap-library-size.svg`** — nested: engine → component breakdown (native by module, oxigraph wasm/glue, comunica by direct-dependency partition of the 368-package closure).
- **`treemap-memory.svg`** — two panels (scan / nested EXISTS), three engine rects each.

## Reproducibility

New tasks regenerate everything from the installed packages and fresh measurements:

- `deno task bench:size` — `bench/measure-libs.ts` (native artifact bytes by module; oxigraph/`comunica` resolved through `node_modules/.deno`, closure walk + exclusive attribution) → `bench/size-data.json` → `bench/treemap.ts` → SVG.
- `deno task bench:memory` — `bench/collect-memory.ts` spawns each engine in its own process (only the target engine loaded) running the workload 5x, sampling `Deno.memoryUsage()` peaks → `bench/memory-data.json` → SVG.

Methodology caveats are stated in the README: machine-specific snapshot (Deno 2.9.5, Windows), ~65 MB shared runtime baseline excluded by symmetry, GC noise means ±10-20% run-to-run variance (all three sources — table, JSON, SVG — are regenerated together).

## Verification

- Full suite 381 tests pass; fmt/lint clean on the new bench files.
- The treemap geometry is validated (all rects within bounds, sane layout).

No engine code touched — docs, bench tooling, and measured data only.