### PR TITLE
fix(ci): correct stale W3C 1.1 suite counts in comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - run: deno task publish:dry
   # W3C differential gate: native must agree with comunica on the vendored
   # SPARQL 1.1 evaluation-core suite. The pass rate is the tracked progress
-  # metric — this job goes green only on a full pass (336/336): native agrees
+  # metric — this job goes green only on a full pass (345/345): native agrees
   # with comunica, or matches the W3C reference where comunica is wrong.
   w3c-parity:
     runs-on: ubuntu-latest

--- a/test/w3c/README.md
+++ b/test/w3c/README.md
@@ -46,7 +46,7 @@ tests.
 ## Vendored fixtures and re-fetching
 
 `fixtures/sparql11/` holds a snapshot of the W3C rdf-tests evaluation core (~2.6
-MB, 336 tests across 23 categories) fetched from the upstream `w3c/rdf-tests`
+MB, 345 tests across 31 categories) fetched from the upstream `w3c/rdf-tests`
 gh-pages branch. Committing the fixtures keeps CI deterministic and
 offline-capable; queries and data resolve against canonical
 `http://www.w3.org/2009/sparql/docs/tests/data-sparql11/...` URLs so relative

--- a/test/w3c/w3c-main.ts
+++ b/test/w3c/w3c-main.ts
@@ -127,7 +127,7 @@ const report = await new W3cRunner(readFixture).run(cases);
 printReport(report, skipped);
 
 // Coverage gate: the terminal milestone requires a full pass — every test
-// green (336/336), i.e. zero parity gaps. Runner errors are always fatal —
+// green (345/345), i.e. zero parity gaps. Runner errors are always fatal —
 // they indicate a harness bug, not a parity gap.
 const threshold = report.total;
 if (report.pass < threshold || report.error > 0) {


### PR DESCRIPTION
Comment-only fix. The w3c-parity runner loads **345 tests across 31 categories** (the `w3c-main.ts` CATEGORIES list, including `syntax-query`/`syntax-update`), not 336/23 — verified by the runner's own output (`total: 345, pass: 345`). Three stale comments corrected:

- `.github/workflows/ci.yml` — w3c-parity job comment: `(336/336)` → `(345/345)`
- `test/w3c/README.md` — fixtures snapshot description: 336/23 → 345/31
- `test/w3c/w3c-main.ts` — coverage-gate comment: `(336/336)` → `(345/345)`

No behavior change; the gate itself already asserts `report.total` dynamically.