### PR TITLE
Reconcile CONSTRUCT comparison to the multiset contract across all harness layers

### DIFF
--- a/bench/engine_bench.ts
+++ b/bench/engine_bench.ts
@@ -454,6 +454,26 @@ function quadRecord(
 }
 
 /**
+ * dedupeRecords keeps one copy of each distinct canonical record, preserving
+ * first-occurrence order. Reference-engine CONSTRUCT streams may repeat a
+ * triple their graph would not, so the reference side of a cross-engine
+ * comparison is normalized to graph content before comparing — the native
+ * side stays as-emitted (issue #87 contract).
+ */
+function dedupeRecords<T>(records: T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const record of records) {
+    const key = JSON.stringify(record);
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(record);
+    }
+  }
+  return out;
+}
+
+/**
  * quadRecords projects quads into ordered [s, p, o, g] canonical term lists,
  * the record shape the blank-node-isomorphic comparison operates on.
  */
@@ -734,16 +754,18 @@ async function verifyConstructEquality(
     sources: [memoryStore],
   });
   const comunicaQuads = await comunicaStream.toArray();
-  const comunicaSet = comunicaQuads
-    .map((item) => quadRecord(item, canonicalizeComunicaTerm))
-    .sort();
+  // Reference sides are normalized to graph content (issue #87 contract);
+  // the native side above stays as-emitted.
+  const comunicaSet = dedupeRecords(
+    comunicaQuads.map((item) => quadRecord(item, canonicalizeComunicaTerm)),
+  ).sort();
 
   const oxigraphQuads = oxigraphStore.query(
     query,
   ) as unknown as rdfjs.Quad[];
-  const oxigraphSet = oxigraphQuads
-    .map((item) => quadRecord(item, canonicalizeRdfTerm))
-    .sort();
+  const oxigraphSet = dedupeRecords(
+    oxigraphQuads.map((item) => quadRecord(item, canonicalizeRdfTerm)),
+  ).sort();
 
   assertEquals(
     nativeSet,
@@ -779,12 +801,18 @@ async function verifyConstructIsoEquality(
     sources: [memoryStore],
   });
   const comunicaQuads = await comunicaStream.toArray();
-  const comunicaRecords = quadRecords(comunicaQuads, canonicalizeComunicaTerm);
+  // Reference sides are normalized to graph content (issue #87 contract);
+  // the native side above stays as-emitted.
+  const comunicaRecords = dedupeRecords(
+    quadRecords(comunicaQuads, canonicalizeComunicaTerm),
+  );
 
   const oxigraphQuads = oxigraphStore.query(
     query,
   ) as unknown as rdfjs.Quad[];
-  const oxigraphRecords = quadRecords(oxigraphQuads, canonicalizeRdfTerm);
+  const oxigraphRecords = dedupeRecords(
+    quadRecords(oxigraphQuads, canonicalizeRdfTerm),
+  );
 
   assertEquals(
     isomorphicMultiset(nativeRecords, comunicaRecords),

--- a/test/parity/parity-harness.ts
+++ b/test/parity/parity-harness.ts
@@ -337,7 +337,15 @@ async function compareResult(
         comunicaStore,
       );
       const nativeQuads = nativeResult.data.quads.map(canonicalQuadString);
-      return compareMultisets(comunicaQuads, nativeQuads, "CONSTRUCT quads");
+      // Issue #87 contract: the reference side is normalized to graph
+      // content (Comunica's stream may repeat a triple its graph would
+      // not), while the native side is compared as-emitted — a conforming
+      // engine emits no duplicate quads, so a duplicate regression fails.
+      return compareMultisets(
+        [...new Set(comunicaQuads)],
+        nativeQuads,
+        "CONSTRUCT quads",
+      );
     }
     case "describe": {
       if (nativeResult.kind !== "construct") {

--- a/test/w3c/construct-semantics.test.ts
+++ b/test/w3c/construct-semantics.test.ts
@@ -1,0 +1,101 @@
+import { assertEquals } from "@std/assert";
+import type * as rdfjs from "@rdfjs/types";
+import { canonicalizeRdfTerm, DataFactory } from "@/term/mod.ts";
+import type { CanonicalTerm } from "@/term/mod.ts";
+import { compareConstructRecords, dedupeRecords } from "./runner.ts";
+
+/**
+ * Issue #87 contract pins: the W3C CONSTRUCT gate compares the native result
+ * as-emitted (a conforming engine emits no duplicate quads — decision #29),
+ * while the reference side is normalized to its graph content (Comunica's
+ * stream may repeat a triple its graph would not). The first test is the
+ * regression detector the multiset contract exists for: a future native
+ * change that starts emitting duplicate quads must fail the gate, not
+ * silently pass.
+ */
+
+const { namedNode, quad } = DataFactory;
+const ex = (local: string) => namedNode(`http://example.org/${local}`);
+const q = (s: string, p: string, o: string): rdfjs.Quad =>
+  quad(ex(s), ex(p), ex(o));
+
+/** rec renders one quad as the canonical [s, p, o] record the gate compares. */
+function rec(item: rdfjs.Quad): CanonicalTerm[] {
+  return [
+    canonicalizeRdfTerm(item.subject),
+    canonicalizeRdfTerm(item.predicate),
+    canonicalizeRdfTerm(item.object),
+  ];
+}
+
+/** key is the canonical string key dedupeRecords pairs records with. */
+function key(item: rdfjs.Quad): string {
+  return JSON.stringify(rec(item));
+}
+
+Deno.test(
+  "CONSTRUCT gate fails when native emits a duplicate quad (issue #87 regression detector)",
+  () => {
+    const quad1 = q("s", "p", "o");
+    // Native emits the same quad twice; the reference holds it once.
+    assertEquals(
+      compareConstructRecords(
+        [rec(quad1), rec(quad1)],
+        [rec(quad1)],
+        [key(quad1)],
+      ),
+      false,
+    );
+  },
+);
+
+Deno.test(
+  "CONSTRUCT gate normalizes duplicate reference-stream quads",
+  () => {
+    const quad1 = q("s", "p", "o");
+    // Native emits once; Comunica's stream repeats the triple — the
+    // reference side is normalized, so the graphs agree.
+    assertEquals(
+      compareConstructRecords(
+        [rec(quad1)],
+        [rec(quad1), rec(quad1)],
+        [key(quad1), key(quad1)],
+      ),
+      true,
+    );
+  },
+);
+
+Deno.test("CONSTRUCT gate passes on agreeing results in any order", () => {
+  const quad1 = q("s", "p", "o");
+  const quad2 = q("s", "q", "o2");
+  assertEquals(
+    compareConstructRecords(
+      [rec(quad1), rec(quad2)],
+      [rec(quad2), rec(quad1)],
+      [key(quad2), key(quad1)],
+    ),
+    true,
+  );
+});
+
+Deno.test("CONSTRUCT gate fails on missing quads", () => {
+  const quad1 = q("s", "p", "o");
+  const quad2 = q("s", "q", "o2");
+  assertEquals(
+    compareConstructRecords(
+      [rec(quad1)],
+      [rec(quad1), rec(quad2)],
+      [key(quad1), key(quad2)],
+    ),
+    false,
+  );
+});
+
+Deno.test("dedupeRecords keeps first occurrence and preserves order", () => {
+  const quad1 = q("s", "p", "o");
+  const quad2 = q("s", "q", "o2");
+  const records = [rec(quad1), rec(quad2), rec(quad1)];
+  const keys = [key(quad1), key(quad2), key(quad1)];
+  assertEquals(dedupeRecords(records, keys), [rec(quad1), rec(quad2)]);
+});

--- a/test/w3c/runner.ts
+++ b/test/w3c/runner.ts
@@ -92,12 +92,14 @@ function canonicalQuadString(
 
 /**
  * dedupeRecords keeps one record per distinct canonical key, pairing each
- * record with the canonical string of the quad it came from. A CONSTRUCT
- * result is an RDF graph — a set of triples — so duplicate instantiations
- * are not part of the result content (the W3C reference files are sets), and
- * Comunica's query stream may repeat a triple that its graph would not.
+ * record with the canonical string of the quad it came from. It normalizes
+ * a reference-engine CONSTRUCT stream to its graph content: the reference
+ * is a set of triples (the W3C reference files are sets), and Comunica's
+ * query stream may repeat a triple that its graph would not. Only the
+ * reference side is normalized — the native side is compared as-emitted
+ * (issue #87 contract, see compareConstructRecords).
  */
-function dedupeRecords(
+export function dedupeRecords(
   records: CanonicalTerm[][],
   keys: string[],
 ): CanonicalTerm[][] {
@@ -148,6 +150,28 @@ function isomorphicMultiset(
     return false;
   }
   return multisetEqual(canonicalizeBnodes(a), canonicalizeBnodes(b));
+}
+
+/**
+ * compareConstructRecords compares a native CONSTRUCT result against a
+ * reference (Comunica) result under the graph-result contract (issue #87):
+ * the reference side is normalized to its graph content (Comunica's stream
+ * may repeat a triple its graph would not), while the native side is
+ * compared as-emitted. Decision #29 guarantees a conforming engine emits no
+ * duplicate quads — CONSTRUCT collapses duplicate instantiations — so raw
+ * native records equal the normalized reference exactly when the graph
+ * contents agree, and a future change that starts emitting duplicates fails
+ * the gate instead of silently passing.
+ */
+export function compareConstructRecords(
+  nativeRecords: CanonicalTerm[][],
+  comunicaRecords: CanonicalTerm[][],
+  comunicaKeys: string[],
+): boolean {
+  return isomorphicMultiset(
+    nativeRecords,
+    dedupeRecords(comunicaRecords, comunicaKeys),
+  );
 }
 
 /**
@@ -670,18 +694,16 @@ export class W3cRunner {
       case "construct": {
         let comunicaSet: string[];
         let comunicaRecords: CanonicalTerm[][];
+        let comunicaKeys: string[];
         try {
           const stream = await this.comunicaEngine.queryQuads(query, options);
           const comunicaQuads = await stream.toArray();
-          const comunicaKeys = comunicaQuads.map((item) =>
+          comunicaKeys = comunicaQuads.map((item) =>
             canonicalQuadString(item, canonicalizeComunicaTerm)
           );
           comunicaSet = [...comunicaKeys].sort();
-          comunicaRecords = dedupeRecords(
-            comunicaQuads.map((item) =>
-              this.quadRecords(item, canonicalizeComunicaTerm)
-            ),
-            comunicaKeys,
+          comunicaRecords = comunicaQuads.map((item) =>
+            this.quadRecords(item, canonicalizeComunicaTerm)
           );
         } catch (error) {
           return {
@@ -695,15 +717,18 @@ export class W3cRunner {
           canonicalQuadString(item, canonicalizeRdfTerm)
         );
         const nativeSet = [...nativeKeys].sort();
-        // Compare graph content, not stream shape: CONSTRUCT results are
-        // graphs (sets), and duplicates collapse on both sides.
-        const nativeRecords = dedupeRecords(
-          nativeResult.data.quads.map((item) =>
-            this.quadRecords(item, canonicalizeRdfTerm)
-          ),
-          nativeKeys,
+        // Issue #87 contract: the reference side is normalized to its graph
+        // content, while the native side is compared as-emitted — decision
+        // #29 guarantees a conforming engine emits no duplicate quads, so a
+        // future change that starts emitting them fails this gate.
+        const nativeRecords = nativeResult.data.quads.map((item) =>
+          this.quadRecords(item, canonicalizeRdfTerm)
         );
-        return isomorphicMultiset(nativeRecords, comunicaRecords)
+        return compareConstructRecords(
+            nativeRecords,
+            comunicaRecords,
+            comunicaKeys,
+          )
           ? { status: "pass" }
           : {
             status: "gap",


### PR DESCRIPTION
Closes #87

## Decision: option (b) — all-multiset, with asymmetric reference normalization

CONSTRUCT comparison now follows one contract in all three layers:

- **Reference side: normalized to graph content.** Comunica's CONSTRUCT stream may repeat a triple its graph would not, so the reference side is deduped before comparing.
- **Native side: compared as-emitted (no dedupe).** Decision #29 guarantees a conforming engine emits no duplicate quads — CONSTRUCT collapses duplicate instantiations — so raw native output equals the normalized reference exactly when the graph contents agree. A future native change that starts emitting spurious duplicates now **fails every gate** instead of silently passing the set-based W3C runner.

The nuance over the issue's bare option (b): the W3C runner doesn't drop its dedupe entirely — it drops the *native-side* dedupe and keeps reference-side normalization, since `dedupeRecords` exists precisely because Comunica's stream repeats triples (dropping it would cause false failures).

## Changes

- **`test/w3c/runner.ts`** (SPARQL 1.1 gate): the CONSTRUCT case no longer dedupes the native side; comparison goes through a new exported `compareConstructRecords` helper (reference-side dedupe + blank-node-isomorphic multiset). `dedupeRecords` is exported and re-documented as reference-side normalization only.
- **`test/parity/parity-harness.ts`**: CONSTRUCT case dedupes the Comunica side, keeps native as-emitted. (DESCRIBE keeps its dedupe-both — native can legitimately repeat arcs across repeated resources, unlike CONSTRUCT.)
- **`bench/engine_bench.ts`**: `verifyConstructEquality` and `verifyConstructIsoEquality` dedupe the Comunica/Oxigraph reference sides, keep native as-emitted, via a new record-level `dedupeRecords` helper.
- **`test/w3c/construct-semantics.test.ts`** (new): five unit tests pin the contract — duplicate-native emission fails the gate (the regression detector), duplicate-reference-stream quads normalize, agreeing results pass in any order, missing quads fail, and `dedupeRecords` preserves first-occurrence order.

## Verification

- `test:w3c` **345/345** (100%), `test:sparql12` **249/249**, full suite **386 passed**, bench construct/construct-list cross-engine verifications green, fmt/lint clean.
- Behavior-neutral today: a conforming engine emits no duplicates, so the W3C 1.1 gate's native-side dedupe was a no-op — the change only activates when a regression appears.