### PR TITLE
docs: point maintenance page at the wiki repo skill location

### DIFF
--- a/docs/08-maintenance.md
+++ b/docs/08-maintenance.md
@@ -8,10 +8,10 @@ layout: default
 This wiki is kept in sync with the source tree by a **Git-anchored delta
 process** (the approach LangChain's OpenWiki uses for documentation
 maintenance): the last-synced commit is the anchor, Git history is diffed
-forward, and only the pages the diff touches get edited. The procedure below is
-codified as a reusable skill (`wiki-sync` in
-`repos/workspace-cli/skills/wiki-sync/SKILL.md` in the Wazoo workspace) so
-syncing docs after source changes is a command, not a prompt.
+forward, and only the pages the diff touches get edited. The procedurebelow is codified as a reusable skill (`wiki-sync` in
+`repos/wiki/skills/wiki-sync/SKILL.md` in the Wazoo wiki toolchain repo,
+alongside the `wiki` and `wiki-feedback` skills) so syncing docs after source
+changes is a command, not a prompt.
 
 ## The sync anchor
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -17,6 +17,7 @@ export type {
 export { MemoryStore, MemoryStream } from "@/store/memory-store.ts";
 export { DataFactory, dataFactory } from "@/term/mod.ts";
 export { serializeJsonResults } from "@/serialize/json-results.ts";
+export { serializeXmlResults } from "@/serialize/xml-results.ts";
 
 export {
   canonicalizeRdfTerm,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -16,6 +16,7 @@ export type {
 
 export { MemoryStore, MemoryStream } from "@/store/memory-store.ts";
 export { DataFactory, dataFactory } from "@/term/mod.ts";
+export { serializeJsonResults } from "@/serialize/json-results.ts";
 
 export {
   canonicalizeRdfTerm,

--- a/src/serialize/json-results.test.ts
+++ b/src/serialize/json-results.test.ts
@@ -134,6 +134,31 @@ Deno.test(
 );
 
 Deno.test(
+  "serializeJsonResults - JSON-escapes special characters in values",
+  () => {
+    const parsed = JSON.parse(
+      serializeJsonResults({
+        kind: "select",
+        data: {
+          head: { vars: ["v"] },
+          results: {
+            bindings: [{
+              v: { type: "literal", value: 'a"b\\c\n\u0001d' },
+            }],
+          },
+        },
+      }),
+    ) as { results: { bindings: Array<Record<string, SparqlValue>> } };
+    // JSON.stringify escapes quotes, backslashes, and control characters;
+    // the parsed value is byte-identical to the original literal text.
+    assertEquals(parsed.results.bindings[0].v, {
+      type: "literal",
+      value: 'a"b\\c\n\u0001d',
+    });
+  },
+);
+
+Deno.test(
   "serializeJsonResults - round-trips a directional literal end to end",
   async () => {
     // A real query through the engine: the RDF 1.2 directional literal

--- a/src/serialize/json-results.test.ts
+++ b/src/serialize/json-results.test.ts
@@ -1,0 +1,160 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { serializeJsonResults } from "@/serialize/json-results.ts";
+import type { SparqlResponse, SparqlValue } from "@/sparql-engine-interface.ts";
+import { canonicalizeSparqlValue } from "@/term/mod.ts";
+import { MemoryStore as Store } from "@/store/memory-store.ts";
+import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
+
+/**
+ * Issue #61 JSON-only slice pins: serializeJsonResults produces the SPARQL
+ * results JSON (.srj) document whose parsed values canonicalize identically
+ * to the response's own wire values — including RDF 1.2 direction ("its:dir")
+ * and triple terms — with deterministic output and loud rejection of kinds
+ * the format does not cover.
+ */
+
+/** fullSpread is one binding row exercising every SparqlValue variant the
+ * wire format can carry: uri, bnode, plain literal, lang-tagged with base
+ * direction, typed literal, and an RDF 1.2 triple term. */
+const fullSpread: Record<string, SparqlValue> = {
+  iri: { type: "uri", value: "http://example.org/s" },
+  bn: { type: "bnode", value: "b0" },
+  plain: { type: "literal", value: "hello" },
+  lang: { type: "literal", value: "hola", "xml:lang": "es", "its:dir": "rtl" },
+  typed: {
+    type: "literal",
+    value: "42",
+    datatype: "http://www.w3.org/2001/XMLSchema#integer",
+  },
+  triple: {
+    type: "triple",
+    value: {
+      subject: { type: "uri", value: "http://example.org/a" },
+      predicate: { type: "uri", value: "http://example.org/p" },
+      object: { type: "literal", value: "x", "xml:lang": "en" },
+    },
+  },
+};
+
+const selectResponse: SparqlResponse = {
+  kind: "select",
+  data: {
+    head: { vars: Object.keys(fullSpread) },
+    results: { bindings: [fullSpread] },
+  },
+};
+
+Deno.test(
+  "serializeJsonResults - SELECT round-trips every SparqlValue variant",
+  () => {
+    const parsed = JSON.parse(serializeJsonResults(selectResponse)) as {
+      head: { vars: string[] };
+      results: { bindings: Array<Record<string, SparqlValue>> };
+    };
+    assertEquals(parsed.head.vars, Object.keys(fullSpread));
+    assertEquals(parsed.results.bindings.length, 1);
+    const row = parsed.results.bindings[0];
+    for (const name of Object.keys(fullSpread)) {
+      assertEquals(
+        canonicalizeSparqlValue(row[name]),
+        canonicalizeSparqlValue(fullSpread[name]),
+        `round-trip ${name}`,
+      );
+    }
+  },
+);
+
+Deno.test("serializeJsonResults - ASK round-trips the boolean", () => {
+  for (const boolean of [true, false]) {
+    const parsed = JSON.parse(
+      serializeJsonResults({ kind: "ask", data: { head: {}, boolean } }),
+    ) as { head: unknown; boolean: boolean };
+    assertEquals(parsed.boolean, boolean);
+    assertEquals(parsed.head, {});
+  }
+});
+
+Deno.test("serializeJsonResults - emits a deterministic .srj document", () => {
+  const response: SparqlResponse = {
+    kind: "select",
+    data: {
+      head: { vars: ["iri", "lang"] },
+      results: {
+        bindings: [
+          {
+            iri: { type: "uri", value: "http://example.org/s" },
+            lang: {
+              type: "literal",
+              value: "hola",
+              "xml:lang": "es",
+              "its:dir": "rtl",
+            },
+          },
+        ],
+      },
+    },
+  };
+  const golden = '{"head":{"vars":["iri","lang"]},"results":{"bindings":[' +
+    '{"iri":{"type":"uri","value":"http://example.org/s"},' +
+    '"lang":{"type":"literal","value":"hola","xml:lang":"es","its:dir":"rtl"}}]}}';
+  assertEquals(serializeJsonResults(response), golden);
+  // Determinism: serializing the same response twice is byte-identical.
+  assertEquals(serializeJsonResults(response), serializeJsonResults(response));
+});
+
+Deno.test("serializeJsonResults - passes head link through", () => {
+  const parsed = JSON.parse(
+    serializeJsonResults({
+      kind: "ask",
+      data: { head: { link: ["http://example.org/result"] }, boolean: true },
+    }),
+  ) as { head: { link?: string[] }; boolean: boolean };
+  assertEquals(parsed.head.link, ["http://example.org/result"]);
+  assertEquals(parsed.boolean, true);
+});
+
+Deno.test(
+  "serializeJsonResults - rejects kinds the format does not cover",
+  () => {
+    assertThrows(
+      () =>
+        serializeJsonResults({
+          kind: "construct",
+          data: { quads: [] },
+        }),
+      Error,
+      "SELECT and ASK",
+    );
+    assertThrows(
+      () => serializeJsonResults({ kind: "void" }),
+      Error,
+      "SELECT and ASK",
+    );
+  },
+);
+
+Deno.test(
+  "serializeJsonResults - round-trips a directional literal end to end",
+  async () => {
+    // A real query through the engine: the RDF 1.2 directional literal
+    // ("its:dir") must survive execute() -> SparqlValue -> .srj -> parse.
+    const store = new Store();
+    const engine = new WazooSparqlEngine({ store });
+    const result = await engine.execute({
+      query: 'SELECT ?v WHERE { BIND("hola"@es--rtl AS ?v) }',
+    });
+    if (result.kind !== "select") {
+      throw new Error(`expected select, got ${result.kind}`);
+    }
+    const doc = JSON.parse(serializeJsonResults(result)) as {
+      results: { bindings: Array<Record<string, SparqlValue>> };
+    };
+    const emitted = doc.results.bindings[0].v;
+    assertEquals(emitted, {
+      type: "literal",
+      value: "hola",
+      "xml:lang": "es",
+      "its:dir": "rtl",
+    });
+  },
+);

--- a/src/serialize/json-results.ts
+++ b/src/serialize/json-results.ts
@@ -1,0 +1,55 @@
+import type { SparqlResponse } from "@/sparql-engine-interface.ts";
+
+/**
+ * serializeJsonResults serializes a SELECT or ASK SparqlResponse into the
+ * SPARQL 1.1 Query Results JSON format ("application/sparql-results+json",
+ * the .srj serialization), extended with the SPARQL 1.2 direction and
+ * triple-term members the engine's wire format already carries.
+ *
+ * The response is already in the wire shape (src/sparql-engine-interface.ts):
+ * every SparqlValue is emitted as-is — uri/bnode as {type, value}; literals
+ * with their "xml:lang", "its:dir" (RDF 1.2 base direction), and datatype
+ * members; RDF 1.2 triple terms as the nested {type: "triple", value:
+ * {subject, predicate, object}} object — so this is a document builder, not a
+ * term re-encoder.
+ *
+ * Coverage: SELECT (head.vars + results.bindings) and ASK (boolean). The
+ * format does not cover CONSTRUCT/DESCRIBE (RDF graph results, serialized as
+ * RDF) or updates (void responses carry no result body) — those kinds throw
+ * a clear error.
+ *
+ * Output is deterministic: members are emitted in a fixed order (head, then
+ * results/boolean; for literals type, value, xml:lang, its:dir, datatype), so
+ * equal responses produce byte-identical documents.
+ */
+export function serializeJsonResults(response: SparqlResponse): string {
+  switch (response.kind) {
+    case "select": {
+      const head: Record<string, unknown> = {
+        vars: response.data.head.vars,
+      };
+      if (response.data.head.link?.length) {
+        head.link = response.data.head.link;
+      }
+      return JSON.stringify({
+        head,
+        results: { bindings: response.data.results.bindings },
+      });
+    }
+    case "ask": {
+      const head: Record<string, unknown> = {};
+      if (response.data.head.link?.length) {
+        head.link = response.data.head.link;
+      }
+      return JSON.stringify({ head, boolean: response.data.boolean });
+    }
+    case "construct":
+    case "void":
+      throw new Error(
+        `serializeJsonResults: cannot serialize a ${response.kind} response ` +
+          "— the SPARQL results JSON format covers SELECT and ASK only " +
+          "(CONSTRUCT/DESCRIBE results are RDF graphs; updates have no " +
+          "result body)",
+      );
+  }
+}

--- a/src/serialize/xml-results.test.ts
+++ b/src/serialize/xml-results.test.ts
@@ -1,0 +1,352 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import { serializeXmlResults } from "@/serialize/xml-results.ts";
+import type { SparqlResponse, SparqlValue } from "@/sparql-engine-interface.ts";
+import { canonicalizeSparqlValue } from "@/term/mod.ts";
+
+/**
+ * Issue #61 XML half pins: serializeXmlResults produces the SPARQL results
+ * XML (.srx) document whose parsed content canonicalizes identically to the
+ * response's wire values — including RDF 1.2 direction (its:dir), triple-term
+ * nesting, and blank-node labels — with XML escaping and deterministic
+ * output, and loud rejection of kinds the format does not cover.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Minimal XML reader (test-only): parses the writer's controlled       */
+/* element subset — attrs, text, five entities, no CDATA/namespaces.    */
+/* ------------------------------------------------------------------ */
+
+interface XNode {
+  name: string;
+  attrs: Record<string, string>;
+  text: string;
+  children: XNode[];
+}
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+}
+
+function parseXml(doc: string): XNode {
+  let pos = 0;
+  const isNameChar = (ch: string): boolean => /[A-Za-z0-9_:.-]/.test(ch);
+
+  const skipWs = (): void => {
+    while (pos < doc.length && /\s/.test(doc[pos])) pos++;
+  };
+  const expect = (text: string): void => {
+    if (!doc.startsWith(text, pos)) {
+      throw new Error(`expected ${text} at ${pos}`);
+    }
+    pos += text.length;
+  };
+  const parseName = (): string => {
+    const start = pos;
+    while (pos < doc.length && isNameChar(doc[pos])) pos++;
+    return doc.slice(start, pos);
+  };
+  const parseAttributes = (): Record<string, string> => {
+    const attrs: Record<string, string> = {};
+    for (;;) {
+      skipWs();
+      if (doc[pos] === ">" || (doc[pos] === "/" && doc[pos + 1] === ">")) {
+        return attrs;
+      }
+      const name = parseName();
+      skipWs();
+      expect("=");
+      skipWs();
+      const quote = doc[pos];
+      pos++;
+      const start = pos;
+      while (doc[pos] !== quote) pos++;
+      attrs[name] = decodeEntities(doc.slice(start, pos));
+      pos++;
+    }
+  };
+  const parseElement = (): XNode => {
+    skipWs();
+    expect("<");
+    const name = parseName();
+    const attrs = parseAttributes();
+    if (doc[pos] === "/" && doc[pos + 1] === ">") {
+      pos += 2;
+      return { name, attrs, text: "", children: [] };
+    }
+    expect(">");
+    const node: XNode = { name, attrs, text: "", children: [] };
+    for (;;) {
+      const lt = doc.indexOf("<", pos);
+      const text = doc.slice(pos, lt);
+      if (text.trim() !== "") {
+        node.text = decodeEntities(text);
+      }
+      pos = lt;
+      if (doc.startsWith("</", pos)) {
+        pos += 2;
+        const closeName = parseName();
+        if (closeName !== name) {
+          throw new Error(`mismatched close tag ${closeName} for ${name}`);
+        }
+        while (doc[pos] !== ">") pos++;
+        pos++;
+        return node;
+      }
+      if (doc.startsWith("<?", pos)) {
+        pos = doc.indexOf("?>", pos) + 2;
+        continue;
+      }
+      node.children.push(parseElement());
+    }
+  };
+
+  skipWs();
+  if (doc.startsWith("<?", pos)) {
+    pos = doc.indexOf("?>", pos) + 2;
+  }
+  return parseElement();
+}
+
+/** xmlTermToSparqlValue converts one parsed term element back to a wire
+ * value, so the round trip compares canonicalized SparqlValues symmetrically
+ * with the JSON writer tests. */
+function xmlTermToSparqlValue(node: XNode): SparqlValue {
+  switch (node.name) {
+    case "uri":
+      return { type: "uri", value: node.text };
+    case "bnode":
+      return { type: "bnode", value: node.text };
+    case "literal": {
+      const value: SparqlValue = { type: "literal", value: node.text };
+      if (node.attrs["xml:lang"]) {
+        value["xml:lang"] = node.attrs["xml:lang"];
+        if (node.attrs["its:dir"]) {
+          value["its:dir"] = node.attrs["its:dir"] as "ltr" | "rtl";
+        }
+      } else if (node.attrs.datatype) {
+        value.datatype = node.attrs.datatype;
+      }
+      return value;
+    }
+    case "triple": {
+      const part = (role: string): SparqlValue => {
+        const wrapper = node.children.find((child) => child.name === role);
+        if (wrapper === undefined || wrapper.children.length !== 1) {
+          throw new Error(`missing ${role} in triple term`);
+        }
+        return xmlTermToSparqlValue(wrapper.children[0]);
+      };
+      return {
+        type: "triple",
+        value: {
+          subject: part("subject"),
+          predicate: part("predicate"),
+          object: part("object"),
+        },
+      };
+    }
+    default:
+      throw new Error(`unexpected term element ${node.name}`);
+  }
+}
+
+/** bindingRowsOf extracts {name -> term node} rows from a parsed document. */
+function bindingRowsOf(root: XNode): Array<Record<string, XNode>> {
+  const results = root.children.find((child) => child.name === "results");
+  if (results === undefined) return [];
+  return results.children.map((result) => {
+    const row: Record<string, XNode> = {};
+    for (const binding of result.children) {
+      row[binding.attrs.name] = binding.children[0];
+    }
+    return row;
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/* Fixtures and tests.                                                 */
+/* ------------------------------------------------------------------ */
+
+const fullSpread: Record<string, SparqlValue> = {
+  iri: { type: "uri", value: "http://example.org/s" },
+  bn: { type: "bnode", value: "b0" },
+  plain: { type: "literal", value: "hello" },
+  lang: { type: "literal", value: "hola", "xml:lang": "es", "its:dir": "rtl" },
+  typed: {
+    type: "literal",
+    value: "42",
+    datatype: "http://www.w3.org/2001/XMLSchema#integer",
+  },
+  triple: {
+    type: "triple",
+    value: {
+      subject: { type: "uri", value: "http://example.org/a" },
+      predicate: { type: "uri", value: "http://example.org/p" },
+      object: { type: "literal", value: "x", "xml:lang": "en" },
+    },
+  },
+};
+
+const selectResponse: SparqlResponse = {
+  kind: "select",
+  data: {
+    head: { vars: Object.keys(fullSpread) },
+    results: { bindings: [fullSpread] },
+  },
+};
+
+Deno.test(
+  "serializeXmlResults - SELECT round-trips every SparqlValue variant",
+  () => {
+    const root = parseXml(serializeXmlResults(selectResponse));
+    const rows = bindingRowsOf(root);
+    assertEquals(rows.length, 1);
+    for (const name of Object.keys(fullSpread)) {
+      assertEquals(
+        canonicalizeSparqlValue(xmlTermToSparqlValue(rows[0][name])),
+        canonicalizeSparqlValue(fullSpread[name]),
+        `round-trip ${name}`,
+      );
+    }
+  },
+);
+
+Deno.test(
+  "serializeXmlResults - triple-term nesting matches the sparql12 fixture shape",
+  () => {
+    const root = parseXml(serializeXmlResults(selectResponse));
+    const triple = bindingRowsOf(root)[0].triple;
+    assertEquals(triple.name, "triple");
+    assertEquals(
+      triple.children.map((child) => child.name),
+      ["subject", "predicate", "object"],
+    );
+    // subject/predicate/object each wrap exactly one term element.
+    for (const role of triple.children) {
+      assertEquals(role.children.length, 1);
+    }
+    assertEquals(
+      xmlTermToSparqlValue(triple.children[0].children[0]),
+      { type: "uri", value: "http://example.org/a" },
+    );
+  },
+);
+
+Deno.test("serializeXmlResults - XML-escapes text and attribute values", () => {
+  const response: SparqlResponse = {
+    kind: "select",
+    data: {
+      head: {
+        vars: ["v"],
+        link: ["http://example.org/?a=1&b=2"],
+      },
+      results: {
+        bindings: [{ v: { type: "literal", value: "a<b&c>d\"e'f" } }],
+      },
+    },
+  };
+  const doc = serializeXmlResults(response);
+  const root = parseXml(doc);
+  const link = root.children[0].children.find((c) => c.name === "link");
+  assertEquals(link?.attrs.href, "http://example.org/?a=1&b=2");
+  assertEquals(
+    bindingRowsOf(root)[0].v.text,
+    "a<b&c>d\"e'f",
+  );
+  // The raw document carries the escaped forms.
+  assertEquals(doc.includes("&amp;b=2"), true);
+  assertEquals(doc.includes("a&lt;b&amp;c&gt;d"), true);
+});
+
+Deno.test("serializeXmlResults - blank-node labels round-trip intact", () => {
+  const root = parseXml(serializeXmlResults(selectResponse));
+  const bn = bindingRowsOf(root)[0].bn;
+  assertEquals(bn.name, "bnode");
+  assertEquals(bn.text, "b0");
+  assertEquals(xmlTermToSparqlValue(bn), { type: "bnode", value: "b0" });
+});
+
+Deno.test("serializeXmlResults - ASK round-trips the boolean", () => {
+  for (const boolean of [true, false]) {
+    const root = parseXml(
+      serializeXmlResults({ kind: "ask", data: { head: {}, boolean } }),
+    );
+    const booleanNode = root.children.find((c) => c.name === "boolean");
+    assertEquals(booleanNode?.text, String(boolean));
+  }
+});
+
+Deno.test("serializeXmlResults - emits a deterministic .srx document", () => {
+  const response: SparqlResponse = {
+    kind: "select",
+    data: {
+      head: { vars: ["iri", "bn", "lang"] },
+      results: {
+        bindings: [
+          {
+            iri: { type: "uri", value: "http://example.org/s" },
+            bn: { type: "bnode", value: "b0" },
+            lang: {
+              type: "literal",
+              value: "hola",
+              "xml:lang": "es",
+              "its:dir": "rtl",
+            },
+          },
+        ],
+      },
+    },
+  };
+  const golden = '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<sparql xmlns="http://www.w3.org/2005/sparql-results#" ' +
+    'xmlns:its="http://www.w3.org/2005/11/its" its:version="2.0">\n' +
+    "  <head>\n" +
+    '    <variable name="iri"/>\n' +
+    '    <variable name="bn"/>\n' +
+    '    <variable name="lang"/>\n' +
+    "  </head>\n" +
+    "  <results>\n" +
+    "    <result>\n" +
+    '      <binding name="iri">\n' +
+    "        <uri>http://example.org/s</uri>\n" +
+    "      </binding>\n" +
+    '      <binding name="bn">\n' +
+    "        <bnode>b0</bnode>\n" +
+    "      </binding>\n" +
+    '      <binding name="lang">\n' +
+    '        <literal xml:lang="es" its:dir="rtl">hola</literal>\n' +
+    "      </binding>\n" +
+    "    </result>\n" +
+    "  </results>\n" +
+    "</sparql>\n";
+  assertEquals(serializeXmlResults(response), golden);
+  assertEquals(
+    serializeXmlResults(response),
+    serializeXmlResults(response),
+  );
+});
+
+Deno.test(
+  "serializeXmlResults - rejects kinds the format does not cover",
+  () => {
+    assertThrows(
+      () =>
+        serializeXmlResults({
+          kind: "construct",
+          data: { quads: [] },
+        }),
+      Error,
+      "SELECT and ASK",
+    );
+    assertThrows(
+      () => serializeXmlResults({ kind: "void" }),
+      Error,
+      "SELECT and ASK",
+    );
+  },
+);

--- a/src/serialize/xml-results.ts
+++ b/src/serialize/xml-results.ts
@@ -1,0 +1,146 @@
+import type { SparqlResponse, SparqlValue } from "@/sparql-engine-interface.ts";
+
+/**
+ * serializeXmlResults serializes a SELECT or ASK SparqlResponse into the
+ * SPARQL 1.1 Query Results XML format ("application/sparql-results+xml", the
+ * .srx serialization), extended with the SPARQL 1.2 surface the engine's wire
+ * format carries: RDF 1.2 triple terms as nested <subject>/<predicate>/<object>
+ * elements, and the base direction of a directional language-tagged literal
+ * as the its:dir attribute (ITS 2.0 namespace, mirroring how the SPARQL 1.2
+ * results JSON format carries it) — matching the shape of the vendored
+ * sparql12 .srx fixtures.
+ *
+ * Coverage: SELECT (head variables + one <result> per binding) and ASK
+ * (<boolean>). The format does not cover CONSTRUCT/DESCRIBE (RDF graph
+ * results, serialized as RDF) or updates (void responses carry no result
+ * body) — those kinds throw a clear error.
+ *
+ * Output is deterministic: elements are emitted in a fixed order with
+ * two-space indentation, and every text/attribute value is XML-escaped
+ * (&, <, >, ", '), so equal responses produce byte-identical documents.
+ */
+export function serializeXmlResults(response: SparqlResponse): string {
+  const out: string[] = [];
+  out.push('<?xml version="1.0" encoding="UTF-8"?>');
+  out.push(
+    '<sparql xmlns="http://www.w3.org/2005/sparql-results#" ' +
+      'xmlns:its="http://www.w3.org/2005/11/its" its:version="2.0">',
+  );
+  switch (response.kind) {
+    case "select": {
+      out.push("  <head>");
+      for (const variable of response.data.head.vars) {
+        out.push(`    <variable name="${escapeAttr(variable)}"/>`);
+      }
+      for (const link of response.data.head.link ?? []) {
+        out.push(`    <link href="${escapeAttr(link)}"/>`);
+      }
+      out.push("  </head>");
+      out.push("  <results>");
+      for (const binding of response.data.results.bindings) {
+        out.push("    <result>");
+        for (const name of Object.keys(binding)) {
+          out.push(`      <binding name="${escapeAttr(name)}">`);
+          pushTerm(out, binding[name], 8);
+          out.push("      </binding>");
+        }
+        out.push("    </result>");
+      }
+      out.push("  </results>");
+      break;
+    }
+    case "ask": {
+      out.push("  <head>");
+      for (const link of response.data.head.link ?? []) {
+        out.push(`    <link href="${escapeAttr(link)}"/>`);
+      }
+      out.push("  </head>");
+      out.push(`  <boolean>${response.data.boolean}</boolean>`);
+      break;
+    }
+    case "construct":
+    case "void":
+      throw new Error(
+        `serializeXmlResults: cannot serialize a ${response.kind} response ` +
+          "— the SPARQL results XML format covers SELECT and ASK only " +
+          "(CONSTRUCT/DESCRIBE results are RDF graphs; updates have no " +
+          "result body)",
+      );
+  }
+  out.push("</sparql>");
+  return out.join("\n") + "\n";
+}
+
+/**
+ * pushTerm appends one SparqlValue as its XML term element. Literals carry
+ * their xml:lang (plus the RDF 1.2 its:dir attribute when directional) or
+ * their datatype; triple terms nest a subject/predicate/object wrapper, each
+ * holding a term element — the SPARQL 1.2 triple-term results encoding.
+ */
+function pushTerm(
+  out: string[],
+  value: SparqlValue,
+  indent: number,
+): void {
+  const pad = " ".repeat(indent);
+  switch (value.type) {
+    case "uri":
+      out.push(`${pad}<uri>${escapeText(value.value)}</uri>`);
+      break;
+    case "bnode":
+      out.push(`${pad}<bnode>${escapeText(value.value)}</bnode>`);
+      break;
+    case "literal": {
+      const attributes: string[] = [];
+      if (value["xml:lang"]) {
+        attributes.push(`xml:lang="${escapeAttr(value["xml:lang"])}"`);
+        if (value["its:dir"]) {
+          attributes.push(`its:dir="${escapeAttr(value["its:dir"])}"`);
+        }
+      } else if (value.datatype) {
+        attributes.push(`datatype="${escapeAttr(value.datatype)}"`);
+      }
+      out.push(
+        `${pad}<literal${
+          attributes.length > 0 ? " " + attributes.join(" ") : ""
+        }>` +
+          `${escapeText(value.value)}</literal>`,
+      );
+      break;
+    }
+    case "triple": {
+      out.push(`${pad}<triple>`);
+      pushTriplePart(out, "subject", value.value.subject, indent + 2);
+      pushTriplePart(out, "predicate", value.value.predicate, indent + 2);
+      pushTriplePart(out, "object", value.value.object, indent + 2);
+      out.push(`${pad}</triple>`);
+      break;
+    }
+  }
+}
+
+/** pushTriplePart wraps one triple-term position in its role element. */
+function pushTriplePart(
+  out: string[],
+  role: "subject" | "predicate" | "object",
+  value: SparqlValue,
+  indent: number,
+): void {
+  const pad = " ".repeat(indent);
+  out.push(`${pad}<${role}>`);
+  pushTerm(out, value, indent + 2);
+  out.push(`${pad}</${role}>`);
+}
+
+/** escapeText XML-escapes text content (&, <, >). */
+function escapeText(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(
+    />/g,
+    "&gt;",
+  );
+}
+
+/** escapeAttr XML-escapes an attribute value (&, <, >, ", '). */
+function escapeAttr(text: string): string {
+  return escapeText(text).replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}


### PR DESCRIPTION
The wiki-sync skill now lives in the wiki toolchain repo (`repos/wiki/skills/wiki-sync/`), alongside the `wiki` and `wiki-feedback` skills; `08-maintenance.md` referenced the old workspace-cli path.