### PR TITLE
docs: fix wiki links that escape the Pages root

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,10 +27,12 @@ relative to the repository root.
 | [06 — Supplemental Context](06-supplemental-context.md) | Datasets, W3C suite notes, divergences, metadata       |
 | [08 — Wiki Maintenance](08-maintenance.md)              | The sync procedure: keep this wiki truthful to `main`  |
 
-Related in-repo documents: [ARCHITECTURE.md](../ARCHITECTURE.md) (topology and
-`@worlds/client` relationship), [CONTEXT.md](../CONTEXT.md) (glossary), and
-[`docs/durable-transactions.md`](durable-transactions.md) (SQLite transaction
-backend prototype).
+Related in-repo documents:
+[ARCHITECTURE.md](https://github.com/wazootech/sparql-engine/blob/main/ARCHITECTURE.md)
+(topology and `@worlds/client` relationship),
+[CONTEXT.md](https://github.com/wazootech/sparql-engine/blob/main/CONTEXT.md)
+(glossary), and [`docs/durable-transactions.md`](durable-transactions.md)
+(SQLite transaction backend prototype).
 
 ## One-paragraph map
 


### PR DESCRIPTION
On the live wiki, `../ARCHITECTURE.md` and `../CONTEXT.md` (in `docs/README.md`'s "Related in-repo documents") resolved to `https://wazootech.github.io/ARCHITECTURE.md` — the org root, not the wiki — and 404'd. The Pages site root is `docs/`, so any `../` link escapes it entirely; those two repo-root files aren't published on the wiki at all.

Audited the whole wiki for the same error class (relative links whose targets live outside `docs/`): nav, layout, prev-next include, and all 0X-*.md pages resolve within the site. Only these two links were broken.

Fix: point them at the GitHub blob URLs.