### PR TITLE
docs: add tree-shakeable subpath quickstart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,100 @@ if (result.kind === "select") {
 }
 ```
 
+## Tree-shakeable subpath imports
+
+The package also exposes four subpath entrypoints, so a consumer that only needs
+one layer never loads the whole engine graph. Each subpath's import closure is
+measured by `deno task bench:size:closures` — a store-only app pays **53 KiB
+instead of 576 KiB**, and the serializers are the cheapest leaf at 7.4 KiB.
+
+### `@wazoo/sparql-engine/term` — term algebra (40.3 KiB)
+
+RDF/JS term construction, hashing, comparison, and conversion, without the
+evaluator:
+
+```typescript
+import { DataFactory, sameRdfTerm, termKey } from "@wazoo/sparql-engine/term";
+
+const { literal, namedNode } = DataFactory;
+const xsd = "http://www.w3.org/2001/XMLSchema#";
+const a = literal("42", namedNode(xsd + "integer"));
+const b = literal("42", namedNode(xsd + "integer"));
+
+termKey(a); // stable hash key for maps/sets
+sameRdfTerm(a, b); // structural equality incl. datatype → true
+```
+
+### `@wazoo/sparql-engine/store` — RDF/JS quad store (53.1 KiB)
+
+The zero-dependency in-memory store, implementing the full `rdfjs.Store`
+interface — no query engine attached:
+
+```typescript
+import { DataFactory } from "@wazoo/sparql-engine/term";
+import { MemoryStore } from "@wazoo/sparql-engine/store";
+
+const { literal, namedNode, quad } = DataFactory;
+const store = new MemoryStore([
+  quad(
+    namedNode("https://example.org/alice"),
+    namedNode("https://xmlns.com/foaf/0.1/name"),
+    literal("Alice"),
+  ),
+]);
+
+// `match` returns an RDF/JS stream (async iterable)
+for await (const q of store.match(namedNode("https://example.org/alice"))) {
+  console.log(q.object.value); // "Alice"
+}
+```
+
+### `@wazoo/sparql-engine/parser` — SPARQL AST parser (213.8 KiB)
+
+Parse SPARQL 1.1 & 1.2 into the sparqljs-compatible AST without loading the
+evaluator:
+
+```typescript
+import { SparqlParser } from "@wazoo/sparql-engine/parser";
+
+const ast = new SparqlParser({ sparqlStar: true }).parse(
+  "SELECT ?s WHERE { ?s ?p ?o }",
+);
+console.log(ast.type); // "query"
+console.log(ast.variables); // [Variable{ value: "s" }]
+```
+
+### `@wazoo/sparql-engine/serialize` — results writers (7.4 KiB)
+
+Serialize a `SparqlResponse` to SPARQL results JSON (`.srj`) or XML (`.srx`):
+
+```typescript
+import {
+  serializeJsonResults,
+  serializeXmlResults,
+} from "@wazoo/sparql-engine/serialize";
+
+const response = {
+  kind: "select",
+  data: {
+    head: { vars: ["s"] },
+    results: {
+      bindings: [
+        { s: { type: "uri", value: "https://example.org/alice" } },
+      ],
+    },
+  },
+};
+
+serializeJsonResults(response); // {"head":{"vars":["s"]},"results":…}
+serializeXmlResults(response); // <?xml version="1.0" encoding="UTF-8"?>…
+```
+
+The subpaths can be mixed freely — e.g. the store above with the term layer, or
+the serializers fed by `engine.execute()`'s response. Anything not re-exported
+through `./term`, `./store`, `./parser`, or `./serialize` (or the root
+entrypoint) is private surface.
+
 ## Parity testing
 
 The differential test suite in `test/parity/` proves behavioral equivalence with


### PR DESCRIPTION
Adds a "Tree-shakeable subpath imports" section to the root README, right after the main Usage block, documenting the four subpath entrypoints from PR #102:

- **`./term`** (40.3 KiB) — `DataFactory`, `termKey`, `sameRdfTerm` for term hashing/equality without the evaluator
- **`./store`** (53.1 KiB) — store-only `MemoryStore` session (async-iterable `match`)
- **`./parser`** (213.8 KiB) — `SparqlParser` → sparqljs-compatible AST, no evaluator
- **`./serialize`** (7.4 KiB) — `serializeJsonResults` / `serializeXmlResults` over a `SparqlResponse`

Each section carries the measured import closure size (vs 575.9 KiB for the full engine) and a runnable example — every snippet was executed against the local modules before committing. A closing note clarifies the mixing rule and that anything not re-exported through the subpaths is private surface.