### PR TITLE
chore: rename "native" engine references to "wazoo"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       # EXISTS gate runs even if the ci task's dependency list changes.
       - run: deno task test:exists-ref
       - run: deno task publish:dry
-  # W3C differential gate: native must agree with comunica on the vendored
+  # W3C differential gate: wazoo must agree with comunica on the vendored
   # SPARQL 1.1 evaluation-core suite. The pass rate is the tracked progress
-  # metric — this job goes green only on a full pass (345/345): native agrees
+  # metric — this job goes green only on a full pass (345/345): wazoo agrees
   # with comunica, or matches the W3C reference where comunica is wrong.
   w3c-parity:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ repository in the Wazoo multi-repo workspace.
 - **Zero cryptic abbreviations:** Never utilize ambiguous shorthand (`rs`,
   `res`, `q`, `err`). Use `resultSet`, `response`, `quad`, `error`.
 - **Direct file-symbol alignment:** Source filenames must match exported primary
-  symbols using lowercase kebab-case (e.g. `native-sparql-engine.ts`).
+  symbols using lowercase kebab-case (e.g. `wazoo-sparql-engine.ts`).
 - **JSDoc semantics:** JSDoc comments for all exported symbols MUST begin
   directly with the symbol's exact name.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,6 @@ transaction objects.
 The interface is intentionally duplicated in both packages under an
 identical-spec policy: the two copies must stay identical. Behavioral deltas
 today: `ComunicaSparqlEngine` enforces `timeoutMs` and accepts a request-level
-`baseIri`, while the native engine derives the base IRI from the query's `BASE`
+`baseIri`, while the wazoo engine derives the base IRI from the query's `BASE`
 directive and does not yet enforce a timeout. Keep these differences in mind
 when swapping engines.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,19 +12,19 @@
   an RDF/JS store. `WazooSparqlEngine` is a drop-in replacement behind
   `SparqlEngineInterface`, with no client changes.
 - **Parity reference** — the installed `@comunica/query-sparql-rdfjs-lite`
-  (5.3.0) that the native engine is measured against. The porting surface is the
+  (5.3.0) that the wazoo engine is measured against. The porting surface is the
   lite config (`config-rdfjs-lite-v5-1-3.json` in the Comunica monorepo).
 - **Differential parity** — the harness's deep comparison of SELECT bindings,
   CONSTRUCT quads, ASK booleans, and final update store contents across engines
   on identical inputs. A feature is "done" only when it agrees differentially.
 - **Spec-wins divergence** — when the parity reference contradicts the SPARQL
-  spec (e.g. `LIMIT 0` ignored, malformed regex throws), the native engine
+  spec (e.g. `LIMIT 0` ignored, malformed regex throws), the wazoo engine
   implements the spec, documents the divergence, and skips the parity case.
 - **Superset directive** — the standing rule that anything the parity reference
-  can do, the native engine must do; parity is the floor. The **superset
+  can do, the wazoo engine must do; parity is the floor. The **superset
   ceiling** is the as-yet-uncharted question of which features beyond that floor
-  the native engine should carry.
-- **In-repo parser** — the parser module the native engine owns (`src/parser/`):
+  the wazoo engine should carry.
+- **In-repo parser** — the parser module the wazoo engine owns (`src/parser/`):
   a maintained sparqljs 3.7.4 grammar, extended in-repo with the SPARQL 1.2
   surface, no longer a runtime dependency.
 - **Pattern-evaluation hook** — the injected seam that lets the pure expression

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # @wazoo/sparql-engine
 
-Wazoo-native SPARQL 1.1 & 1.2 Query & Update Engine over RDF/JS Quad Stores.
+Wazoo SPARQL 1.1 & 1.2 Query & Update Engine over RDF/JS Quad Stores.
 
 ## Key capabilities
 
-- **SPARQL 1.1 & 1.2 Query Engine**: Native evaluation of `SELECT`, `ASK`,
+- **SPARQL 1.1 & 1.2 Query Engine**: Wazoo evaluation of `SELECT`, `ASK`,
   `CONSTRUCT`, and `DESCRIBE` queries over `rdfjs.Store` sources — including
   SPARQL 1.2 direction functions (`LANGDIR`, `STRLANGDIR`, `hasLang`,
   `hasLangDir`) and RDF 1.2 reified triple terms (`<< s p o >>`).
@@ -20,7 +20,7 @@ Wazoo-native SPARQL 1.1 & 1.2 Query & Update Engine over RDF/JS Quad Stores.
   terms, reifiers, and annotations); zero runtime dependencies (only type-only
   `@rdfjs/types`), and no Comunica framework overhead — browser-friendly and
   JSR-ready without transitive npm baggage.
-- **JSR & Deno Native**: Published on JSR as `@wazoo/sparql-engine` for Deno,
+- **JSR & Deno Wazoo**: Published on JSR as `@wazoo/sparql-engine` for Deno,
   Node.js, and browser environments.
 - **Drop-in for `@worlds/client`**: Implements the same `SparqlEngineInterface`
   as `ComunicaSparqlEngine` (`@worlds/client/comunica`), so it can be swapped
@@ -67,8 +67,8 @@ ASK booleans, and CONSTRUCT quads.
 
 Blank nodes are compared by identity, not by label. Comunica skolemizes blank
 nodes from query sources into prefixed labels (`bc_<sourceId>_<label>`); the
-native engine returns the store's own labels. SPARQL 1.1 result semantics treat
-blank node labels as scoped and opaque, so the native engine deliberately does
+wazoo engine returns the store's own labels. SPARQL 1.1 result semantics treat
+blank node labels as scoped and opaque, so the wazoo engine deliberately does
 not replicate the prefix — the harness strips it from Comunica's output before
 comparing (see `test/parity/parity-harness.ts`). A test in
 `test/parity/parity.test.ts` locks in this known difference against real
@@ -97,7 +97,7 @@ benchmark stores. The reorder-chain group demonstrates the dynamic join
 ordering: a three-pattern chain written in worst-case order runs ~90x faster
 with reordering enabled, because the planner scans each pattern once and joins
 in order of estimated cost, preferring patterns whose variables are already
-bound. Timings use Deno's built-in bench runner with the native engine as the
+bound. Timings use Deno's built-in bench runner with the wazoo engine as the
 per-group baseline:
 
 ```bash
@@ -106,14 +106,14 @@ deno task bench
 
 ### Results
 
-A snapshot measured on a Windows desktop with Deno 2.9.5 (native engine as the
+A snapshot measured on a Windows desktop with Deno 2.9.5 (wazoo engine as the
 per-group baseline). Each cell is the per-iteration average; every query is
 cross-verified to return identical results on all three engines before timing.
 Timings are machine-specific — run `deno task bench` for your own numbers.
 
 Core joins, 400-person graph (~2,200 quads):
 
-| query                        | native   | comunica | oxigraph |
+| query                        | wazoo    | comunica | oxigraph |
 | ---------------------------- | -------- | -------- | -------- |
 | full scan                    | 1.3 ms   | 7.6 ms   | 12.2 ms  |
 | join (knows × name)          | 1.0 ms   | 5.2 ms   | 2.6 ms   |
@@ -123,7 +123,7 @@ Core joins, 400-person graph (~2,200 quads):
 
 EXISTS surface, 400-person graph:
 
-| query               | native  | comunica | oxigraph |
+| query               | wazoo   | comunica | oxigraph |
 | ------------------- | ------- | -------- | -------- |
 | `FILTER EXISTS`     | 0.81 ms | 29.2 ms  | 1.0 ms   |
 | `FILTER NOT EXISTS` | 0.88 ms | 33.3 ms  | 1.3 ms   |
@@ -132,34 +132,34 @@ EXISTS surface, 400-person graph:
 
 EXISTS surface, 10,000-person graph (~55,000 quads):
 
-| query               | native  | comunica | oxigraph |
+| query               | wazoo   | comunica | oxigraph |
 | ------------------- | ------- | -------- | -------- |
 | `FILTER EXISTS`     | 27.8 ms | 729.5 ms | 27.0 ms  |
 | `FILTER NOT EXISTS` | 26.8 ms | 835.9 ms | 30.7 ms  |
 | nested `EXISTS`     | 41.3 ms | 3.1 s    | 43.3 ms  |
 | nested `NOT EXISTS` | 39.6 ms | 3.2 s    | 32.3 ms  |
 
-Scaling the data 25x (400 → 10,000 people) grows native's EXISTS cost ~35-40x
+Scaling the data 25x (400 → 10,000 people) grows wazoo's EXISTS cost ~35-40x
 while the nested-vs-simple ratio _shrinks_ (1.45x → 1.12x): the snapshot is
 drained and indexed once per query, and each probe touches only its candidate
 bucket, so nesting stays cheap relative to the dataset. Across the exists
-surface native is 20-180x faster than comunica and roughly at parity with
+surface wazoo is 20-180x faster than comunica and roughly at parity with
 oxigraph (a compiled Rust/WASM engine with native indexes, which remains ahead
-on the reorder-chain row); on the core scan/join rows native is the fastest of
+on the reorder-chain row); on the core scan/join rows wazoo is the fastest of
 the three.
 
 Join surface, 10,000-person graph (~55,000 quads) — UNION joins 10k x 20k
 bindings on the shared subject (~200M candidate pairs); OPTIONAL and MINUS join
-10k x 5k (~50M pairs). The native engine's hash join probes an indexed right
-side per left binding instead of scanning it:
+10k x 5k (~50M pairs). The wazoo engine's hash join probes an indexed right side
+per left binding instead of scanning it:
 
-| query               | native  | comunica | oxigraph |
+| query               | wazoo   | comunica | oxigraph |
 | ------------------- | ------- | -------- | -------- |
 | UNION (10k x 20k)   | 45.1 ms | 106.6 ms | 107.5 ms |
 | OPTIONAL (10k x 5k) | 22.1 ms | 587.9 ms | 56.5 ms  |
 | MINUS (10k x 5k)    | 18.0 ms | 41.7 ms  | 23.1 ms  |
 
-On this surface native leads all three engines, and the fan-out join scaling is
+On this surface wazoo leads all three engines, and the fan-out join scaling is
 sub-quadratic: the nested-loop before-state for the same UNION was ~7 s/iter
 versus 45 ms with the hash join (~150x), with OPTIONAL and MINUS showing the
 same shape (~60-80x).
@@ -176,16 +176,15 @@ summarize both:
 
 | engine   | on disk      | contents                                                                                                                                        |
 | -------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| native   | **0.61 MiB** | 37 files (the whole JSR artifact: `src/` + `README.md` + `LICENSE`; build-time grammars + unreachable code excluded); zero runtime dependencies |
+| wazoo    | **0.61 MiB** | 37 files (the whole JSR artifact: `src/` + `README.md` + `LICENSE`; build-time grammars + unreachable code excluded); zero runtime dependencies |
 | oxigraph | 7.9 MiB      | WASM runtime (7.8 MiB) + JS glue/types                                                                                                          |
 | comunica | 28.3 MiB     | 368 npm packages in the transitive dependency closure                                                                                           |
 
-Regenerated by `deno task bench:size`. The native artifact is **~0.61 MiB on
-disk (~0.13 MiB gzipped)** — the JSR `publish.exclude` drops the build-time
-grammar sources (`*.jison`, `generate-parser.ts`, ~88 KiB) and the unreachable
-Node-only `sqlite-store.ts` (~11 KiB), so consumers never install build
-artifacts; the treemap and the `bench:size` JSON both mirror that file set
-exactly.
+Regenerated by `deno task bench:size`. The wazoo artifact is **~0.61 MiB on disk
+(~0.13 MiB gzipped)** — the JSR `publish.exclude` drops the build-time grammar
+sources (`*.jison`, `generate-parser.ts`, ~88 KiB) and the unreachable Node-only
+`sqlite-store.ts` (~11 KiB), so consumers never install build artifacts; the
+treemap and the `bench:size` JSON both mirror that file set exactly.
 
 **Per-entrypoint consumer closure** — what importing a subpath actually loads
 from the published package (value-import graph, type-only imports erased;
@@ -210,16 +209,16 @@ symmetric):
 
 ![Memory treemap](docs/assets/treemap-memory.svg)
 
-| workload             | native     | comunica | oxigraph |
+| workload             | wazoo      | comunica | oxigraph |
 | -------------------- | ---------- | -------- | -------- |
 | full scan (55k rows) | **134 MB** | 214 MB   | 251 MB   |
 | nested EXISTS        | **82 MB**  | 271 MB   | 108 MB   |
 
-Native is the smallest on disk by 13-46x (0.61 vs 7.9 vs 28.3 MiB) and holds its
+Wazoo is the smallest on disk by 13-46x (0.61 vs 7.9 vs 28.3 MiB) and holds its
 speed advantage with the lowest peak heap on both workloads — including a peak
 roughly a third of comunica's on the nested-EXISTS surface the timings above
 highlight. Oxigraph's WASM runtime is compact on disk, but its result
-materialization peaks higher than native on both workloads.
+materialization peaks higher than wazoo on both workloads.
 
 These are machine-specific snapshots (Deno 2.9.5, Windows), not guarantees.
 Regenerate them with `deno task bench:size` (library sizes, from the installed

--- a/bench/collect-memory.ts
+++ b/bench/collect-memory.ts
@@ -5,7 +5,7 @@
 // Run: deno run --allow-all --allow-write --allow-read bench/collect-memory.ts
 import { join } from "@std/path";
 
-const ENGINES = ["native", "comunica", "oxigraph"];
+const ENGINES = ["wazoo", "comunica", "oxigraph"];
 const WORKLOADS = ["scan", "exists"] as const;
 
 const engines: Record<string, Record<string, unknown>> = {};

--- a/bench/engine_bench.ts
+++ b/bench/engine_bench.ts
@@ -191,8 +191,8 @@ const dataset = buildDataset();
 const memoryStore = seedStore(dataset);
 const oxigraphStore = seedOxigraphStore(dataset);
 
-const nativeEngine = new WazooSparqlEngine({ store: memoryStore });
-const nativeEngineNoReorder = new WazooSparqlEngine({
+const wazooEngine = new WazooSparqlEngine({ store: memoryStore });
+const wazooEngineNoReorder = new WazooSparqlEngine({
   store: memoryStore,
   reorderPatterns: false,
 });
@@ -204,7 +204,7 @@ const comunicaEngine = getComunicaEngine();
 const largeDataset = buildPeopleDataset(LARGE_PERSON_COUNT);
 const largeMemoryStore = seedStore(largeDataset);
 const largeOxigraphStore = seedOxigraphStore(largeDataset);
-const largeNativeEngine = new WazooSparqlEngine({ store: largeMemoryStore });
+const largeWazooEngine = new WazooSparqlEngine({ store: largeMemoryStore });
 
 // GRAPH / FROM groups run against their own named-graph stores; the update
 // verification keeps the main dataset default-graph-only so its graph-blind
@@ -212,14 +212,14 @@ const largeNativeEngine = new WazooSparqlEngine({ store: largeMemoryStore });
 const graphDataset = buildGraphDataset();
 const graphMemoryStore = seedStore(graphDataset);
 const graphOxigraphStore = seedOxigraphStore(graphDataset);
-const graphNativeEngine = new WazooSparqlEngine({ store: graphMemoryStore });
+const graphWazooEngine = new WazooSparqlEngine({ store: graphMemoryStore });
 const graphOpsDataset = buildGraphOpsDataset();
 
 const scanQuery = "SELECT ?s ?p ?o WHERE { ?s ?p ?o }";
 const joinQuery =
   "SELECT ?friend ?name WHERE { ?person <http://xmlns.com/foaf/0.1/knows> ?friend . " +
   "?friend <http://xmlns.com/foaf/0.1/name> ?name }";
-// Written order is worst-case for the native engine: the unselective pattern
+// Written order is worst-case for the wazoo engine: the unselective pattern
 // (0 constants, matches all 1,600 quads) comes first, followed by a very
 // selective pattern (2 constants, 1 quad). Static reordering flips them.
 const asymJoinQuery = "SELECT ?s ?p ?o ?n WHERE { ?s ?p ?o . " +
@@ -273,7 +273,7 @@ const unionQuery =
   "UNION { ?s <http://example.org/pet> ?p } }";
 // 10k join-scaling queries: each joins a large accumulated binding set
 // against a large right side on the shared subject variable, so the rows
-// measure the join machinery (hash join for the native engine) rather than
+// measure the join machinery (hash join for the wazoo engine) rather than
 // the element evaluation. UNION joins 10k x 20k (~200M candidate pairs),
 // OPTIONAL and MINUS join 10k x 5k (~50M pairs).
 const unionJoinQuery =
@@ -352,7 +352,7 @@ const nestedNotExistsQuery =
 // XSD cast constructors over the integer age literal, plus boolean and
 // dateTime casts from string constants (the shared dataset carries no
 // boolean/dateTime literals). The xsd prefix is declared explicitly because
-// Oxigraph requires it for cast-function syntax. xsd:double is omitted: native
+// Oxigraph requires it for cast-function syntax. xsd:double is omitted: wazoo
 // and Comunica emit the canonical "2.0E1" lexical form while Oxigraph emits
 // "20", so a three-engine lexical comparison cannot cross-verify it.
 const castNumericQuery = "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> " +
@@ -457,7 +457,7 @@ function quadRecord(
  * dedupeRecords keeps one copy of each distinct canonical record, preserving
  * first-occurrence order. Reference-engine CONSTRUCT streams may repeat a
  * triple their graph would not, so the reference side of a cross-engine
- * comparison is normalized to graph content before comparing — the native
+ * comparison is normalized to graph content before comparing — the wazoo
  * side stays as-emitted (issue #87 contract).
  */
 function dedupeRecords<T>(records: T[]): T[] {
@@ -637,23 +637,23 @@ function oxigraphBindingRecord(binding: OxigraphBinding): string {
  * results for the given query, so benchmark timings compare like for like.
  */
 interface EngineTrio {
-  native: WazooSparqlEngine;
+  wazoo: WazooSparqlEngine;
   comunicaStore: Store;
   oxigraph: OxigraphStore;
 }
 
 const mainTrio: EngineTrio = {
-  native: nativeEngine,
+  wazoo: wazooEngine,
   comunicaStore: memoryStore,
   oxigraph: oxigraphStore,
 };
 const largeTrio: EngineTrio = {
-  native: largeNativeEngine,
+  wazoo: largeWazooEngine,
   comunicaStore: largeMemoryStore,
   oxigraph: largeOxigraphStore,
 };
 const graphTrio: EngineTrio = {
-  native: graphNativeEngine,
+  wazoo: graphWazooEngine,
   comunicaStore: graphMemoryStore,
   oxigraph: graphOxigraphStore,
 };
@@ -663,11 +663,11 @@ async function verifySelectEquality(
   label: string,
   trio: EngineTrio = mainTrio,
 ): Promise<void> {
-  const nativeResult = await trio.native.execute({ query });
-  if (nativeResult.kind !== "select") {
-    throw new Error(`${label}: native engine returned ${nativeResult.kind}`);
+  const wazooResult = await trio.wazoo.execute({ query });
+  if (wazooResult.kind !== "select") {
+    throw new Error(`${label}: wazoo engine returned ${wazooResult.kind}`);
   }
-  const nativeSet = nativeResult.data.results.bindings
+  const wazooSet = wazooResult.data.results.bindings
     .map((binding) => {
       const record: Record<string, CanonicalTerm> = {};
       for (const name of Object.keys(binding)) {
@@ -698,14 +698,14 @@ async function verifySelectEquality(
   const oxigraphSet = oxigraphBindings.map(oxigraphBindingRecord).sort();
 
   assertEquals(
-    nativeSet,
+    wazooSet,
     comunicaSet,
-    `${label}: native and comunica disagree`,
+    `${label}: wazoo and comunica disagree`,
   );
   assertEquals(
-    nativeSet,
+    wazooSet,
     oxigraphSet,
-    `${label}: native and oxigraph disagree`,
+    `${label}: wazoo and oxigraph disagree`,
   );
 }
 
@@ -713,9 +713,9 @@ async function verifySelectEquality(
  * verifyAskEquality asserts all three engines return the same ASK boolean.
  */
 async function verifyAskEquality(query: string, label: string): Promise<void> {
-  const nativeResult = await nativeEngine.execute({ query });
-  if (nativeResult.kind !== "ask") {
-    throw new Error(`${label}: native engine returned ${nativeResult.kind}`);
+  const wazooResult = await wazooEngine.execute({ query });
+  if (wazooResult.kind !== "ask") {
+    throw new Error(`${label}: wazoo engine returned ${wazooResult.kind}`);
   }
   const comunicaBoolean = await comunicaEngine.queryBoolean(query, {
     sources: [memoryStore],
@@ -723,14 +723,14 @@ async function verifyAskEquality(query: string, label: string): Promise<void> {
   const oxigraphBoolean = oxigraphStore.query(query) as boolean;
 
   assertEquals(
-    nativeResult.data.boolean,
+    wazooResult.data.boolean,
     comunicaBoolean,
-    `${label}: native and comunica disagree`,
+    `${label}: wazoo and comunica disagree`,
   );
   assertEquals(
-    nativeResult.data.boolean,
+    wazooResult.data.boolean,
     oxigraphBoolean,
-    `${label}: native and oxigraph disagree`,
+    `${label}: wazoo and oxigraph disagree`,
   );
 }
 
@@ -742,11 +742,11 @@ async function verifyConstructEquality(
   query: string,
   label: string,
 ): Promise<void> {
-  const nativeResult = await nativeEngine.execute({ query });
-  if (nativeResult.kind !== "construct") {
-    throw new Error(`${label}: native engine returned ${nativeResult.kind}`);
+  const wazooResult = await wazooEngine.execute({ query });
+  if (wazooResult.kind !== "construct") {
+    throw new Error(`${label}: wazoo engine returned ${wazooResult.kind}`);
   }
-  const nativeSet = nativeResult.data.quads
+  const wazooSet = wazooResult.data.quads
     .map((item) => quadRecord(item, canonicalizeRdfTerm))
     .sort();
 
@@ -755,7 +755,7 @@ async function verifyConstructEquality(
   });
   const comunicaQuads = await comunicaStream.toArray();
   // Reference sides are normalized to graph content (issue #87 contract);
-  // the native side above stays as-emitted.
+  // the wazoo side above stays as-emitted.
   const comunicaSet = dedupeRecords(
     comunicaQuads.map((item) => quadRecord(item, canonicalizeComunicaTerm)),
   ).sort();
@@ -768,14 +768,14 @@ async function verifyConstructEquality(
   ).sort();
 
   assertEquals(
-    nativeSet,
+    wazooSet,
     comunicaSet,
-    `${label}: native and comunica disagree`,
+    `${label}: wazoo and comunica disagree`,
   );
   assertEquals(
-    nativeSet,
+    wazooSet,
     oxigraphSet,
-    `${label}: native and oxigraph disagree`,
+    `${label}: wazoo and oxigraph disagree`,
   );
 }
 
@@ -788,12 +788,12 @@ async function verifyConstructIsoEquality(
   query: string,
   label: string,
 ): Promise<void> {
-  const nativeResult = await nativeEngine.execute({ query });
-  if (nativeResult.kind !== "construct") {
-    throw new Error(`${label}: native engine returned ${nativeResult.kind}`);
+  const wazooResult = await wazooEngine.execute({ query });
+  if (wazooResult.kind !== "construct") {
+    throw new Error(`${label}: wazoo engine returned ${wazooResult.kind}`);
   }
-  const nativeRecords = quadRecords(
-    nativeResult.data.quads,
+  const wazooRecords = quadRecords(
+    wazooResult.data.quads,
     canonicalizeRdfTerm,
   );
 
@@ -802,7 +802,7 @@ async function verifyConstructIsoEquality(
   });
   const comunicaQuads = await comunicaStream.toArray();
   // Reference sides are normalized to graph content (issue #87 contract);
-  // the native side above stays as-emitted.
+  // the wazoo side above stays as-emitted.
   const comunicaRecords = dedupeRecords(
     quadRecords(comunicaQuads, canonicalizeComunicaTerm),
   );
@@ -815,14 +815,14 @@ async function verifyConstructIsoEquality(
   );
 
   assertEquals(
-    isomorphicMultiset(nativeRecords, comunicaRecords),
+    isomorphicMultiset(wazooRecords, comunicaRecords),
     true,
-    `${label}: native and comunica disagree up to blank-node isomorphism`,
+    `${label}: wazoo and comunica disagree up to blank-node isomorphism`,
   );
   assertEquals(
-    isomorphicMultiset(nativeRecords, oxigraphRecords),
+    isomorphicMultiset(wazooRecords, oxigraphRecords),
     true,
-    `${label}: native and oxigraph disagree up to blank-node isomorphism`,
+    `${label}: wazoo and oxigraph disagree up to blank-node isomorphism`,
   );
 }
 
@@ -848,13 +848,13 @@ async function verifyUpdateEquality(
   label: string,
   seed: rdfjs.Quad[] = dataset,
 ): Promise<void> {
-  const nativeStore = seedStore(seed);
-  const nativeUpdateEngine = new WazooSparqlEngine({ store: nativeStore });
-  const nativeResult = await nativeUpdateEngine.execute({ query });
-  if (nativeResult.kind !== "void") {
-    throw new Error(`${label}: native engine returned ${nativeResult.kind}`);
+  const wazooStore = seedStore(seed);
+  const wazooUpdateEngine = new WazooSparqlEngine({ store: wazooStore });
+  const wazooResult = await wazooUpdateEngine.execute({ query });
+  if (wazooResult.kind !== "void") {
+    throw new Error(`${label}: wazoo engine returned ${wazooResult.kind}`);
   }
-  const nativeSet = storeQuadStrings(nativeStore);
+  const wazooSet = storeQuadStrings(wazooStore);
 
   const comunicaStore = seedStore(seed);
   await comunicaEngine.queryVoid(query, { sources: [comunicaStore] });
@@ -873,14 +873,14 @@ async function verifyUpdateEquality(
     .sort();
 
   assertEquals(
-    nativeSet,
+    wazooSet,
     comunicaSet,
-    `${label}: native and comunica disagree`,
+    `${label}: wazoo and comunica disagree`,
   );
   assertEquals(
-    nativeSet,
+    wazooSet,
     oxigraphSet,
-    `${label}: native and oxigraph disagree`,
+    `${label}: wazoo and oxigraph disagree`,
   );
 }
 
@@ -973,11 +973,11 @@ await verifyUpdateEquality(
 );
 
 Deno.bench(
-  { name: "native - scan", group: "scan", baseline: true },
+  { name: "wazoo - scan", group: "scan", baseline: true },
   async () => {
-    const result = await nativeEngine.execute({ query: scanQuery });
+    const result = await wazooEngine.execute({ query: scanQuery });
     if (result.kind !== "select" || result.data.results.bindings.length === 0) {
-      throw new Error("native scan returned no bindings");
+      throw new Error("wazoo scan returned no bindings");
     }
   },
 );
@@ -1000,11 +1000,11 @@ Deno.bench({ name: "oxigraph - scan", group: "scan" }, () => {
 });
 
 Deno.bench(
-  { name: "native - join", group: "join", baseline: true },
+  { name: "wazoo - join", group: "join", baseline: true },
   async () => {
-    const result = await nativeEngine.execute({ query: joinQuery });
+    const result = await wazooEngine.execute({ query: joinQuery });
     if (result.kind !== "select" || result.data.results.bindings.length === 0) {
-      throw new Error("native join returned no bindings");
+      throw new Error("wazoo join returned no bindings");
     }
   },
 );
@@ -1027,23 +1027,23 @@ Deno.bench({ name: "oxigraph - join", group: "join" }, () => {
 });
 
 Deno.bench(
-  { name: "native - asym (reorder on)", group: "asym-join", baseline: true },
+  { name: "wazoo - asym (reorder on)", group: "asym-join", baseline: true },
   async () => {
-    const result = await nativeEngine.execute({ query: asymJoinQuery });
+    const result = await wazooEngine.execute({ query: asymJoinQuery });
     if (result.kind !== "select" || result.data.results.bindings.length === 0) {
-      throw new Error("native asym join returned no bindings");
+      throw new Error("wazoo asym join returned no bindings");
     }
   },
 );
 
 Deno.bench(
-  { name: "native - asym (reorder off)", group: "asym-join" },
+  { name: "wazoo - asym (reorder off)", group: "asym-join" },
   async () => {
-    const result = await nativeEngineNoReorder.execute({
+    const result = await wazooEngineNoReorder.execute({
       query: asymJoinQuery,
     });
     if (result.kind !== "select" || result.data.results.bindings.length === 0) {
-      throw new Error("native asym join (no reorder) returned no bindings");
+      throw new Error("wazoo asym join (no reorder) returned no bindings");
     }
   },
 );
@@ -1069,24 +1069,24 @@ Deno.bench({ name: "oxigraph - asym", group: "asym-join" }, () => {
 
 Deno.bench(
   {
-    name: "native - chain (reorder on)",
+    name: "wazoo - chain (reorder on)",
     group: "reorder-chain",
     baseline: true,
   },
   async () => {
-    const result = await nativeEngine.execute({ query: chainQuery });
+    const result = await wazooEngine.execute({ query: chainQuery });
     if (result.kind !== "select" || result.data.results.bindings.length === 0) {
-      throw new Error("native chain returned no bindings");
+      throw new Error("wazoo chain returned no bindings");
     }
   },
 );
 
 Deno.bench(
-  { name: "native - chain (reorder off)", group: "reorder-chain" },
+  { name: "wazoo - chain (reorder off)", group: "reorder-chain" },
   async () => {
-    const result = await nativeEngineNoReorder.execute({ query: chainQuery });
+    const result = await wazooEngineNoReorder.execute({ query: chainQuery });
     if (result.kind !== "select" || result.data.results.bindings.length === 0) {
-      throw new Error("native chain (no reorder) returned no bindings");
+      throw new Error("wazoo chain (no reorder) returned no bindings");
     }
   },
 );
@@ -1111,11 +1111,11 @@ Deno.bench({ name: "oxigraph - chain", group: "reorder-chain" }, () => {
 });
 
 Deno.bench(
-  { name: "native - ask", group: "ask", baseline: true },
+  { name: "wazoo - ask", group: "ask", baseline: true },
   async () => {
-    const result = await nativeEngine.execute({ query: askQuery });
+    const result = await wazooEngine.execute({ query: askQuery });
     if (result.kind !== "ask" || !result.data.boolean) {
-      throw new Error("native ask returned an unexpected result");
+      throw new Error("wazoo ask returned an unexpected result");
     }
   },
 );
@@ -1137,11 +1137,11 @@ Deno.bench({ name: "oxigraph - ask", group: "ask" }, () => {
 });
 
 Deno.bench(
-  { name: "native - construct", group: "construct", baseline: true },
+  { name: "wazoo - construct", group: "construct", baseline: true },
   async () => {
-    const result = await nativeEngine.execute({ query: constructQuery });
+    const result = await wazooEngine.execute({ query: constructQuery });
     if (result.kind !== "construct" || result.data.quads.length === 0) {
-      throw new Error("native construct returned no quads");
+      throw new Error("wazoo construct returned no quads");
     }
   },
 );
@@ -1166,11 +1166,11 @@ Deno.bench({ name: "oxigraph - construct", group: "construct" }, () => {
 });
 
 Deno.bench(
-  { name: "native - update", group: "update", baseline: true },
+  { name: "wazoo - update", group: "update", baseline: true },
   async () => {
-    const result = await nativeEngine.execute({ query: rewriteUpdateQuery });
+    const result = await wazooEngine.execute({ query: rewriteUpdateQuery });
     if (result.kind !== "void") {
-      throw new Error("native update returned a non-void result");
+      throw new Error("wazoo update returned a non-void result");
     }
   },
 );
@@ -1186,8 +1186,8 @@ Deno.bench({ name: "oxigraph - update", group: "update" }, async () => {
 });
 
 /**
- * benchSelectTrio registers the native/comunica/oxigraph bench trio for one
- * SELECT group. Native is the baseline; each body asserts a non-empty result
+ * benchSelectTrio registers the wazoo/comunica/oxigraph bench trio for one
+ * SELECT group. Wazoo is the baseline; each body asserts a non-empty result
  * so a silently-broken engine fails loudly mid-run.
  */
 function benchSelectTrio(
@@ -1198,14 +1198,14 @@ function benchSelectTrio(
   options?: { warmup?: number; iterations?: number },
 ): void {
   Deno.bench(
-    { name: `native - ${label}`, group, baseline: true, ...options },
+    { name: `wazoo - ${label}`, group, baseline: true, ...options },
     async () => {
-      const result = await trio.native.execute({ query });
+      const result = await trio.wazoo.execute({ query });
       if (
         result.kind !== "select" ||
         result.data.results.bindings.length === 0
       ) {
-        throw new Error(`native ${label} returned no bindings`);
+        throw new Error(`wazoo ${label} returned no bindings`);
       }
     },
   );
@@ -1229,8 +1229,8 @@ function benchSelectTrio(
 }
 
 /**
- * benchConstructTrio registers the native/comunica/oxigraph bench trio for
- * one CONSTRUCT group. Native is the baseline; each body asserts a non-empty
+ * benchConstructTrio registers the wazoo/comunica/oxigraph bench trio for
+ * one CONSTRUCT group. Wazoo is the baseline; each body asserts a non-empty
  * result so a silently-broken engine fails loudly mid-run.
  */
 function benchConstructTrio(
@@ -1239,11 +1239,11 @@ function benchConstructTrio(
   label: string,
 ): void {
   Deno.bench(
-    { name: `native - ${label}`, group, baseline: true },
+    { name: `wazoo - ${label}`, group, baseline: true },
     async () => {
-      const result = await nativeEngine.execute({ query });
+      const result = await wazooEngine.execute({ query });
       if (result.kind !== "construct" || result.data.quads.length === 0) {
-        throw new Error(`native ${label} returned no quads`);
+        throw new Error(`wazoo ${label} returned no quads`);
       }
     },
   );
@@ -1267,7 +1267,7 @@ function benchConstructTrio(
 }
 
 /**
- * benchUpdateTrio registers the native/comunica/oxigraph bench trio for one
+ * benchUpdateTrio registers the wazoo/comunica/oxigraph bench trio for one
  * update group. Each iteration seeds a fresh store (the graph-management ops
  * are one-way mutations, unlike the self-restoring rewrite update), so the
  * timings never observe a drifted store.
@@ -1279,13 +1279,13 @@ function benchUpdateTrio(
   seed: rdfjs.Quad[],
 ): void {
   Deno.bench(
-    { name: `native - ${label}`, group, baseline: true },
+    { name: `wazoo - ${label}`, group, baseline: true },
     async () => {
       const store = seedStore(seed);
       const engine = new WazooSparqlEngine({ store });
       const result = await engine.execute({ query });
       if (result.kind !== "void") {
-        throw new Error(`native ${label} returned a non-void result`);
+        throw new Error(`wazoo ${label} returned a non-void result`);
       }
     },
   );
@@ -1317,7 +1317,7 @@ benchSelectTrio("from", fromQuery, "from", graphTrio);
 benchSelectTrio("subquery", subqueryQuery, "subquery");
 benchSelectTrio("subquery", subqueryAggQuery, "subquery-agg");
 benchSelectTrio("subquery", subqueryNestedQuery, "subquery-nested");
-// The native EXISTS path is the suite's slowest (tens of ms/iter), so it
+// The wazoo EXISTS path is the suite's slowest (tens of ms/iter), so it
 // needs a longer warmup than the 500 ms default for stable, comparable rows
 // (V8 must finish optimizing the hot EXISTS machinery before measurement),
 // plus more samples to average out scheduler noise.
@@ -1382,7 +1382,7 @@ benchSelectTrio(
   LARGE_EXISTS_BENCH_OPTIONS,
 );
 // 10k join-scaling rows: the same shared-subject join surface as the
-// 400-person rows but at 10k subjects, where the native engine's hash join
+// 400-person rows but at 10k subjects, where the wazoo engine's hash join
 // probes instead of scanning the whole right side per left binding.
 const LARGE_JOIN_BENCH_OPTIONS = { warmup: 2_000, iterations: 10 };
 benchSelectTrio(

--- a/bench/measure-libs.ts
+++ b/bench/measure-libs.ts
@@ -1,7 +1,7 @@
 // Library-size measurement for the README's size comparison. Measures what a
 // consumer must have on disk for each engine:
 //
-//   - native:  the JSR publish artifact (src/ + README.md + LICENSE), broken
+//   - wazoo:  the JSR publish artifact (src/ + README.md + LICENSE), broken
 //              down by top-level module.
 //   - oxigraph: the installed npm package, broken down into the WASM binary
 //              vs the JS glue.
@@ -181,7 +181,7 @@ function comunicaArtifact(): Sized {
 }
 
 /* ------------------------------------------------------------------ */
-/* native + oxigraph                                                  */
+/* wazoo + oxigraph                                                  */
 /* ------------------------------------------------------------------ */
 
 /** Files excluded from the JSR artifact via publish.exclude (mirrors
@@ -244,7 +244,7 @@ async function gzipBytesOf(files: string[]): Promise<number> {
   return total;
 }
 
-function nativeArtifact(): Sized {
+function wazooArtifact(): Sized {
   const root = join(Deno.cwd());
   const files = artifactFiles();
   const byTop = new Map<string, number>();
@@ -254,7 +254,7 @@ function nativeArtifact(): Sized {
     byTop.set(top, (byTop.get(top) ?? 0) + Deno.statSync(file).size);
   }
   return {
-    name: "native",
+    name: "wazoo",
     bytes: [...byTop.values()].reduce((a, b) => a + b, 0),
     children: [...byTop.entries()]
       .map(([name, bytes]) => ({ name, bytes }))
@@ -296,13 +296,13 @@ function oxigraphArtifact(): Sized {
 }
 
 scanInstalled();
-const native = nativeArtifact();
+const wazoo = wazooArtifact();
 const artifact = artifactFiles();
 const result = {
   generatedAt: new Date().toISOString(),
-  engines: [native, oxigraphArtifact(), comunicaArtifact()],
-  native: {
-    artifactBytes: native.bytes,
+  engines: [wazoo, oxigraphArtifact(), comunicaArtifact()],
+  wazoo: {
+    artifactBytes: wazoo.bytes,
     gzipBytes: await gzipBytesOf(artifact),
     files: artifact.length,
   },

--- a/bench/memory-data.json
+++ b/bench/memory-data.json
@@ -4,7 +4,7 @@
   "dataset": "10,000-person graph (~55,000 quads)",
   "measurement": "isolated Deno subprocess per engine, Deno.memoryUsage() peak after each run",
   "engines": {
-    "native": {
+    "wazoo": {
       "scan": {
         "peakHeap": 140895480,
         "peakRss": 263184384,

--- a/bench/memory-probe.ts
+++ b/bench/memory-probe.ts
@@ -3,7 +3,7 @@
 // target engine is loaded), executes the workload several times, and reports
 // the peak heap/RSS observed.
 //
-//   deno run --allow-all bench/memory-probe.ts <native|comunica|oxigraph> <scan|exists>
+//   deno run --allow-all bench/memory-probe.ts <wazoo|comunica|oxigraph> <scan|exists>
 //
 // Prints one JSON document to stdout.
 import type * as rdfjs from "@rdfjs/types";
@@ -51,7 +51,7 @@ const NESTED_EXISTS_QUERY =
 
 const engine = Deno.args[0];
 const workload = Deno.args[1];
-if (engine !== "native" && engine !== "comunica" && engine !== "oxigraph") {
+if (engine !== "wazoo" && engine !== "comunica" && engine !== "oxigraph") {
   throw new Error(`unknown engine: ${engine}`);
 }
 if (workload !== "scan" && workload !== "exists") {
@@ -74,17 +74,17 @@ const observe = (): void => {
 };
 
 async function runWorkload(): Promise<void> {
-  if (engine === "native") {
+  if (engine === "wazoo") {
     const store = new Store();
     for (const q of dataset) {
       store.addQuad(q);
     }
     const { WazooSparqlEngine } = await import("@/wazoo-sparql-engine.ts");
-    const nativeEngine = new WazooSparqlEngine({ store });
+    const wazooEngine = new WazooSparqlEngine({ store });
     for (let i = 0; i < RUNS; i++) {
-      const result = await nativeEngine.execute({ query });
+      const result = await wazooEngine.execute({ query });
       if (result.kind !== "select") {
-        throw new Error(`native returned ${result.kind}`);
+        throw new Error(`wazoo returned ${result.kind}`);
       }
       observe();
     }

--- a/bench/size-data.json
+++ b/bench/size-data.json
@@ -2,7 +2,7 @@
   "generatedAt": "2026-08-14T18:50:35.246Z",
   "engines": [
     {
-      "name": "native",
+      "name": "wazoo",
       "bytes": 641468,
       "children": [
         {
@@ -904,7 +904,7 @@
       ]
     }
   ],
-  "native": {
+  "wazoo": {
     "artifactBytes": 641468,
     "gzipBytes": 137507,
     "files": 37

--- a/bench/treemap.ts
+++ b/bench/treemap.ts
@@ -36,7 +36,7 @@ interface Placed {
   panel?: string;
 }
 
-const COLORS = ["#2f9e44", "#1971c2", "#f08c00"]; // native, oxigraph, comunica
+const COLORS = ["#2f9e44", "#1971c2", "#f08c00"]; // wazoo, oxigraph, comunica
 
 function worst(row: { bytes: number }[], rect: Rect): number {
   const total = row.reduce((s, i) => s + i.bytes, 0);
@@ -287,7 +287,7 @@ function memoryTree(): Placed[] {
       { scan: { peakHeap: number }; exists: { peakHeap: number } }
     >;
   };
-  const names = ["native", "comunica", "oxigraph"];
+  const names = ["wazoo", "comunica", "oxigraph"];
   const workloads = ["scan", "exists"] as const;
   const labels: Record<string, string> = {
     scan: "full scan (55k rows materialized)",
@@ -332,7 +332,7 @@ function memoryTree(): Placed[] {
 
 const sizeSvg = treemapSvg(
   "Library size on disk",
-  "Engine package footprint, excluding the shared Deno runtime (native: JSR artifact; oxigraph: npm package; comunica: full transitive dependency closure)",
+  "Engine package footprint, excluding the shared Deno runtime (wazoo: JSR artifact; oxigraph: npm package; comunica: full transitive dependency closure)",
   sizeTree(),
 );
 Deno.writeTextFileSync(

--- a/docs/01-quickstart.md
+++ b/docs/01-quickstart.md
@@ -161,7 +161,7 @@ deno task test:ref     # allowlisted-divergence audit vs Oxigraph + N3.js
 ## Benchmarks
 
 ```bash
-deno task bench        # native vs Comunica vs Oxigraph, verification-first
+deno task bench        # wazoo vs Comunica vs Oxigraph, verification-first
 deno task bench:check  # regression budget gate (bench/budget.ts)
 deno task bench:size   # on-disk library footprint → docs/assets/treemap-library-size.svg
 deno task bench:memory # peak heap per engine → docs/assets/treemap-memory.svg

--- a/docs/03-api-contracts.md
+++ b/docs/03-api-contracts.md
@@ -21,8 +21,8 @@ export interface SparqlEngineInterface {
 export interface SparqlRequest {
   query?: string; // raw SPARQL query string
   update?: string; // raw SPARQL update string
-  baseIri?: string; // accepted; native engine derives base from BASE directive
-  timeoutMs?: number; // accepted; not yet enforced by the native engine
+  baseIri?: string; // accepted; wazoo engine derives base from BASE directive
+  timeoutMs?: number; // accepted; not yet enforced by the wazoo engine
 }
 ```
 

--- a/docs/04-source-map.md
+++ b/docs/04-source-map.md
@@ -121,20 +121,20 @@ sparql-engine/
 | `test/w3c/ref-crosscheck.ts`                                            | Allowlisted-divergence audit vs Oxigraph + N3.js                                                        |
 | `test/w3c/exists-ref.ts`                                                | EXISTS subquery surface vs Oxigraph                                                                     |
 | `test/w3c/runner.ts`, `manifest.ts`, `divergences.ts`, `rdf-harness.ts` | W3C harness plumbing, manifest parsing, documented divergences, CONSTRUCT multiset contract (issue #87) |
-| `test/w3c/construct-semantics.test.ts`                                  | Pins the CONSTRUCT graph-result contract: reference deduplicated, native as-emitted, duplicates fail    |
+| `test/w3c/construct-semantics.test.ts`                                  | Pins the CONSTRUCT graph-result contract: reference deduplicated, wazoo as-emitted, duplicates fail     |
 | `test/w3c/fixtures/`                                                    | Vendored W3C suites: `sparql11/`, `sparql12/`, `rdf/` (offline, deterministic)                          |
 
 ## `bench/`
 
 | File                                       | Role                                                                                                                       |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `bench/engine_bench.ts`                    | Three-engine benchmark (native / Comunica / Oxigraph) with verification-first equality asserts                             |
+| `bench/engine_bench.ts`                    | Three-engine benchmark (wazoo / Comunica / Oxigraph) with verification-first equality asserts                              |
 | `bench/budget.ts`                          | Regression budget gate (`deno task bench:check`): avg ms/iter against `bench/baseline.json`                                |
 | `bench/baseline.json`                      | `maxAllowedMs: 50`, `maxRegressionRatio: 0.15`                                                                             |
 | `bench/concurrency-probe.ts`               | EXISTS concurrency stress probe (issue #72): shuffled `Promise.all` rounds + update interleaving, exit 1 on error/mismatch |
-| `bench/measure-libs.ts`                    | On-disk footprint of native JSR artifact vs Oxigraph npm vs Comunica transitive closure → `bench/size-data.json`           |
+| `bench/measure-libs.ts`                    | On-disk footprint of wazoo JSR artifact vs Oxigraph npm vs Comunica transitive closure → `bench/size-data.json`            |
 | `bench/collect-memory.ts`                  | Spawns `bench/memory-probe.ts` per engine × workload, merges peak-heap results → `bench/memory-data.json`                  |
-| `bench/memory-probe.ts`                    | Peak `heapUsed` per engine (native/Comunica/Oxigraph) on full-scan + nested-EXISTS workloads over a 10k-person graph       |
+| `bench/memory-probe.ts`                    | Peak `heapUsed` per engine (wazoo/Comunica/Oxigraph) on full-scan + nested-EXISTS workloads over a 10k-person graph        |
 | `bench/treemap.ts`                         | Renders `bench/*-data.json` into `docs/assets/treemap-{library-size,memory}.svg`                                           |
 | `bench/size-data.json`, `memory-data.json` | Measured snapshots consumed by `bench/treemap.ts` and the root `README.md` (Size & memory footprint)                       |
 

--- a/docs/05-testing.md
+++ b/docs/05-testing.md
@@ -84,7 +84,7 @@ The parity contract is **behavioral equivalence with
 - **CONSTRUCT compares under the graph-result contract (issue #87).** A
   CONSTRUCT result is a set of triples: the reference side (Comunica) is
   normalized to graph content — its stream may repeat a triple its graph would
-  not — while the native side is compared **as-emitted**. A conforming engine
+  not — while the wazoo side is compared **as-emitted**. A conforming engine
   emits no duplicate quads (W3C decision #29), so a change that starts emitting
   duplicates fails the gate instead of silently passing;
   `test/w3c/construct-semantics.test.ts` pins the contract with unit tests on
@@ -93,7 +93,7 @@ The parity contract is **behavioral equivalence with
   they agree exactly modulo label identity (the SPARQL contract, since INSERT
   DATA mints fresh labels per execution).
 - **Spec-wins divergences**: when Comunica contradicts the spec (e.g. `LIMIT 0`
-  ignored, malformed regex throwing), the native engine implements the spec,
+  ignored, malformed regex throwing), the wazoo engine implements the spec,
   documents the divergence, and skips the parity case — see
   `test/w3c/divergences.ts`.
 
@@ -103,11 +103,11 @@ The parity contract is **behavioral equivalence with
 tests across 31 categories: aggregates, bind, bindings, cast, construct, exists,
 functions, grouping, negation, project-expression, property-path, subquery, and
 the update categories) **differentially**: every query runs through both
-Comunica and the native engine, and observable results are compared. Categories
+Comunica and the wazoo engine, and observable results are compared. Categories
 per test:
 
 - `pass` — both engines agree.
-- `gap` — native and Comunica disagree; the gap count is the tracked progress
+- `gap` — wazoo and Comunica disagree; the gap count is the tracked progress
   metric and the gate stays red until it reaches zero.
 - `error` — the runner itself failed.
 - `documented divergence` — keyed in `divergences.ts`; validated against the W3C
@@ -141,7 +141,7 @@ how to run each tool and what it gates.
 
 ### `deno task bench` — three-engine comparison
 
-`bench/engine_bench.ts` compares the native engine against
+`bench/engine_bench.ts` compares the wazoo engine against
 `@comunica/query-sparql-rdfjs-lite` and **Oxigraph (WASM)** over an identical
 generated graph (400 people, ~1,600 quads, plus named-graph datasets).
 
@@ -151,9 +151,9 @@ Two properties make the timings trustworthy:
    engines return identical results (`verifySelectEquality`,
    `verifyAskEquality`, `verifyConstructEquality`, `verifyConstructIsoEquality`
    — CONSTRUCT under the graph-result multiset contract: reference deduplicated,
-   native as-emitted (issue #87) — and every update asserts identical final
-   store contents on fresh stores (`verifyUpdateEquality`). A benchmark of a
-   broken engine fails loudly, not silently.
+   wazoo as-emitted (issue #87) — and every update asserts identical final store
+   contents on fresh stores (`verifyUpdateEquality`). A benchmark of a broken
+   engine fails loudly, not silently.
 2. **Self-restoring updates.** The timed update deletes and re-inserts the same
    quads, netting to zero per iteration, so the benchmark stores never drift.
 
@@ -199,14 +199,14 @@ Latency is only half the story: the engine is also benchmarked on what it costs
 to ship and run (root `README.md` → _Size & memory footprint_):
 
 - `bench:size` — `bench/measure-libs.ts` measures the on-disk footprint a
-  consumer must install: the native JSR artifact (0.67 MiB, zero runtime deps)
-  vs the Oxigraph npm package (7.9 MiB) vs Comunica's full transitive closure
-  (28.3 MiB) → `bench/size-data.json`.
+  consumer must install: the wazoo JSR artifact (0.67 MiB, zero runtime deps) vs
+  the Oxigraph npm package (7.9 MiB) vs Comunica's full transitive closure (28.3
+  MiB) → `bench/size-data.json`.
 - `bench:memory` — `bench/collect-memory.ts` spawns `bench/memory-probe.ts` per
   engine in an **isolated Deno subprocess** (so only the target engine is
   loaded), reporting peak `Deno.memoryUsage().heapUsed` over 5 runs on a
   10k-person graph (~55k quads), across a full-scan and a nested-EXISTS workload
-  → `bench/memory-data.json`. Native is lowest on both (134 / 82 MB vs Comunica
+  → `bench/memory-data.json`. Wazoo is lowest on both (134 / 82 MB vs Comunica
   214 / 271 MB, Oxigraph 251 / 108 MB).
 - `bench/treemap.ts` renders both JSON snapshots into
   `docs/assets/treemap-*.svg` (area ∝ size):

--- a/docs/06-supplemental-context.md
+++ b/docs/06-supplemental-context.md
@@ -57,16 +57,16 @@ The project does not run the W3C suites as a pass/fail conformance oracle alone
 results as a secondary check. The posture is:
 
 1. **Parity is the floor.** Anything the parity reference
-   (`@comunica/query-sparql-rdfjs-lite`) can do, the native engine must do.
+   (`@comunica/query-sparql-rdfjs-lite`) can do, the wazoo engine must do.
 2. **Spec wins over the reference.** Where Comunica contradicts the spec
    (`LIMIT 0` ignored, malformed regex throwing, EXISTS subquery correlation),
-   the native engine implements the spec and the case is keyed as a _documented
+   the wazoo engine implements the spec and the case is keyed as a _documented
    divergence_ in `test/w3c/divergences.ts` rather than allowlisted blindly.
 3. **Gaps are tracked, not hidden.** The `w3c-parity` CI job goes green only on
    a full pass; the gap count is the progress metric.
 4. **RDF syntax is gated absolutely.** Negative syntax tests must be rejected
    even when the lenient reference (n3) accepts them; the only tolerated
-   mismatches are _superset acceptances_ — the native grammar is a single
+   mismatches are _superset acceptances_ — the wazoo grammar is a single
    Turtle+TriG+N-Quads superset for `LOAD`'s content-sniffing — each audited
    against Oxigraph and N3.js by `deno task test:ref` (45/45 endorsed).
 
@@ -81,7 +81,7 @@ not a guarantee.
 
 SPARQL 1.1 result semantics treat blank-node labels as scoped and opaque.
 Comunica skolemizes blank nodes from query sources into prefixed labels
-(`bc_<sourceId>_<label>`); the native engine returns the store's own labels and
+(`bc_<sourceId>_<label>`); the wazoo engine returns the store's own labels and
 deliberately does **not** replicate the prefix. The parity harness strips the
 prefix before comparing and locks the normalization with a dedicated test
 (`test/parity/parity.test.ts`). INSERT DATA mints fresh labels per execution
@@ -94,13 +94,13 @@ label identity.
   with the parity reference.
 - **SparqlEngineInterface** — the shared execution contract; duplicated
   identically in `@worlds/client` under an identical-spec policy.
-- **ComunicaSparqlEngine** — the `@worlds/client` adapter the native engine is a
+- **ComunicaSparqlEngine** — the `@worlds/client` adapter the wazoo engine is a
   drop-in replacement for.
 - **Parity reference** — the installed `@comunica/query-sparql-rdfjs-lite`; the
   porting surface is its lite config.
 - **Differential parity** — deep comparison of SELECT bindings, CONSTRUCT quads,
   ASK booleans, and final update store contents across engines.
-- **Spec-wins divergence** — the reference contradicts the spec; native
+- **Spec-wins divergence** — the reference contradicts the spec; wazoo
   implements the spec, documents it, and skips the parity case.
 - **Superset directive** — parity is the floor; the superset ceiling (what
   beyond that floor the engine should carry) is an open question.
@@ -114,9 +114,9 @@ label identity.
 
 ## Known gaps and next steps
 
-- `timeoutMs` in `SparqlRequest` is accepted but not yet enforced by the native
-  engine (Comunica enforces it). `baseIri` is accepted; the native engine
-  derives the base from the query's `BASE` directive instead.
+- `timeoutMs` in `SparqlRequest` is accepted but not yet enforced by the wazoo
+  engine (Comunica enforces it). `baseIri` is accepted; the wazoo engine derives
+  the base from the query's `BASE` directive instead.
 - `SqliteStore` ships as a deep-import prototype; the durable-transactions notes
   (`docs/durable-transactions.md`) list next steps: a dedicated `./sqlite`
   entrypoint, fsync/busy-timeout policy, update-throughput benchmarks, and

--- a/docs/07-benchmarking.md
+++ b/docs/07-benchmarking.md
@@ -23,9 +23,9 @@ trustworthy and what the numbers say" companion.
 
 ## `deno task bench` — three-engine latency comparison
 
-`bench/engine_bench.ts` runs the native engine against
+`bench/engine_bench.ts` runs the wazoo engine against
 `@comunica/query-sparql-rdfjs-lite` and **Oxigraph (WASM)** over identical
-generated graphs. Deno's built-in bench runner times each group, with the native
+generated graphs. Deno's built-in bench runner times each group, with the wazoo
 engine as the per-group baseline.
 
 ### Why the timings are trustworthy
@@ -34,9 +34,9 @@ engine as the per-group baseline.
    engines return identical results (`verifySelectEquality`,
    `verifyAskEquality`, `verifyConstructEquality`, `verifyConstructIsoEquality`
    — CONSTRUCT under the graph-result multiset contract: reference deduplicated,
-   native as-emitted (issue #87) — and every update asserts identical final
-   store contents on fresh stores (`verifyUpdateEquality`). A benchmark of a
-   broken engine fails loudly, not silently.
+   wazoo as-emitted (issue #87) — and every update asserts identical final store
+   contents on fresh stores (`verifyUpdateEquality`). A benchmark of a broken
+   engine fails loudly, not silently.
 2. **Self-restoring updates.** The timed update deletes and re-inserts the same
    quads, netting to zero per iteration, so the benchmark stores never drift.
 3. **Per-group baselines.** Each group is timed independently; results are
@@ -49,14 +49,14 @@ subquery, exists, cast, string-fn, having, reduced, update-ops.
 
 ### Known results
 
-Snapshot measured on a Windows desktop, Deno 2.9.5, native engine as the
+Snapshot measured on a Windows desktop, Deno 2.9.5, wazoo engine as the
 per-group baseline. Each cell is the per-iteration average; every query was
 cross-verified identical on all three engines before timing. Machine-specific —
 run `deno task bench` for your own numbers.
 
 Core joins, 400-person graph (~2,200 quads):
 
-| query                        | native   | comunica | oxigraph |
+| query                        | wazoo    | comunica | oxigraph |
 | ---------------------------- | -------- | -------- | -------- |
 | full scan                    | 1.3 ms   | 7.6 ms   | 12.2 ms  |
 | join (knows × name)          | 1.0 ms   | 5.2 ms   | 2.6 ms   |
@@ -66,7 +66,7 @@ Core joins, 400-person graph (~2,200 quads):
 
 EXISTS surface, 400-person graph:
 
-| query               | native  | comunica | oxigraph |
+| query               | wazoo   | comunica | oxigraph |
 | ------------------- | ------- | -------- | -------- |
 | `FILTER EXISTS`     | 0.81 ms | 29.2 ms  | 1.0 ms   |
 | `FILTER NOT EXISTS` | 0.88 ms | 33.3 ms  | 1.3 ms   |
@@ -75,7 +75,7 @@ EXISTS surface, 400-person graph:
 
 EXISTS surface, 10,000-person graph (~55,000 quads):
 
-| query               | native  | comunica | oxigraph |
+| query               | wazoo   | comunica | oxigraph |
 | ------------------- | ------- | -------- | -------- |
 | `FILTER EXISTS`     | 27.8 ms | 729.5 ms | 27.0 ms  |
 | `FILTER NOT EXISTS` | 26.8 ms | 835.9 ms | 30.7 ms  |
@@ -85,7 +85,7 @@ EXISTS surface, 10,000-person graph (~55,000 quads):
 Join surface, 10,000-person graph — UNION joins 10k × 20k bindings on the shared
 subject (~200M candidate pairs); OPTIONAL and MINUS join 10k × 5k (~50M pairs):
 
-| query               | native  | comunica | oxigraph |
+| query               | wazoo   | comunica | oxigraph |
 | ------------------- | ------- | -------- | -------- |
 | UNION (10k × 20k)   | 45.1 ms | 106.6 ms | 107.5 ms |
 | OPTIONAL (10k × 5k) | 22.1 ms | 587.9 ms | 56.5 ms  |
@@ -93,17 +93,17 @@ subject (~200M candidate pairs); OPTIONAL and MINUS join 10k × 5k (~50M pairs):
 
 ### Reading the numbers
 
-- **Core joins**: native is fastest on every scan/join row, with the asymmetric
+- **Core joins**: wazoo is fastest on every scan/join row, with the asymmetric
   join ~20× faster than Comunica.
-- **Join scaling is sub-quadratic.** The native hash join probes an indexed
-  right side per left binding instead of scanning it: the nested-loop
-  before-state of the UNION benchmark was ~7 s/iter versus 45 ms with the hash
-  join (~150×), with OPTIONAL and MINUS showing the same shape (~60-80×).
+- **Join scaling is sub-quadratic.** The wazoo hash join probes an indexed right
+  side per left binding instead of scanning it: the nested-loop before-state of
+  the UNION benchmark was ~7 s/iter versus 45 ms with the hash join (~150×),
+  with OPTIONAL and MINUS showing the same shape (~60-80×).
 - **EXISTS is flat as data grows.** Scaling the data 25× (400 → 10,000 people)
-  grows native's EXISTS cost ~35-40× while the nested-vs-simple ratio _shrinks_
+  grows wazoo's EXISTS cost ~35-40× while the nested-vs-simple ratio _shrinks_
   (1.45× → 1.12×): the EXISTS snapshot is drained and indexed once per query,
   and each probe touches only its candidate bucket, so nesting stays cheap
-  relative to the dataset. Across the EXISTS surface native is 20-180× faster
+  relative to the dataset. Across the EXISTS surface wazoo is 20-180× faster
   than Comunica and roughly at parity with Oxigraph (a compiled Rust/WASM engine
   with native indexes, which stays ahead on the reorder-chain row).
 - **The dynamic join planner is worth ~90×** on the worst-case-ordered
@@ -151,7 +151,7 @@ in `src/wazoo-sparql-engine.test.ts`.
 ### Methodology
 
 - `bench:size` — `bench/measure-libs.ts` measures the on-disk footprint a
-  consumer must install: the native JSR publish artifact (`src/` + `README.md`
+  consumer must install: the wazoo JSR publish artifact (`src/` + `README.md`
   - `LICENSE`, broken down by top-level module), the installed Oxigraph npm
     package (WASM binary vs JS glue), and `@comunica/query-sparql-rdfjs-lite`
     plus its full transitive dependency closure → `bench/size-data.json`.
@@ -171,11 +171,11 @@ On-disk footprint (what a consumer must have installed):
 
 | engine   | on disk      | contents                                                                                              |
 | -------- | ------------ | ----------------------------------------------------------------------------------------------------- |
-| native   | **0.67 MiB** | 38 source files (the whole JSR artifact: `src/` + `README.md` + `LICENSE`); zero runtime dependencies |
+| wazoo    | **0.67 MiB** | 38 source files (the whole JSR artifact: `src/` + `README.md` + `LICENSE`); zero runtime dependencies |
 | oxigraph | 7.9 MiB      | WASM runtime (7.8 MiB) + JS glue/types                                                                |
 | comunica | 28.3 MiB     | 368 npm packages in the transitive dependency closure                                                 |
 
-Native breaks down as evaluator 226 KiB, parser 381 KiB, store 24 KiB, term 40
+Wazoo breaks down as evaluator 226 KiB, parser 381 KiB, store 24 KiB, term 40
 KiB, README 13 KiB, LICENSE 1 KiB — the parser is the largest single module (the
 generated `parser.ts` from `sparql.jison`).
 
@@ -183,7 +183,7 @@ Peak heap during execution (`heapUsed`; isolated subprocess per engine, peak
 over 5 runs, all three share the same ~65 MB runtime baseline so the comparison
 is symmetric):
 
-| workload             | native     | comunica | oxigraph |
+| workload             | wazoo      | comunica | oxigraph |
 | -------------------- | ---------- | -------- | -------- |
 | full scan (55k rows) | **134 MB** | 214 MB   | 251 MB   |
 | nested EXISTS        | **82 MB**  | 271 MB   | 108 MB   |
@@ -192,11 +192,11 @@ is symmetric):
 
 ![Memory treemap](assets/treemap-memory.svg)
 
-Native is the smallest on disk by 12-42× (0.67 vs 7.9 vs 28.3 MiB) and holds its
+Wazoo is the smallest on disk by 12-42× (0.67 vs 7.9 vs 28.3 MiB) and holds its
 speed advantage with the lowest peak heap on both workloads — including a peak
 roughly a third of Comunica's on the nested-EXISTS surface the timings above
 highlight. Oxigraph's WASM runtime is compact on disk, but its result
-materialization peaks higher than native on both workloads. The probe also
+materialization peaks higher than wazoo on both workloads. The probe also
 records peak RSS in `bench/memory-data.json` for deeper analysis.
 
 ## Regenerating and committing results

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,10 @@ layout: default
 
 # @wazoo/sparql-engine — Code Wiki
 
-Developer documentation for the Wazoo-native SPARQL 1.1 & 1.2 query and update
-engine over RDF/JS Quad Stores. This wiki is an application-first tour of the
-engine: how queries are parsed, optimized, and evaluated; the public API
-contracts; the physical source map; and how to test and benchmark the engine.
+Developer documentation for the Wazoo SPARQL 1.1 & 1.2 query and update engine
+over RDF/JS Quad Stores. This wiki is an application-first tour of the engine:
+how queries are parsed, optimized, and evaluated; the public API contracts; the
+physical source map; and how to test and benchmark the engine.
 
 The content is verified against the codebase and the `deno doc --json` symbol
 inventory of the public surface (`src/mod.ts`). Every file path below is
@@ -58,7 +58,7 @@ Two treemaps summarize what the engine costs to ship and run versus the
 reference engines (area ∝ size; full methodology and tables in
 [07 — Benchmarking & Performance](07-benchmarking.md)):
 
-|                          | native                   | oxigraph | comunica                |
+|                          | wazoo                    | oxigraph | comunica                |
 | ------------------------ | ------------------------ | -------- | ----------------------- |
 | on-disk footprint        | **0.67 MiB** (zero deps) | 7.9 MiB  | 28.3 MiB (368 packages) |
 | peak heap, full scan     | **134 MB**               | 251 MB   | 214 MB                  |

--- a/docs/assets/treemap-library-size.svg
+++ b/docs/assets/treemap-library-size.svg
@@ -4,7 +4,7 @@
   <text x="12" y="20" font-size="13" font-weight="bold"
     fill="#212529">Library size on disk</text>
   <text x="12" y="34" font-size="9"
-    fill="#868e96">Engine package footprint, excluding the shared Deno runtime (native: JSR artifact; oxigraph: npm package; comunica: full transitive dependency closure)</text>
+    fill="#868e96">Engine package footprint, excluding the shared Deno runtime (wazoo: JSR artifact; oxigraph: npm package; comunica: full transitive dependency closure)</text>
   <rect x="12.0" y="44.0" width="535.3" height="264.0" fill="#2f9e44"
     stroke="#ffffff" stroke-width="1" />
   <text x="279.6" y="179.0" text-anchor="middle" font-family="sans-serif"
@@ -72,7 +72,7 @@
     stroke="#ffffff" stroke-width="1" />
   <text x="627.6" y="301.5" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">native<tspan x="627.6" dy="12" font-size="8" fill="#ffffffcc">626 KiB</tspan></text>
+    fill="#fff">wazoo<tspan x="627.6" dy="12" font-size="8" fill="#ffffffcc">626 KiB</tspan></text>
   <rect x="549.3" y="291.0" width="50.5" height="15.0" fill="#fad7a6"
     stroke="#ffffff" stroke-width="1" />
   <text x="574.5" y="288.0" text-anchor="middle" font-family="sans-serif"

--- a/docs/assets/treemap-memory.svg
+++ b/docs/assets/treemap-memory.svg
@@ -23,7 +23,7 @@
     stroke="#ffffff" stroke-width="1" />
   <text x="253.7" y="247.0" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">native<tspan x="253.7" dy="12" font-size="8" fill="#ffffffcc">134.37 MiB</tspan></text>
+    fill="#fff">wazoo<tspan x="253.7" dy="12" font-size="8" fill="#ffffffcc">134.37 MiB</tspan></text>
   <rect x="360.0" y="44.0" width="342.0" height="244.0" fill="#f1f3f5"
     stroke="#dee2e6" stroke-width="1" />
   <text x="366.0" y="60.0" font-family="sans-serif" font-size="10"
@@ -42,5 +42,5 @@
     stroke="#ffffff" stroke-width="1" />
   <text x="630.4" y="242.2" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">native<tspan x="630.4" dy="12" font-size="8" fill="#ffffffcc">81.49 MiB</tspan></text>
+    fill="#fff">wazoo<tspan x="630.4" dy="12" font-size="8" fill="#ffffffcc">81.49 MiB</tspan></text>
 </svg>

--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -8,11 +8,11 @@ that upstream's grammar does not whitelist.
 
 The parity contract is behavioral equivalence with
 `@comunica/query-sparql-rdfjs-lite`, and the target is a superset: anything
-Comunica can run, the native engine must run. Comunica 5.x parses SPARQL with
-`@traqula/parser-sparql-1-2`, which accepts `LANGDIR(...)` — but the native
+Comunica can run, the wazoo engine must run. Comunica 5.x parses SPARQL with
+`@traqula/parser-sparql-1-2`, which accepts `LANGDIR(...)` — but the wazoo
 engine's sparqljs 3.7.4 grammar rejects **all four** SPARQL 1.2
 direction-function names (they are not in its builtin whitelist), so `LANGDIR`
-was a real, reachable parity gap: Comunica ran it, native could not even parse
+was a real, reachable parity gap: Comunica ran it, wazoo could not even parse
 it.
 
 Rather than depend on upstream sparqljs's release cadence, the parser is

--- a/src/term/canonical.ts
+++ b/src/term/canonical.ts
@@ -4,7 +4,7 @@ import { XSD_STRING } from "./numeric.ts";
 
 /**
  * CanonicalTerm is a serialization-stable projection of an RDF term that is
- * produced identically from Comunica terms, native SparqlValue objects, and
+ * produced identically from Comunica terms, wazoo SparqlValue objects, and
  * other RDF/JS-shaped terms such as Oxigraph's. Two terms canonicalize to the
  * same CanonicalTerm exactly when they are the same RDF term.
  */
@@ -59,8 +59,8 @@ export function canonicalizeRdfTerm(term: rdfjs.Term): CanonicalTerm {
 }
 
 /**
- * canonicalizeSparqlValue normalizes a native SparqlValue into a
- * CanonicalTerm, so native results compare structurally with RDF/JS-shaped
+ * canonicalizeSparqlValue normalizes a wazoo SparqlValue into a
+ * CanonicalTerm, so wazoo results compare structurally with RDF/JS-shaped
  * results from other engines.
  */
 export function canonicalizeSparqlValue(value: SparqlValue): CanonicalTerm {

--- a/src/wazoo-sparql-engine.ts
+++ b/src/wazoo-sparql-engine.ts
@@ -52,7 +52,7 @@ export interface WazooSparqlEngineOptions {
 }
 
 /**
- * WazooSparqlEngine is the Wazoo-native SPARQL 1.1 & 1.2 engine over RDFJS Store sources.
+ * WazooSparqlEngine is the Wazoo SPARQL 1.1 & 1.2 engine over RDFJS Store sources.
  */
 export class WazooSparqlEngine implements SparqlEngineInterface {
   private readonly parser: SparqlParser;

--- a/test/parity/parity-harness.ts
+++ b/test/parity/parity-harness.ts
@@ -42,7 +42,7 @@ export interface ParityTestCase {
  * Comunica's query-source skolemization applies to results. Comunica rewrites
  * blank nodes into "bc_<sourceId>_<label>" (BlankNodeScoped) so that identical
  * labels from different sources stay distinct. Blank node labels are opaque per
- * SPARQL 1.1 result semantics, and the native engine deliberately returns the
+ * SPARQL 1.1 result semantics, and the wazoo engine deliberately returns the
  * store's own labels, so the prefix is removed before comparison.
  */
 function normalizeComunicaBlankNodeLabel(label: string): string {
@@ -273,18 +273,18 @@ async function runComunicaConstruct(
 
 /**
  * compareResult runs the given test case against the Comunica engine and
- * compares its observable output with the native engine's result.
+ * compares its observable output with the wazoo engine's result.
  */
 async function compareResult(
   testCase: ParityTestCase,
   comunicaEngine: QueryEngine,
   comunicaStore: Store,
-  nativeResult: SparqlResponse,
+  wazooResult: SparqlResponse,
 ): Promise<string | null> {
   switch (testCase.kind) {
     case "select": {
-      if (nativeResult.kind !== "select") {
-        return `Native engine returned ${nativeResult.kind} instead of select`;
+      if (wazooResult.kind !== "select") {
+        return `Wazoo engine returned ${wazooResult.kind} instead of select`;
       }
       const comunicaBindings = await runComunicaSelect(
         comunicaEngine,
@@ -293,12 +293,12 @@ async function compareResult(
       );
       const varsMismatch = compareVars(
         extractSelectVars(testCase.query),
-        nativeResult.data.head.vars,
+        wazooResult.data.head.vars,
       );
       if (varsMismatch !== null) {
         return varsMismatch;
       }
-      const nativeBindings = nativeResult.data.results.bindings.map(
+      const wazooBindings = wazooResult.data.results.bindings.map(
         (binding) => {
           const canonical: Record<string, CanonicalTerm> = {};
           for (const name of Object.keys(binding)) {
@@ -308,48 +308,48 @@ async function compareResult(
         },
       );
       return testCase.orderSensitive === true
-        ? compareOrdered(comunicaBindings, nativeBindings, "SELECT bindings")
-        : compareMultisets(comunicaBindings, nativeBindings, "SELECT bindings");
+        ? compareOrdered(comunicaBindings, wazooBindings, "SELECT bindings")
+        : compareMultisets(comunicaBindings, wazooBindings, "SELECT bindings");
     }
     case "ask": {
-      if (nativeResult.kind !== "ask") {
-        return `Native engine returned ${nativeResult.kind} instead of ask`;
+      if (wazooResult.kind !== "ask") {
+        return `Wazoo engine returned ${wazooResult.kind} instead of ask`;
       }
       const comunicaBoolean = await comunicaEngine.queryBoolean(
         testCase.query,
         { sources: [comunicaStore] },
       );
-      if (comunicaBoolean !== nativeResult.data.boolean) {
+      if (comunicaBoolean !== wazooResult.data.boolean) {
         return (
           `ASK mismatch: expected ${comunicaBoolean} ` +
-          `but got ${nativeResult.data.boolean}`
+          `but got ${wazooResult.data.boolean}`
         );
       }
       return null;
     }
     case "construct": {
-      if (nativeResult.kind !== "construct") {
-        return `Native engine returned ${nativeResult.kind} instead of construct`;
+      if (wazooResult.kind !== "construct") {
+        return `Wazoo engine returned ${wazooResult.kind} instead of construct`;
       }
       const comunicaQuads = await runComunicaConstruct(
         comunicaEngine,
         testCase.query,
         comunicaStore,
       );
-      const nativeQuads = nativeResult.data.quads.map(canonicalQuadString);
+      const wazooQuads = wazooResult.data.quads.map(canonicalQuadString);
       // Issue #87 contract: the reference side is normalized to graph
       // content (Comunica's stream may repeat a triple its graph would
-      // not), while the native side is compared as-emitted — a conforming
+      // not), while the wazoo side is compared as-emitted — a conforming
       // engine emits no duplicate quads, so a duplicate regression fails.
       return compareMultisets(
         [...new Set(comunicaQuads)],
-        nativeQuads,
+        wazooQuads,
         "CONSTRUCT quads",
       );
     }
     case "describe": {
-      if (nativeResult.kind !== "construct") {
-        return `Native engine returned ${nativeResult.kind} instead of construct (DESCRIBE)`;
+      if (wazooResult.kind !== "construct") {
+        return `Wazoo engine returned ${wazooResult.kind} instead of construct (DESCRIBE)`;
       }
       const comunicaQuads = await runComunicaConstruct(
         comunicaEngine,
@@ -359,10 +359,10 @@ async function compareResult(
       // DESCRIBE results are graphs (sets): Comunica's stream may repeat a
       // resource's arcs, so both sides are deduplicated before comparing.
       const comunicaSet = [...new Set(comunicaQuads)];
-      const nativeSet = [
-        ...new Set(nativeResult.data.quads.map(canonicalQuadString)),
+      const wazooSet = [
+        ...new Set(wazooResult.data.quads.map(canonicalQuadString)),
       ];
-      return compareMultisets(comunicaSet, nativeSet, "DESCRIBE quads");
+      return compareMultisets(comunicaSet, wazooSet, "DESCRIBE quads");
     }
   }
 }
@@ -376,16 +376,16 @@ export async function assertQueryParity(
 ): Promise<void> {
   const comunicaEngine = getComunicaEngine();
   const comunicaStore = createQuadStore(testCase.quads);
-  const nativeEngine = new WazooSparqlEngine({
+  const wazooEngine = new WazooSparqlEngine({
     store: createQuadStore(testCase.quads),
   });
 
-  const nativeResult = await nativeEngine.execute({ query: testCase.query });
+  const wazooResult = await wazooEngine.execute({ query: testCase.query });
   const mismatch = await compareResult(
     testCase,
     comunicaEngine,
     comunicaStore,
-    nativeResult,
+    wazooResult,
   );
   if (mismatch !== null) {
     fail(`${mismatch}\n\nQuery: ${testCase.query}`);
@@ -412,7 +412,7 @@ export interface ParityUpdateCase {
  * canonicalStoreQuads renders a store's full contents as a deterministic
  * multiset of canonical quad strings, normalizing blank node labels by
  * position. Blank node labels are opaque: INSERT DATA mints fresh labels per
- * execution (Comunica emits e_<label>NN, the native engine u<N>), so the
+ * execution (Comunica emits e_<label>NN, the wazoo engine u<N>), so the
  * comparison must treat two stores as equal when they agree up to blank node
  * relabeling. Quads are sorted by their label-independent structural form
  * first, then labels are canonicalized in order of first appearance, which
@@ -470,13 +470,13 @@ export async function assertUpdateParity(
 ): Promise<void> {
   const comunicaEngine = getComunicaEngine();
   const comunicaStore = createQuadStore(testCase.quads);
-  const nativeStore = createQuadStore(testCase.quads);
-  const nativeEngine = new WazooSparqlEngine({ store: nativeStore });
+  const wazooStore = createQuadStore(testCase.quads);
+  const wazooEngine = new WazooSparqlEngine({ store: wazooStore });
 
-  const nativeResult = await nativeEngine.execute({ query: testCase.update });
-  if (nativeResult.kind !== "void") {
+  const wazooResult = await wazooEngine.execute({ query: testCase.update });
+  if (wazooResult.kind !== "void") {
     fail(
-      `${testCase.name}: native engine returned ${nativeResult.kind} ` +
+      `${testCase.name}: wazoo engine returned ${wazooResult.kind} ` +
         `instead of void for update`,
     );
   }
@@ -486,7 +486,7 @@ export async function assertUpdateParity(
 
   const mismatch = compareMultisets(
     canonicalStoreQuads(comunicaStore),
-    canonicalStoreQuads(nativeStore),
+    canonicalStoreQuads(wazooStore),
     "final store quads",
   );
   if (mismatch !== null) {

--- a/test/parity/parity.test.ts
+++ b/test/parity/parity.test.ts
@@ -1199,7 +1199,7 @@ Deno.test(
   async () => {
     const comunicaEngine = getComunicaEngine();
     const comunicaStore = createQuadStore([]);
-    const nativeEngine = new WazooSparqlEngine({ store: createQuadStore([]) });
+    const wazooEngine = new WazooSparqlEngine({ store: createQuadStore([]) });
     const shapeQueries = {
       bnode: "SELECT ?v WHERE { BIND(BNODE() AS ?v) }",
       bnodeLabel: 'SELECT ?v WHERE { BIND(BNODE("x") AS ?v) }',
@@ -1215,12 +1215,12 @@ Deno.test(
         comunicaStore,
       );
       const comunicaTerm = comunicaBindings[0].v;
-      const nativeResult = await nativeEngine.execute({ query });
-      assertEquals(nativeResult.kind, "select");
-      if (nativeResult.kind !== "select") {
+      const wazooResult = await wazooEngine.execute({ query });
+      assertEquals(wazooResult.kind, "select");
+      if (wazooResult.kind !== "select") {
         continue;
       }
-      const nativeTerm = nativeResult.data.results.bindings[0].v;
+      const wazooTerm = wazooResult.data.results.bindings[0].v;
       const comunicaLiteral = comunicaTerm.termType === "Literal"
         ? comunicaTerm
         : null;
@@ -1228,7 +1228,7 @@ Deno.test(
         case "bnode":
         case "bnodeLabel":
           assertEquals(comunicaTerm.termType, "BlankNode");
-          assertEquals(nativeTerm.type, "bnode");
+          assertEquals(wazooTerm.type, "bnode");
           break;
         case "struuid": {
           assertEquals(comunicaTerm.termType, "Literal");
@@ -1236,13 +1236,13 @@ Deno.test(
             comunicaLiteral?.datatype?.value,
             "http://www.w3.org/2001/XMLSchema#string",
           );
-          assertEquals(nativeTerm.type, "literal");
-          const nativeLiteral = nativeTerm as {
+          assertEquals(wazooTerm.type, "literal");
+          const wazooLiteral = wazooTerm as {
             type: "literal";
             value: string;
           };
           assertMatch(
-            nativeLiteral.value,
+            wazooLiteral.value,
             /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
           );
           break;
@@ -1250,9 +1250,9 @@ Deno.test(
         case "uuid":
           assertEquals(comunicaTerm.termType, "NamedNode");
           assertMatch(comunicaTerm.value, /^urn:uuid:/);
-          assertEquals(nativeTerm.type, "uri");
+          assertEquals(wazooTerm.type, "uri");
           assertMatch(
-            (nativeTerm as { type: "uri"; value: string }).value,
+            (wazooTerm as { type: "uri"; value: string }).value,
             /^urn:uuid:/,
           );
           break;
@@ -1262,19 +1262,19 @@ Deno.test(
             comunicaLiteral?.datatype?.value,
             "http://www.w3.org/2001/XMLSchema#double",
           );
-          const nativeLiteral = nativeTerm as {
+          const wazooLiteral = wazooTerm as {
             type: "literal";
             value: string;
             datatype?: string;
           };
-          assertEquals(nativeLiteral.type, "literal");
+          assertEquals(wazooLiteral.type, "literal");
           assertEquals(
-            nativeLiteral.datatype,
+            wazooLiteral.datatype,
             "http://www.w3.org/2001/XMLSchema#double",
           );
-          const nativeValue = Number(nativeLiteral.value);
-          if (!(nativeValue >= 0 && nativeValue < 1)) {
-            throw new Error(`RAND out of range: ${nativeValue}`);
+          const wazooValue = Number(wazooLiteral.value);
+          if (!(wazooValue >= 0 && wazooValue < 1)) {
+            throw new Error(`RAND out of range: ${wazooValue}`);
           }
           break;
         }
@@ -1284,14 +1284,14 @@ Deno.test(
             comunicaLiteral?.datatype?.value,
             "http://www.w3.org/2001/XMLSchema#dateTime",
           );
-          const nativeLiteral = nativeTerm as {
+          const wazooLiteral = wazooTerm as {
             type: "literal";
             value: string;
             datatype?: string;
           };
-          assertEquals(nativeLiteral.type, "literal");
+          assertEquals(wazooLiteral.type, "literal");
           assertEquals(
-            nativeLiteral.datatype,
+            wazooLiteral.datatype,
             "http://www.w3.org/2001/XMLSchema#dateTime",
           );
           break;
@@ -1305,7 +1305,7 @@ Deno.test(
   "parity - known difference: BNODE labels are opaque per engine",
   async () => {
     // Both engines mint a blank node for BNODE("x"), but the labels are
-    // engine-specific ("x1" scoped by Comunica, "x" by the native engine).
+    // engine-specific ("x1" scoped by Comunica, "x" by the wazoo engine).
     // Blank node labels are opaque per SPARQL 1.1, so the parity contract is
     // the term type, not the label.
     const query = `SELECT ?v WHERE { BIND(BNODE("x") AS ?v) }`;
@@ -1315,14 +1315,14 @@ Deno.test(
       query,
       createQuadStore([]),
     );
-    const nativeEngine = new WazooSparqlEngine({
+    const wazooEngine = new WazooSparqlEngine({
       store: createQuadStore([]),
     });
-    const nativeResult = await nativeEngine.execute({ query });
-    assertEquals(nativeResult.kind, "select");
-    if (nativeResult.kind === "select") {
+    const wazooResult = await wazooEngine.execute({ query });
+    assertEquals(wazooResult.kind, "select");
+    if (wazooResult.kind === "select") {
       assertEquals(comunicaBindings[0].v.termType, "BlankNode");
-      assertEquals(nativeResult.data.results.bindings[0].v.type, "bnode");
+      assertEquals(wazooResult.data.results.bindings[0].v.type, "bnode");
     }
   },
 );

--- a/test/w3c/README.md
+++ b/test/w3c/README.md
@@ -2,7 +2,7 @@
 
 Runs the vendored W3C SPARQL 1.1 evaluation-core suite **differentially**: every
 query and update executes through both `@comunica/query-sparql-rdfjs-lite` and
-the native `WazooSparqlEngine` over identical stores, and the observable results
+the wazoo `WazooSparqlEngine` over identical stores, and the observable results
 (SELECT bindings, CONSTRUCT quads, ASK booleans, final update store contents)
 are compared. This is the shared fixture base adopted by the wayfinder decision
 "Decide whether to adopt the W3C SPARQL 1.1 suite as the shared fixture base".
@@ -16,15 +16,15 @@ deno task test:w3c
 The runner prints a report and exits nonzero while **parity gaps** remain:
 
 - **pass** — both engines agree.
-- **gap** — native and comunica disagree on an in-scope test; each gap is a
+- **gap** — wazoo and comunica disagree on an in-scope test; each gap is a
   tracked parity defect. The gap count is the progress metric.
 - **error** — the runner itself failed on a test.
 - **documented divergence** — a test keyed in
   [`divergences.ts`](./divergences.ts) with a documented reason (reserved for
-  decided Comunica bugs where native is spec-correct — never for unimplemented
+  decided Comunica bugs where wazoo is spec-correct — never for unimplemented
   surface). These are validated against the W3C reference result (result-set TTL
   for SELECT, an empty store for the SILENT update cases) instead of against
-  Comunica, so a spec-correct native result **passes**.
+  Comunica, so a spec-correct wazoo result **passes**.
 - **conformance** — a soft, never-gating cross-check of the spec-expected result
   where it is parseable (update post-states and CONSTRUCT result files are TTL;
   SELECT/ASK SPARQL XML/JSON results are not parsed).
@@ -73,28 +73,28 @@ tar -xzf /tmp/rdf-tests.tar.gz -C /tmp
 
 # RDF 1.1 / 1.2 syntax gates
 
-The native Turtle / TriG / N-Triples / N-Quads grammar used by SPARQL `LOAD`
+The wazoo Turtle / TriG / N-Triples / N-Quads grammar used by SPARQL `LOAD`
 (`src/parser/turtle-parser.ts`) is gated against the W3C rdf-tests suites with
 two runners, both invoked from `deno task ci`:
 
 - `deno task test:rdf11` — **RDF 1.1 differential** (`rdf-differential.ts`).
   Every Turtle / TriG / N-Triples / N-Quads syntax and eval test is parsed with
-  both the native grammar and `n3@2.2.0`; the two must agree on accept/reject
-  and on the resulting quads (up to blank-node relabeling). Negative tests are
-  additionally gated absolutely — native must reject them even if n3 is lenient.
+  both the wazoo grammar and `n3@2.2.0`; the two must agree on accept/reject and
+  on the resulting quads (up to blank-node relabeling). Negative tests are
+  additionally gated absolutely — wazoo must reject them even if n3 is lenient.
   Eval tests are also gated against their `.nt`/`.nq` reference result (parsed
-  with the native grammar), so a native+n3 agreement on the wrong quads still
+  with the wazoo grammar), so a wazoo+n3 agreement on the wrong quads still
   fails.
 - `deno task test:rdf12` — **RDF 1.2 manifest classifier** (`rdf-classify.ts`).
   n3 predates RDF 1.2 triple terms and reifiers, so each positive syntax test
   must parse, each negative syntax test must be rejected, and each eval test
   must produce quads isomorphic to its `.nt`/`.nq` reference (parsed with the
-  native grammar, which is a superset of N-Triples/N-Quads).
+  wazoo grammar, which is a superset of N-Triples/N-Quads).
 
 Both gates are expected to be green. The only tolerated mismatches are
 documented divergences keyed inside each runner:
 
-- **Superset acceptances** — the native grammar is a single Turtle + TriG +
+- **Superset acceptances** — the wazoo grammar is a single Turtle + TriG +
   N-Quads superset (LOAD content-sniffs the format rather than trusting the file
   extension), so it accepts Turtle/TriG/N-Quads constructs in files where the
   strict N-Triples/N-Quads/Turtle/TriG grammar rejects them. Everything else
@@ -103,7 +103,7 @@ documented divergences keyed inside each runner:
 ### Reference-engine cross-check (`deno task test:ref`)
 
 `ref-crosscheck.ts` audits every allowlisted divergence against two independent
-reference engines and fails if any of them is accepted by native but rejected by
+reference engines and fails if any of them is accepted by wazoo but rejected by
 every lenient reference:
 
 - **Oxigraph** (`npm:oxigraph`, Rust/WASM) — format-strict. Checked in both the
@@ -117,7 +117,7 @@ every lenient reference:
   catchably.
 
 Current result: **45/45 allowlisted cases endorsed** (RDF 1.1: 32, RDF 1.2: 13).
-Every construct native accepts is genuine Turtle/TriG 1.1/1.2 syntax or RFC 3986
+Every construct wazoo accepts is genuine Turtle/TriG 1.1/1.2 syntax or RFC 3986
 IRI resolution:
 
 - Turtle constructs in `.nt`/`.nq` files (relative IRIs, `@prefix`/`@base`,
@@ -130,7 +130,7 @@ IRI resolution:
   tests exist because the N-Triples / N-Quads 1.2 grammars contain no annotation
   production at all, not because the constructs are invalid.
 - `ntriples12-bad-iri-1` (`<//example/missing-scheme>`) — RFC 3986 network-path
-  reference, accepted by Oxigraph-Turtle exactly as native's RFC 3986 resolver
+  reference, accepted by Oxigraph-Turtle exactly as wazoo's RFC 3986 resolver
   handles it.
 - `.nq` files whose Oxigraph/TriG rejection is only about graph-name placement
   (`<g>.` after a triple/annotation, which TriG cannot express) — the same

--- a/test/w3c/construct-semantics.test.ts
+++ b/test/w3c/construct-semantics.test.ts
@@ -5,11 +5,11 @@ import type { CanonicalTerm } from "@/term/mod.ts";
 import { compareConstructRecords, dedupeRecords } from "./runner.ts";
 
 /**
- * Issue #87 contract pins: the W3C CONSTRUCT gate compares the native result
+ * Issue #87 contract pins: the W3C CONSTRUCT gate compares the wazoo result
  * as-emitted (a conforming engine emits no duplicate quads — decision #29),
  * while the reference side is normalized to its graph content (Comunica's
  * stream may repeat a triple its graph would not). The first test is the
- * regression detector the multiset contract exists for: a future native
+ * regression detector the multiset contract exists for: a future wazoo
  * change that starts emitting duplicate quads must fail the gate, not
  * silently pass.
  */
@@ -34,10 +34,10 @@ function key(item: rdfjs.Quad): string {
 }
 
 Deno.test(
-  "CONSTRUCT gate fails when native emits a duplicate quad (issue #87 regression detector)",
+  "CONSTRUCT gate fails when wazoo emits a duplicate quad (issue #87 regression detector)",
   () => {
     const quad1 = q("s", "p", "o");
-    // Native emits the same quad twice; the reference holds it once.
+    // Wazoo emits the same quad twice; the reference holds it once.
     assertEquals(
       compareConstructRecords(
         [rec(quad1), rec(quad1)],
@@ -53,7 +53,7 @@ Deno.test(
   "CONSTRUCT gate normalizes duplicate reference-stream quads",
   () => {
     const quad1 = q("s", "p", "o");
-    // Native emits once; Comunica's stream repeats the triple — the
+    // Wazoo emits once; Comunica's stream repeats the triple — the
     // reference side is normalized, so the graphs agree.
     assertEquals(
       compareConstructRecords(

--- a/test/w3c/divergences.ts
+++ b/test/w3c/divergences.ts
@@ -3,7 +3,7 @@
  *
  * Per the "Decide whether to adopt the W3C SPARQL 1.1 suite as the shared
  * fixture base" resolution, the parity-gap count is the tracked metric and
- * allowlist entries exist ONLY for documented decisions where the native
+ * allowlist entries exist ONLY for documented decisions where the wazoo
  * engine is spec-correct and Comunica lite deviates (e.g. the malformed
  * regex throw) — never for unimplemented surface. Each entry's value is the
  * documented reason, mirroring the divergence list on the wayfinder map.
@@ -14,29 +14,29 @@ export const documentedDivergences: Record<string, string> = {
   // COUNT inside GRAPH with no GROUP BY: the subquery yields one solution per
   // named graph (empty matches still produce COUNT=0), so the outer query has
   // two rows — one per graphData entry. Comunica lite collapses them into a
-  // single ungrouped row and drops the ?g binding. Native matches the W3C
+  // single ungrouped row and drops the ?g binding. Wazoo matches the W3C
   // reference. (SPARQL 1.1 Query §18.2.2.2 aggregation, §13.3 GRAPH.)
   "aggregates:agg-empty-group-count-graph":
-    "Native returns the two spec rows (singleton -> 0, pair -> 2); Comunica collapses to one ungrouped row and drops ?g. SPARQL 1.1 Query §18.2.2.2/§13.3.",
+    "Wazoo returns the two spec rows (singleton -> 0, pair -> 2); Comunica collapses to one ungrouped row and drops ?g. SPARQL 1.1 Query §18.2.2.2/§13.3.",
 
   // VALUES inside GRAPH binding the same variable as the graph name: the
   // VALUES row binds ?g and ?t, and GRAPH ?g joins those with the named
-  // graphs, keeping ?g bound. Native returns the three reference rows
+  // graphs, keeping ?g bound. Wazoo returns the three reference rows
   // (matching graph.ttl); Comunica lite drops the ?g binding and returns two.
   // (SPARQL 1.1 Query §10.2 VALUES, §13.3 GRAPH.)
   "bindings:graph":
-    "Native keeps ?g bound through VALUES-in-GRAPH (3 rows, matching graph.ttl); Comunica drops ?g (2 rows). SPARQL 1.1 Query §10.2/§13.3.",
+    "Wazoo keeps ?g bound through VALUES-in-GRAPH (3 rows, matching graph.ttl); Comunica drops ?g (2 rows). SPARQL 1.1 Query §10.2/§13.3.",
 
   // LOAD ... SILENT: a failed remote retrieval must be ignored, leaving the
-  // store unchanged. Native honors SILENT; Comunica lite has no loader for
+  // store unchanged. Wazoo honors SILENT; Comunica lite has no loader for
   // the somescheme:// IRI and throws a query-source identification error.
   // (SPARQL 1.1 Update §3.1.3 LOAD.)
   "update-silent:load-silent":
-    "Native ignores the unloadable somescheme:// IRI per SILENT; Comunica lite throws a query-source identification error. SPARQL 1.1 Update §3.1.3.",
+    "Wazoo ignores the unloadable somescheme:// IRI per SILENT; Comunica lite throws a query-source identification error. SPARQL 1.1 Update §3.1.3.",
 
   // LOAD ... INTO GRAPH ... SILENT: same as LOAD SILENT, but targeting a
-  // named graph. Native honors SILENT and leaves the graph unchanged;
+  // named graph. Wazoo honors SILENT and leaves the graph unchanged;
   // Comunica lite throws on the unloadable IRI. (SPARQL 1.1 Update §3.1.3.)
   "update-silent:load-into-silent":
-    "Native ignores the unloadable somescheme:// IRI per SILENT; Comunica lite throws a query-source identification error. SPARQL 1.1 Update §3.1.3.",
+    "Wazoo ignores the unloadable somescheme:// IRI per SILENT; Comunica lite throws a query-source identification error. SPARQL 1.1 Update §3.1.3.",
 };

--- a/test/w3c/exists-ref.ts
+++ b/test/w3c/exists-ref.ts
@@ -4,19 +4,19 @@ import { MemoryStore as Store } from "@/store/memory-store.ts";
 import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
 
 /**
- * EXISTS surface cross-check: the native engine must agree with Oxigraph on
+ * EXISTS surface cross-check: the wazoo engine must agree with Oxigraph on
  * subqueries inside EXISTS/NOT EXISTS.
  *
  * The EXISTS evaluator (src/evaluator/bgp-evaluator.ts) evaluates subqueries
  * over the graph-scoped candidate snapshot, then runs the shared select
  * pipeline (src/evaluator/select-pipeline.ts). The in-repo regression tests
- * assert native semantics; this gate cross-validates them against an
+ * assert wazoo semantics; this gate cross-validates them against an
  * independent SPARQL 1.1 engine — Oxigraph (Rust/WASM) — so a future change
  * that quietly breaks subquery-in-EXISTS evaluation fails CI even if the
  * unit tests are updated to match. Every case projects one variable; the
  * comparison is over the sorted set of projected values.
  *
- * This mirrors the earlier probe-driven validation (native = Oxigraph on all
+ * This mirrors the earlier probe-driven validation (wazoo = Oxigraph on all
  * 9 cases, SPARQL 1.1 §18.2.4 non-correlation included) and keeps it
  * repeatable. Comunica's lite engine is deliberately not an oracle here: it
  * correlates subqueries with outer bindings (wrong per §18.2.4) and
@@ -28,7 +28,7 @@ import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
 const BASE = "http://example.org/base";
 
 /** Dataset shared by both engines, as Turtle (loaded by Oxigraph) and as
- * RDF/JS quads (built into the native MemoryStore). */
+ * RDF/JS quads (built into the wazoo MemoryStore). */
 const TURTLE = `
 @prefix ex: <http://example.org/> .
 ex:s ex:p ex:a .
@@ -45,7 +45,7 @@ interface Case {
 }
 
 /** Projected-variable expected values are implied by the subquery semantics;
- * the gate compares native vs Oxigraph, not against a hardcoded list. */
+ * the gate compares wazoo vs Oxigraph, not against a hardcoded list. */
 const CASES: Case[] = [
   {
     name: "basic",
@@ -130,7 +130,7 @@ const CASES: Case[] = [
 
 const { namedNode, literal, quad } = DataFactory;
 
-function nativeStore(): Store {
+function wazooStore(): Store {
   const store = new Store();
   const ex = (local: string) => namedNode(`http://example.org/${local}`);
   const add = (s: string, p: string, o: string) =>
@@ -147,12 +147,12 @@ function nativeStore(): Store {
   return store;
 }
 
-/** Native: project a variable from the SELECT results, sorted. */
-async function nativeProjected(
+/** Wazoo: project a variable from the SELECT results, sorted. */
+async function wazooProjected(
   query: string,
   variable: string,
 ): Promise<string[]> {
-  const engine = new WazooSparqlEngine({ store: nativeStore() });
+  const engine = new WazooSparqlEngine({ store: wazooStore() });
   const result = await engine.execute({ query });
   if (result.kind !== "select") {
     throw new Error(`expected select, got ${result.kind}`);
@@ -180,15 +180,15 @@ function oxigraphProjected(query: string, variable: string): string[] {
 }
 
 let failures = 0;
-console.log("case | native | oxigraph | verdict");
+console.log("case | wazoo | oxigraph | verdict");
 console.log("-".repeat(72));
 for (const c of CASES) {
-  const native = await nativeProjected(c.query, "s");
+  const wazoo = await wazooProjected(c.query, "s");
   const oxi = oxigraphProjected(c.query, "s");
-  const pass = JSON.stringify(native) === JSON.stringify(oxi);
+  const pass = JSON.stringify(wazoo) === JSON.stringify(oxi);
   if (!pass) failures++;
   console.log(
-    `${c.name} | [${native.join(", ")}] | [${oxi.join(", ")}] | ` +
+    `${c.name} | [${wazoo.join(", ")}] | [${oxi.join(", ")}] | ` +
       `${pass ? "pass" : "DIVERGE"}`,
   );
 }
@@ -196,13 +196,13 @@ for (const c of CASES) {
 console.log(`\n${CASES.length} EXISTS-subquery case(s) cross-checked.`);
 if (failures > 0) {
   console.error(
-    `\nCross-check FAILED: native diverges from Oxigraph on ${failures} ` +
+    `\nCross-check FAILED: wazoo diverges from Oxigraph on ${failures} ` +
       `case(s). Fix the EXISTS evaluator or the select pipeline before ` +
       `touching the queries.\n`,
   );
   Deno.exit(1);
 }
 console.log(
-  "\nCross-check passed: native agrees with Oxigraph on every subquery-in-" +
+  "\nCross-check passed: wazoo agrees with Oxigraph on every subquery-in-" +
     "EXISTS case, including §18.2.4 non-correlation.",
 );

--- a/test/w3c/rdf-classify.ts
+++ b/test/w3c/rdf-classify.ts
@@ -4,12 +4,12 @@ import { loadRdfManifest, quadSetsIsomorphicAsSets } from "./rdf-harness.ts";
 import type { RdfSyntaxCase } from "./rdf-harness.ts";
 
 /**
- * RDF 1.2 manifest classifier: the native grammar must (1) accept every
+ * RDF 1.2 manifest classifier: the wazoo grammar must (1) accept every
  * positive syntax test, (2) reject every negative syntax test, and (3) for
  * eval tests, parse the action into quads isomorphic to the `.nt`/`.nq`
  * reference result. n3 cannot be the oracle here — n3@2.2.0 predates RDF 1.2
  * triple terms and reifiers — so the reference result is parsed with the
- * native grammar itself (N-Triples/N-Quads are a subset of it).
+ * wazoo grammar itself (N-Triples/N-Quads are a subset of it).
  *
  * Permitted negative-test failures are documented in one allowlist below:
  * `supersetDivergences` (RDF 1.2 constructs the single superset grammar
@@ -27,10 +27,10 @@ const RDF12_MANIFESTS = [
 
 const SUPERSET_REASON =
   "RDF 1.2 N-Triples/N-Quads reject triple terms, reifiers, annotations, and " +
-  "relative IRIs, but native's single Turtle + TriG + N-Quads superset grammar " +
+  "relative IRIs, but wazoo's single Turtle + TriG + N-Quads superset grammar " +
   "accepts them (LOAD sniffs the format from the content). Intentional.";
 
-/** Negative tests native accepts by design (RDF 1.2 superset grammar). */
+/** Negative tests wazoo accepts by design (RDF 1.2 superset grammar). */
 export const supersetDivergences: ReadonlySet<string> = new Set([
   "rdf12:rdf-n-triples/syntax:ntriples12-bad-09",
   "rdf12:rdf-n-triples/syntax:ntriples12-bad-iri-1",
@@ -85,7 +85,7 @@ function evaluate(testCase: RdfSyntaxCase): Verdict {
 
   if (testCase.kind === "negative") {
     if (quads === null) return { status: "pass" };
-    const detail = `native accepted a negative test${
+    const detail = `wazoo accepted a negative test${
       allowlisted ? ` — allowlisted: ${reason}` : ""
     }`;
     return { status: "gap", detail, allowlisted };
@@ -94,7 +94,7 @@ function evaluate(testCase: RdfSyntaxCase): Verdict {
   if (quads === null) {
     return {
       status: "gap",
-      detail: `native rejected a positive test: ${error}`,
+      detail: `wazoo rejected a positive test: ${error}`,
       allowlisted: false,
     };
   }
@@ -120,7 +120,7 @@ function evaluate(testCase: RdfSyntaxCase): Verdict {
     if (reference === null) {
       return {
         status: "gap",
-        detail: `native rejected the reference result: ${referenceError}`,
+        detail: `wazoo rejected the reference result: ${referenceError}`,
         allowlisted: false,
       };
     }
@@ -130,7 +130,7 @@ function evaluate(testCase: RdfSyntaxCase): Verdict {
     return {
       status: "gap",
       detail:
-        `eval mismatch: native ${quads.length} quads vs reference ${reference.length} quads`,
+        `eval mismatch: wazoo ${quads.length} quads vs reference ${reference.length} quads`,
       allowlisted: false,
     };
   }

--- a/test/w3c/rdf-differential.ts
+++ b/test/w3c/rdf-differential.ts
@@ -10,16 +10,16 @@ import {
 import type { RdfSyntaxCase } from "./rdf-harness.ts";
 
 /**
- * RDF 1.1 differential gate: the native Turtle/TriG/N-Triples/N-Quads grammar
+ * RDF 1.1 differential gate: the wazoo Turtle/TriG/N-Triples/N-Quads grammar
  * (parseTurtleQuads) must agree with n3@2.2.0 on every W3C RDF 1.1 syntax and
  * eval test — same accept/reject verdict, and isomorphic quads for the tests
- * both accept. Negative tests are additionally gated absolutely: native must
+ * both accept. Negative tests are additionally gated absolutely: wazoo must
  * reject them even if n3 is lenient. Eval tests are also gated against their
- * W3C `.nt`/`.nq` reference result (parsed with the native grammar), so a
- * native+n3 agreement on the wrong quads still fails.
+ * W3C `.nt`/`.nq` reference result (parsed with the wazoo grammar), so a
+ * wazoo+n3 agreement on the wrong quads still fails.
  *
  * The only permitted mismatches are in `supersetDivergences`: negative tests
- * the native grammar accepts because it is a single Turtle + TriG + N-Quads
+ * the wazoo grammar accepts because it is a single Turtle + TriG + N-Quads
  * superset (LOAD content-sniffs the document format rather than trusting the
  * file extension). Every other disagreement is a defect.
  */
@@ -32,13 +32,13 @@ const RDF11_MANIFESTS = [
 ];
 
 const SUPERSET_REASON =
-  "Native's grammar is a single Turtle + TriG + N-Quads superset (LOAD sniffs " +
+  "Wazoo's grammar is a single Turtle + TriG + N-Quads superset (LOAD sniffs " +
   "the format from the content, not the file extension), so it accepts " +
   "Turtle/TriG/N-Quads constructs — @prefix/@base, relative IRIs, numeric and " +
   "string literal shorthands, graph blocks, and graph labels — in files where " +
   "the strict N-Triples/N-Quads/Turtle/TriG grammar rejects them. Intentional.";
 
-/** Negative tests native accepts by design (superset grammar), keyed by id. */
+/** Negative tests wazoo accepts by design (superset grammar), keyed by id. */
 export const supersetDivergences: ReadonlySet<string> = new Set([
   "rdf11:rdf-turtle:turtle-syntax-bad-struct-01",
   "rdf11:rdf-turtle:turtle-syntax-bad-struct-03",
@@ -89,7 +89,7 @@ function readFixture(rel: string): string {
   return Deno.readTextFileSync(`test/w3c/fixtures/${rel}`);
 }
 
-function parseNative(testCase: RdfSyntaxCase): rdfjs.Quad[] {
+function parseWazoo(testCase: RdfSyntaxCase): rdfjs.Quad[] {
   return parseTurtleQuads(readFixture(testCase.action), testCase.actionUrl);
 }
 
@@ -112,14 +112,14 @@ function describe(err: unknown): string {
 function evaluate(testCase: RdfSyntaxCase): Verdict {
   const allowlisted = supersetDivergences.has(testCase.id);
 
-  let nativeQuads: rdfjs.Quad[] | null = null;
-  let nativeError: string | null = null;
+  let wazooQuads: rdfjs.Quad[] | null = null;
+  let wazooError: string | null = null;
   try {
-    nativeQuads = parseNative(testCase);
+    wazooQuads = parseWazoo(testCase);
   } catch (err) {
-    nativeError = describe(err);
+    wazooError = describe(err);
   }
-  const nativeAccepts = nativeQuads !== null;
+  const wazooAccepts = wazooQuads !== null;
 
   let n3Quads: rdfjs.Quad[] | null = null;
   let n3Error: string | null = null;
@@ -131,11 +131,11 @@ function evaluate(testCase: RdfSyntaxCase): Verdict {
   const n3Accepts = n3Quads !== null;
 
   if (testCase.kind === "negative") {
-    // Absolute gate: a negative test must be rejected by native. n3's verdict
+    // Absolute gate: a negative test must be rejected by wazoo. n3's verdict
     // is informational only (it is the stricter reference for N-Triples and
-    // N-Quads, but agreement does not excuse native accepting a negative test).
-    if (!nativeAccepts) return { status: "pass" };
-    const detail = `native accepted a negative test${
+    // N-Quads, but agreement does not excuse wazoo accepting a negative test).
+    if (!wazooAccepts) return { status: "pass" };
+    const detail = `wazoo accepted a negative test${
       n3Accepts ? " (n3 also accepted it)" : " (n3 rejected it)"
     }`;
     return allowlisted
@@ -147,9 +147,9 @@ function evaluate(testCase: RdfSyntaxCase): Verdict {
       : { status: "gap", detail, allowlisted: false };
   }
 
-  // Positive / eval: native must parse, and agree with n3 when both parse.
-  if (!nativeAccepts) {
-    const detail = `native rejected a positive test: ${nativeError}` +
+  // Positive / eval: wazoo must parse, and agree with n3 when both parse.
+  if (!wazooAccepts) {
+    const detail = `wazoo rejected a positive test: ${wazooError}` +
       (n3Accepts ? " (n3 accepted it)" : " (n3 also rejected it)");
     return { status: "gap", detail, allowlisted: false };
   }
@@ -157,12 +157,12 @@ function evaluate(testCase: RdfSyntaxCase): Verdict {
   if (!n3Accepts) {
     return {
       status: "gap",
-      detail: `native accepted, n3 rejected: ${n3Error}`,
+      detail: `wazoo accepted, n3 rejected: ${n3Error}`,
       allowlisted,
     };
   }
 
-  if (quadSetsIsomorphic(nativeQuads!, n3Quads!)) {
+  if (quadSetsIsomorphic(wazooQuads!, n3Quads!)) {
     // Eval tests must additionally reproduce the W3C reference result, so
     // agreement with n3 is not enough on its own.
     if (testCase.kind === "eval") {
@@ -183,14 +183,14 @@ function evaluate(testCase: RdfSyntaxCase): Verdict {
       if (reference === null) {
         return {
           status: "gap",
-          detail: `native rejected the reference result: ${referenceError}`,
+          detail: `wazoo rejected the reference result: ${referenceError}`,
           allowlisted: false,
         };
       }
-      if (!quadSetsIsomorphicAsSets(nativeQuads!, reference)) {
+      if (!quadSetsIsomorphicAsSets(wazooQuads!, reference)) {
         return {
           status: "gap",
-          detail: `eval mismatch vs reference: native ${nativeQuads!.length} ` +
+          detail: `eval mismatch vs reference: wazoo ${wazooQuads!.length} ` +
             `quads vs reference ${reference.length} quads`,
           allowlisted: false,
         };
@@ -200,7 +200,7 @@ function evaluate(testCase: RdfSyntaxCase): Verdict {
   }
   return {
     status: "gap",
-    detail: `quad mismatch: native ${nativeQuads!.length} quads vs n3 ${
+    detail: `quad mismatch: wazoo ${wazooQuads!.length} quads vs n3 ${
       n3Quads!.length
     } quads`,
     allowlisted,
@@ -235,7 +235,7 @@ if (import.meta.main) {
     r.verdict.status === "gap" && !r.verdict.allowlisted
   );
 
-  console.log("\n=== RDF 1.1 differential (native vs n3) ===");
+  console.log("\n=== RDF 1.1 differential (wazoo vs n3) ===");
   console.log(`total:      ${rows.length}`);
   console.log(`pass:       ${pass}`);
   console.log(`gap:        ${realGaps.length}`);

--- a/test/w3c/rdf-harness.ts
+++ b/test/w3c/rdf-harness.ts
@@ -11,7 +11,7 @@ import { MemoryStore } from "@/store/memory-store.ts";
  * w3c/rdf-tests tree, so every on-disk path maps 1:1 to a canonical
  * `https://w3c.github.io/rdf-tests/…` URL. Relative IRIs in the test files
  * resolve against that canonical URL (matching the W3C harness), which is what
- * makes native output comparable to the `.nt` reference results.
+ * makes wazoo output comparable to the `.nt` reference results.
  */
 
 const RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";

--- a/test/w3c/ref-crosscheck.ts
+++ b/test/w3c/ref-crosscheck.ts
@@ -11,7 +11,7 @@ import { supersetDivergences as rdf12Allowlist } from "./rdf-classify.ts";
  *
  * Every case in `supersetDivergences` (rdf-differential.ts, rdf11) and
  * `supersetDivergences` (rdf-classify.ts, rdf12) is a *negative* syntax test
- * that native accepts on purpose: LOAD parses with a single Turtle + TriG +
+ * that wazoo accepts on purpose: LOAD parses with a single Turtle + TriG +
  * N-Quads superset grammar and content-sniffs the format instead of trusting
  * the file extension, so Turtle/TriG constructs inside strict-format files are
  * accepted. This tool audits that policy against independent reference
@@ -23,12 +23,12 @@ import { supersetDivergences as rdf12Allowlist } from "./rdf-classify.ts";
  *   - N3.js in RDF-star mode (the engine behind @comunica's rdf-parse, which
  *     passes `mediaType + "*"` to enable RDF-star syntax in every format —
  *     see @comunica/actor-rdf-parse-n3). This is the lenient, content-sniffing
- *     reference; it mirrors native's design. The synchronous API is used
+ *     reference; it mirrors wazoo's design. The synchronous API is used
  *     because rdf-parse's streaming path throws an *uncaught* null-deref on
  *     some malformed RDF 1.2 inputs (nquads12-nested-bad-annotated-syntax-1)
  *     that would kill the whole tool.
  *
- * A case is endorsed when native accepts it AND at least one of:
+ * A case is endorsed when wazoo accepts it AND at least one of:
  *   1. N3 (RDF-star mode) accepts the file, or
  *   2. oxigraph accepts the file in the superset format, or
  *   3. for .nq files, oxigraph (Turtle) accepts the content with graph names
@@ -111,7 +111,7 @@ interface Row {
   action: string;
   text: string;
   url: string;
-  native: Verdict;
+  wazoo: Verdict;
   oxiSup: Verdict;
   oxiStrict: Verdict;
   n3Len: Verdict;
@@ -126,10 +126,10 @@ for (const manifest of MANIFESTS) {
     const allowed = RDF11_ALLOWED.has(c.id) || RDF12_ALLOWED.has(c.id);
     if (!allowed) continue;
     const text = readFixture(c.action);
-    const native = verdictOf(() => parseTurtleQuads(text, c.actionUrl));
+    const wazoo = verdictOf(() => parseTurtleQuads(text, c.actionUrl));
     const oxiSup = oxi(text, supersetFormat(c.action), c.actionUrl);
     const n3Len = n3(text, strictFormat(c.action), c.actionUrl, true);
-    let endorsed = native.kind === "accept" &&
+    let endorsed = wazoo.kind === "accept" &&
       (n3Len.kind === "accept" || oxiSup.kind === "accept");
     if (!endorsed && c.action.endsWith(".nq")) {
       const stripped = oxi(stripGraphNames(text), "text/turtle", c.actionUrl);
@@ -140,7 +140,7 @@ for (const manifest of MANIFESTS) {
       action: c.action,
       text,
       url: c.actionUrl,
-      native,
+      wazoo,
       oxiSup,
       oxiStrict: oxi(text, strictFormat(c.action), c.actionUrl),
       n3Len,
@@ -153,12 +153,12 @@ for (const manifest of MANIFESTS) {
 const fmt = (v: Verdict): string => v.kind === "accept" ? `A(${v.quads})` : `R`;
 
 console.log(
-  "case | native | oxi-superset | oxi-strict | n3-lenient | n3-strict | endorsed",
+  "case | wazoo | oxi-superset | oxi-strict | n3-lenient | n3-strict | endorsed",
 );
 console.log("-".repeat(110));
 for (const r of rows) {
   console.log(
-    `${r.id} | ${fmt(r.native)} | ${fmt(r.oxiSup)} | ${fmt(r.oxiStrict)} | ` +
+    `${r.id} | ${fmt(r.wazoo)} | ${fmt(r.oxiSup)} | ${fmt(r.oxiStrict)} | ` +
       `${fmt(r.n3Len)} | ${fmt(r.n3Strict)} | ${r.endorsed ? "yes" : "NO"}`,
   );
 }
@@ -183,7 +183,7 @@ if (n3Crashed.length > 0) {
 if (unendorsed.length > 0) {
   console.error(
     `\nCross-check FAILED: ${unendorsed.length} allowlisted case(s) are accepted ` +
-      `by native but rejected by every lenient reference engine. These are ` +
+      `by wazoo but rejected by every lenient reference engine. These are ` +
       `candidates for unholding — tighten the grammar or remove them from the ` +
       `allowlist:\n  ${unendorsed.map((r) => r.id).join("\n  ")}`,
   );

--- a/test/w3c/runner.ts
+++ b/test/w3c/runner.ts
@@ -65,7 +65,7 @@ export interface W3cRunReport {
   /** conformance is the soft (never gating) spec-expected cross-check. */
   conformance: Array<{
     id: string;
-    native: string;
+    wazoo: string;
     comunica: string;
   }>;
 }
@@ -96,7 +96,7 @@ function canonicalQuadString(
  * a reference-engine CONSTRUCT stream to its graph content: the reference
  * is a set of triples (the W3C reference files are sets), and Comunica's
  * query stream may repeat a triple that its graph would not. Only the
- * reference side is normalized — the native side is compared as-emitted
+ * reference side is normalized — the wazoo side is compared as-emitted
  * (issue #87 contract, see compareConstructRecords).
  */
 export function dedupeRecords(
@@ -153,23 +153,23 @@ function isomorphicMultiset(
 }
 
 /**
- * compareConstructRecords compares a native CONSTRUCT result against a
+ * compareConstructRecords compares a wazoo CONSTRUCT result against a
  * reference (Comunica) result under the graph-result contract (issue #87):
  * the reference side is normalized to its graph content (Comunica's stream
- * may repeat a triple its graph would not), while the native side is
+ * may repeat a triple its graph would not), while the wazoo side is
  * compared as-emitted. Decision #29 guarantees a conforming engine emits no
  * duplicate quads — CONSTRUCT collapses duplicate instantiations — so raw
- * native records equal the normalized reference exactly when the graph
+ * wazoo records equal the normalized reference exactly when the graph
  * contents agree, and a future change that starts emitting duplicates fails
  * the gate instead of silently passing.
  */
 export function compareConstructRecords(
-  nativeRecords: CanonicalTerm[][],
+  wazooRecords: CanonicalTerm[][],
   comunicaRecords: CanonicalTerm[][],
   comunicaKeys: string[],
 ): boolean {
   return isomorphicMultiset(
-    nativeRecords,
+    wazooRecords,
     dedupeRecords(comunicaRecords, comunicaKeys),
   );
 }
@@ -442,7 +442,7 @@ export class W3cRunner {
 
   /**
    * compareReference validates a documented divergence against the W3C
-   * reference result instead of Comunica, so a spec-correct native result
+   * reference result instead of Comunica, so a spec-correct wazoo result
    * passes even when Comunica lite is buggy. SELECT divergences compare
    * against the rs:ResultSet reference up to blank-node isomorphism; update
    * divergences with an empty mf:result compare the final store against an
@@ -466,30 +466,30 @@ export class W3cRunner {
     }
 
     const store = this.loadStore(testCase);
-    const native = new WazooSparqlEngine({ store });
-    const nativeResult = await native.execute({
+    const wazoo = new WazooSparqlEngine({ store });
+    const wazooResult = await wazoo.execute({
       query: this.queryText(testCase),
     });
-    if (nativeResult.kind !== "select") {
+    if (wazooResult.kind !== "select") {
       return {
         status: "error",
         detail:
-          `documented divergence ${testCase.id} returned kind ${nativeResult.kind}, expected select`,
+          `documented divergence ${testCase.id} returned kind ${wazooResult.kind}, expected select`,
       };
     }
 
     const solutions = this.parseResultSetTtl(testCase, testCase.resultFile);
-    const nativeRecords = this.nativeSelectRecords(nativeResult);
+    const wazooRecords = this.wazooSelectRecords(wazooResult);
     const referenceRecords = this.resultSetRecords(solutions);
-    if (isomorphicMultiset(nativeRecords, referenceRecords)) {
+    if (isomorphicMultiset(wazooRecords, referenceRecords)) {
       return { status: "pass" };
     }
     return {
       status: "gap",
       detail: this.firstDiff(
-        this.nativeSelectStrings(nativeResult),
+        this.wazooSelectStrings(wazooResult),
         this.resultSetStrings(solutions),
-        "native vs W3C reference bindings",
+        "wazoo vs W3C reference bindings",
       ),
     };
   }
@@ -497,33 +497,33 @@ export class W3cRunner {
   private async compareUpdateReference(
     testCase: W3cTestCase,
   ): Promise<TestOutcome> {
-    const nativeStore = this.loadStore(testCase);
-    const native = new WazooSparqlEngine({ store: nativeStore });
+    const wazooStore = this.loadStore(testCase);
+    const wazoo = new WazooSparqlEngine({ store: wazooStore });
     try {
-      const result = await native.execute({ query: this.queryText(testCase) });
+      const result = await wazoo.execute({ query: this.queryText(testCase) });
       if (result.kind !== "void") {
         return {
           status: "error",
-          detail: `native update ${testCase.id} returned a non-void result`,
+          detail: `wazoo update ${testCase.id} returned a non-void result`,
         };
       }
     } catch (error) {
       return {
         status: "error",
-        detail: `native rejected the update for divergence ${testCase.id}: ${
+        detail: `wazoo rejected the update for divergence ${testCase.id}: ${
           error instanceof Error ? error.message : String(error)
         }`,
       };
     }
 
-    const quads: rdfjs.Quad[] = nativeStore.getQuads(null, null, null, null);
+    const quads: rdfjs.Quad[] = wazooStore.getQuads(null, null, null, null);
     if (quads.length === 0) {
       return { status: "pass" };
     }
     return {
       status: "gap",
       detail:
-        `native left ${quads.length} quad(s) after ${testCase.id}; the W3C reference (mf:result []) expects an empty store`,
+        `wazoo left ${quads.length} quad(s) after ${testCase.id}; the W3C reference (mf:result []) expects an empty store`,
     };
   }
 
@@ -531,7 +531,7 @@ export class W3cRunner {
    * parseResultSetTtl parses an rs:ResultSet result file into canonical
    * binding records — the W3C reference representation of a SELECT result.
    * Each record maps variable name -> canonical term, matching the shape
-   * nativeSelectRecords and runComunicaSelectRecords build from live results.
+   * wazooSelectRecords and runComunicaSelectRecords build from live results.
    */
   private parseResultSetTtl(
     testCase: W3cTestCase,
@@ -614,13 +614,13 @@ export class W3cRunner {
   private async compareQuery(testCase: W3cTestCase): Promise<TestOutcome> {
     const query = this.queryText(testCase);
 
-    let nativeResult: SparqlResponse;
+    let wazooResult: SparqlResponse;
     try {
       const store = this.loadStore(testCase);
-      const native = new WazooSparqlEngine({ store });
-      nativeResult = await native.execute({ query });
+      const wazoo = new WazooSparqlEngine({ store });
+      wazooResult = await wazoo.execute({ query });
     } catch (error) {
-      // Native rejected the query. Differential contract: pass only if
+      // Wazoo rejected the query. Differential contract: pass only if
       // Comunica rejects it too (both-reject agreement, which is the
       // expected outcome for NegativeSyntaxTest11 entries).
       const comunicaAccepted = await this.comunicaRunsQuery(testCase, query);
@@ -629,25 +629,25 @@ export class W3cRunner {
       }
       return {
         status: "gap",
-        detail: `native rejected the query, comunica accepted it: ${
+        detail: `wazoo rejected the query, comunica accepted it: ${
           error instanceof Error ? error.message : String(error)
         }`,
       };
     }
 
-    const comunicaOutcome = await this.runComunicaQuery(testCase, nativeResult);
+    const comunicaOutcome = await this.runComunicaQuery(testCase, wazooResult);
     return comunicaOutcome;
   }
 
   private async runComunicaQuery(
     testCase: W3cTestCase,
-    nativeResult: SparqlResponse,
+    wazooResult: SparqlResponse,
   ): Promise<TestOutcome> {
     const store = this.loadStore(testCase);
     const query = this.queryText(testCase);
     const options = { sources: [store] };
 
-    switch (nativeResult.kind) {
+    switch (wazooResult.kind) {
       case "select": {
         let comunica: string[];
         try {
@@ -655,22 +655,22 @@ export class W3cRunner {
         } catch (error) {
           return {
             status: "gap",
-            detail: `native executed the query, comunica rejected it: ${
+            detail: `wazoo executed the query, comunica rejected it: ${
               error instanceof Error ? error.message : String(error)
             }`,
           };
         }
-        const native = this.nativeSelectStrings(nativeResult);
-        const nativeRecords = this.nativeSelectRecords(nativeResult);
+        const wazoo = this.wazooSelectStrings(wazooResult);
+        const wazooRecords = this.wazooSelectRecords(wazooResult);
         const comunicaRecords = await this.runComunicaSelectRecords(
           query,
           store,
         );
-        return isomorphicMultiset(nativeRecords, comunicaRecords)
+        return isomorphicMultiset(wazooRecords, comunicaRecords)
           ? { status: "pass" }
           : {
             status: "gap",
-            detail: this.firstDiff(native, comunica, "SELECT bindings"),
+            detail: this.firstDiff(wazoo, comunica, "SELECT bindings"),
           };
       }
       case "ask": {
@@ -680,15 +680,15 @@ export class W3cRunner {
         } catch (error) {
           return {
             status: "gap",
-            detail: `native executed the query, comunica rejected it: ${
+            detail: `wazoo executed the query, comunica rejected it: ${
               error instanceof Error ? error.message : String(error)
             }`,
           };
         }
-        return comunica === nativeResult.data.boolean ? { status: "pass" } : {
+        return comunica === wazooResult.data.boolean ? { status: "pass" } : {
           status: "gap",
           detail:
-            `ASK mismatch: comunica=${comunica} native=${nativeResult.data.boolean}`,
+            `ASK mismatch: comunica=${comunica} wazoo=${wazooResult.data.boolean}`,
         };
       }
       case "construct": {
@@ -708,46 +708,46 @@ export class W3cRunner {
         } catch (error) {
           return {
             status: "gap",
-            detail: `native executed the query, comunica rejected it: ${
+            detail: `wazoo executed the query, comunica rejected it: ${
               error instanceof Error ? error.message : String(error)
             }`,
           };
         }
-        const nativeKeys = nativeResult.data.quads.map((item) =>
+        const wazooKeys = wazooResult.data.quads.map((item) =>
           canonicalQuadString(item, canonicalizeRdfTerm)
         );
-        const nativeSet = [...nativeKeys].sort();
+        const wazooSet = [...wazooKeys].sort();
         // Issue #87 contract: the reference side is normalized to its graph
-        // content, while the native side is compared as-emitted — decision
+        // content, while the wazoo side is compared as-emitted — decision
         // #29 guarantees a conforming engine emits no duplicate quads, so a
         // future change that starts emitting them fails this gate.
-        const nativeRecords = nativeResult.data.quads.map((item) =>
+        const wazooRecords = wazooResult.data.quads.map((item) =>
           this.quadRecords(item, canonicalizeRdfTerm)
         );
         return compareConstructRecords(
-            nativeRecords,
+            wazooRecords,
             comunicaRecords,
             comunicaKeys,
           )
           ? { status: "pass" }
           : {
             status: "gap",
-            detail: this.firstDiff(nativeSet, comunicaSet, "CONSTRUCT quads"),
+            detail: this.firstDiff(wazooSet, comunicaSet, "CONSTRUCT quads"),
           };
       }
       default:
         return {
           status: "error",
-          detail: `native returned unexpected kind ${nativeResult.kind}`,
+          detail: `wazoo returned unexpected kind ${wazooResult.kind}`,
         };
     }
   }
 
-  private nativeSelectStrings(nativeResult: SparqlResponse): string[] {
-    if (nativeResult.kind !== "select") {
+  private wazooSelectStrings(wazooResult: SparqlResponse): string[] {
+    if (wazooResult.kind !== "select") {
       return [];
     }
-    return nativeResult.data.results.bindings.map((binding) => {
+    return wazooResult.data.results.bindings.map((binding) => {
       const record: Record<string, CanonicalTerm> = {};
       for (const name of Object.keys(binding)) {
         record[name] = canonicalizeSparqlValue(binding[name]);
@@ -756,11 +756,11 @@ export class W3cRunner {
     });
   }
 
-  private nativeSelectRecords(nativeResult: SparqlResponse): CanonicalTerm[][] {
-    if (nativeResult.kind !== "select") {
+  private wazooSelectRecords(wazooResult: SparqlResponse): CanonicalTerm[][] {
+    if (wazooResult.kind !== "select") {
       return [];
     }
-    return nativeResult.data.results.bindings.map((binding) => {
+    return wazooResult.data.results.bindings.map((binding) => {
       const record: Record<string, CanonicalTerm> = {};
       for (const name of Object.keys(binding)) {
         record[name] = canonicalizeSparqlValue(binding[name]);
@@ -819,8 +819,8 @@ export class W3cRunner {
     for (let index = 0; index < Math.max(aSet.length, bSet.length); index++) {
       if (aSet[index] !== bSet[index]) {
         return (
-          `${label} diverge (native ${aSet.length}, comunica ${bSet.length}):\n` +
-          `  native:   ${aSet[index] ?? "<absent>"}\n` +
+          `${label} diverge (wazoo ${aSet.length}, comunica ${bSet.length}):\n` +
+          `  wazoo:   ${aSet[index] ?? "<absent>"}\n` +
           `  comunica: ${bSet[index] ?? "<absent>"}`
         );
       }
@@ -831,14 +831,14 @@ export class W3cRunner {
   private async compareUpdate(testCase: W3cTestCase): Promise<TestOutcome> {
     const request = this.queryText(testCase);
 
-    const nativeStore = this.loadStore(testCase);
-    const native = new WazooSparqlEngine({ store: nativeStore });
+    const wazooStore = this.loadStore(testCase);
+    const wazoo = new WazooSparqlEngine({ store: wazooStore });
     try {
-      const result = await native.execute({ query: request });
+      const result = await wazoo.execute({ query: request });
       if (result.kind !== "void") {
         return {
           status: "error",
-          detail: "native update returned a non-void result",
+          detail: "wazoo update returned a non-void result",
         };
       }
     } catch (error) {
@@ -848,7 +848,7 @@ export class W3cRunner {
       }
       return {
         status: "gap",
-        detail: `native rejected the update, comunica accepted it: ${
+        detail: `wazoo rejected the update, comunica accepted it: ${
           error instanceof Error ? error.message : String(error)
         }`,
       };
@@ -862,21 +862,21 @@ export class W3cRunner {
     } catch (error) {
       return {
         status: "gap",
-        detail: `native executed the update, comunica rejected it: ${
+        detail: `wazoo executed the update, comunica rejected it: ${
           error instanceof Error ? error.message : String(error)
         }`,
       };
     }
 
-    const nativeSet = this.storeQuadStrings(nativeStore).sort();
+    const wazooSet = this.storeQuadStrings(wazooStore).sort();
     const comunicaSet = this.storeQuadStrings(comunicaStore).sort();
-    const nativeRecords = this.storeQuadRecords(nativeStore);
+    const wazooRecords = this.storeQuadRecords(wazooStore);
     const comunicaRecords = this.storeQuadRecords(comunicaStore);
-    return isomorphicMultiset(nativeRecords, comunicaRecords)
+    return isomorphicMultiset(wazooRecords, comunicaRecords)
       ? { status: "pass" }
       : {
         status: "gap",
-        detail: this.firstDiff(nativeSet, comunicaSet, "final store contents"),
+        detail: this.firstDiff(wazooSet, comunicaSet, "final store contents"),
       };
   }
 
@@ -931,12 +931,12 @@ export class W3cRunner {
     }
 
     const evaluate = async (
-      engine: "native" | "comunica",
+      engine: "wazoo" | "comunica",
     ): Promise<boolean> => {
       try {
         const store = this.loadStore(testCase);
         let actualQuads: rdfjs.Quad[] = [];
-        if (engine === "native") {
+        if (engine === "wazoo") {
           const res = await new WazooSparqlEngine({ store }).execute({
             query: this.queryText(testCase),
           });
@@ -978,11 +978,11 @@ export class W3cRunner {
       }
     };
 
-    const native = await evaluate("native");
+    const wazoo = await evaluate("wazoo");
     const comunica = await evaluate("comunica");
     return {
       id: testCase.id,
-      native: native ? "conforms" : "deviates",
+      wazoo: wazoo ? "conforms" : "deviates",
       comunica: comunica ? "conforms" : "deviates",
     };
   }

--- a/test/w3c/sparql12-gap.ts
+++ b/test/w3c/sparql12-gap.ts
@@ -287,7 +287,7 @@ function parseGraphReference(
   );
 }
 
-function nativeSelectRecords(result: SparqlResponse): CanonicalTerm[][] {
+function wazooSelectRecords(result: SparqlResponse): CanonicalTerm[][] {
   if (result.kind !== "select") return [];
   return result.data.results.bindings.map((binding) => {
     const record: Record<string, CanonicalTerm> = {};
@@ -298,7 +298,7 @@ function nativeSelectRecords(result: SparqlResponse): CanonicalTerm[][] {
   });
 }
 
-function nativeQuadRecords(quads: rdfjs.Quad[]): CanonicalTerm[][] {
+function wazooQuadRecords(quads: rdfjs.Quad[]): CanonicalTerm[][] {
   return quads.map((quad) =>
     [quad.subject, quad.predicate, quad.object, quad.graph].map((term) =>
       canonicalizeRdfTerm(term)
@@ -312,8 +312,8 @@ function firstDiff(a: string[], b: string[], label: string): string {
   for (let index = 0; index < Math.max(aSet.length, bSet.length); index++) {
     if (aSet[index] !== bSet[index]) {
       return (
-        `${label} diverge (native ${aSet.length}, reference ${bSet.length}):\n` +
-        `  native:    ${aSet[index] ?? "<absent>"}\n` +
+        `${label} diverge (wazoo ${aSet.length}, reference ${bSet.length}):\n` +
+        `  wazoo:    ${aSet[index] ?? "<absent>"}\n` +
         `  reference: ${bSet[index] ?? "<absent>"}`
       );
     }
@@ -334,12 +334,12 @@ function resultKind(testCase: W3cTestCase): Row["result"] {
   return "ttl";
 }
 
-async function runNative(
+async function runWazoo(
   testCase: W3cTestCase,
 ): Promise<{ store: MemoryStore; result: SparqlResponse }> {
   const store = loadStore(testCase);
-  const native = new WazooSparqlEngine({ store });
-  const result = await native.execute({ query: queryText(testCase) });
+  const wazoo = new WazooSparqlEngine({ store });
+  const result = await wazoo.execute({ query: queryText(testCase) });
   return { store, result };
 }
 
@@ -347,9 +347,9 @@ async function evaluate(testCase: W3cTestCase): Promise<Verdict> {
   const kind = resultKind(testCase);
   const resultFile = testCase.resultFile;
 
-  let native: { store: MemoryStore; result: SparqlResponse };
+  let wazoo: { store: MemoryStore; result: SparqlResponse };
   try {
-    native = await runNative(testCase);
+    wazoo = await runWazoo(testCase);
   } catch (error) {
     return {
       status: "error",
@@ -370,19 +370,19 @@ async function evaluate(testCase: W3cTestCase): Promise<Verdict> {
   }
 
   if (compareKind === "srj") {
-    if (native.result.kind !== "select") {
+    if (wazoo.result.kind !== "select") {
       return {
         status: "error",
-        detail: `expected SELECT, native returned ${native.result.kind}`,
+        detail: `expected SELECT, wazoo returned ${wazoo.result.kind}`,
       };
     }
     const reference = parseSrj(compareFile);
-    const nativeRecords = nativeSelectRecords(native.result);
+    const wazooRecords = wazooSelectRecords(wazoo.result);
     const referenceRecords = recordsOf(reference);
-    if (isomorphicMultiset(nativeRecords, referenceRecords)) {
+    if (isomorphicMultiset(wazooRecords, referenceRecords)) {
       return { status: "pass" };
     }
-    const nativeStrings = native.result.data.results.bindings.map((binding) => {
+    const wazooStrings = wazoo.result.data.results.bindings.map((binding) => {
       const record: Record<string, CanonicalTerm> = {};
       for (const name of Object.keys(binding)) {
         record[name] = canonicalizeSparqlValue(binding[name]);
@@ -392,7 +392,7 @@ async function evaluate(testCase: W3cTestCase): Promise<Verdict> {
     return {
       status: "gap",
       detail: firstDiff(
-        nativeStrings,
+        wazooStrings,
         reference.map(bindingRecord),
         "SELECT bindings",
       ),
@@ -401,26 +401,26 @@ async function evaluate(testCase: W3cTestCase): Promise<Verdict> {
 
   // ttl (CONSTRUCT) and trig (update) both compare a final graph.
   const reference = parseGraphReference(testCase, compareFile);
-  if (native.result.kind === "construct") {
-    const nativeRecords = nativeQuadRecords(native.result.data.quads);
-    if (isomorphicMultiset(nativeRecords, reference)) return { status: "pass" };
+  if (wazoo.result.kind === "construct") {
+    const wazooRecords = wazooQuadRecords(wazoo.result.data.quads);
+    if (isomorphicMultiset(wazooRecords, reference)) return { status: "pass" };
     return {
       status: "gap",
       detail: firstDiff(
-        nativeRecords.map((r) => JSON.stringify(r)),
+        wazooRecords.map((r) => JSON.stringify(r)),
         reference.map((r) => JSON.stringify(r)),
         "graph contents",
       ),
     };
   }
-  if (native.result.kind === "void") {
-    const quads = native.store.getQuads(null, null, null, null);
-    const nativeRecords = nativeQuadRecords(quads);
-    if (isomorphicMultiset(nativeRecords, reference)) return { status: "pass" };
+  if (wazoo.result.kind === "void") {
+    const quads = wazoo.store.getQuads(null, null, null, null);
+    const wazooRecords = wazooQuadRecords(quads);
+    if (isomorphicMultiset(wazooRecords, reference)) return { status: "pass" };
     return {
       status: "gap",
       detail: firstDiff(
-        nativeRecords.map((r) => JSON.stringify(r)),
+        wazooRecords.map((r) => JSON.stringify(r)),
         reference.map((r) => JSON.stringify(r)),
         "final store contents",
       ),
@@ -429,7 +429,7 @@ async function evaluate(testCase: W3cTestCase): Promise<Verdict> {
   return {
     status: "error",
     detail:
-      `unexpected native result kind ${native.result.kind} for ${kind} result`,
+      `unexpected wazoo result kind ${wazoo.result.kind} for ${kind} result`,
   };
 }
 
@@ -458,7 +458,7 @@ const error = rows.filter((r) => r.verdict.status === "error").length;
 const deferred = rows.filter((r) => r.verdict.status === "deferred").length;
 
 console.log(
-  "=== SPARQL 1.2 eval-triple-terms gap measurement (native vs W3C reference) ===",
+  "=== SPARQL 1.2 eval-triple-terms gap measurement (wazoo vs W3C reference) ===",
 );
 console.log(`total:    ${rows.length}`);
 console.log(`pass:     ${pass}`);

--- a/test/w3c/sparql12-main.ts
+++ b/test/w3c/sparql12-main.ts
@@ -244,10 +244,10 @@ async function evaluate(testCase: W3cTestCase): Promise<Verdict> {
   }
 
   const store = loadStore(testCase);
-  let nativeResult: SparqlResponse;
+  let wazooResult: SparqlResponse;
   try {
-    const native = new WazooSparqlEngine({ store });
-    nativeResult = await native.execute({ query });
+    const wazoo = new WazooSparqlEngine({ store });
+    wazooResult = await wazoo.execute({ query });
   } catch (error) {
     return {
       status: "error",
@@ -273,9 +273,9 @@ async function evaluate(testCase: W3cTestCase): Promise<Verdict> {
           canonicalizeRdfTerm(q.object),
         ],
       );
-      const actualQuads = nativeResult.kind === "construct"
-        ? nativeResult.data.quads
-        : (nativeResult.kind === "void"
+      const actualQuads = wazooResult.kind === "construct"
+        ? wazooResult.data.quads
+        : (wazooResult.kind === "void"
           ? store.getQuads(null, null, null, null)
           : []);
       const actualRecords = actualQuads.map(

--- a/test/w3c/w3c-main.ts
+++ b/test/w3c/w3c-main.ts
@@ -78,7 +78,7 @@ function printReport(
   console.log(`skipped:    ${skipped}`);
 
   if (report.gapDetails.length > 0) {
-    console.log("\n--- parity gaps (native disagrees with comunica) ---");
+    console.log("\n--- parity gaps (wazoo disagrees with comunica) ---");
     for (const gap of report.gapDetails) {
       console.log(`\n[${gap.id}] ${gap.name}`);
       console.log(gap.detail.split("\n").map((line) => `  ${line}`).join("\n"));
@@ -92,13 +92,13 @@ function printReport(
   }
   if (report.conformance.length > 0) {
     const conforms = report.conformance.filter((c) =>
-      c.native === "conforms" && c.comunica === "conforms"
+      c.wazoo === "conforms" && c.comunica === "conforms"
     ).length;
-    const nativeConforms = report.conformance.filter((c) =>
-      c.native === "conforms"
+    const wazooConforms = report.conformance.filter((c) =>
+      c.wazoo === "conforms"
     ).length;
-    const nativeDeviations = report.conformance.filter((c) =>
-      c.native === "deviates"
+    const wazooDeviations = report.conformance.filter((c) =>
+      c.wazoo === "deviates"
     ).length;
     const comunicaDeviations = report.conformance.filter((c) =>
       c.comunica === "deviates"
@@ -107,16 +107,14 @@ function printReport(
       "\n--- conformance soft-report (parseable results only) ---",
     );
     console.log(
-      `checked: ${report.conformance.length} | native conforms: ${nativeConforms}/${report.conformance.length} | both conform: ${conforms} | ` +
-        `native deviates: ${nativeDeviations} | comunica deviates: ` +
+      `checked: ${report.conformance.length} | wazoo conforms: ${wazooConforms}/${report.conformance.length} | both conform: ${conforms} | ` +
+        `wazoo deviates: ${wazooDeviations} | comunica deviates: ` +
         `${comunicaDeviations}`,
     );
-    const asymmetric = report.conformance.filter((c) =>
-      c.native !== c.comunica
-    );
+    const asymmetric = report.conformance.filter((c) => c.wazoo !== c.comunica);
     for (const entry of asymmetric.slice(0, 10)) {
       console.log(
-        `  [${entry.id}] native=${entry.native} comunica=${entry.comunica}`,
+        `  [${entry.id}] wazoo=${entry.wazoo} comunica=${entry.comunica}`,
       );
     }
   }
@@ -135,7 +133,7 @@ if (report.pass < threshold || report.error > 0) {
     `\nW3C differential gate FAILED: ${report.pass}/${report.total} pass is ` +
       `below the ${threshold} (100%) threshold, with ${report.gap} parity ` +
       `gap(s) and ${report.error} error(s). The parity-gap count is the ` +
-      `tracked progress metric — each gap is a place native must converge ` +
+      `tracked progress metric — each gap is a place wazoo must converge ` +
       `with comunica.`,
   );
   Deno.exit(1);


### PR DESCRIPTION
Closes the terminology nit: the engine is referred to by its brand name **wazoo** everywhere instead of the vague "native".

**What changed** (38 files, pure word swap — 482/485 +/-):
- Code identifiers: `nativeEngine`→`wazooEngine`, `nativeResult`→`wazooResult`, `nativeArtifact`→`wazooArtifact`, `runNative`→`runWazoo`, `largeNativeEngine`→`largeWazooEngine`, etc.
- Bench display names: `"native - scan"` → `"wazoo - scan"` (group keys unchanged — `bench:check` budget unaffected)
- Data keys: `size-data.json` / `memory-data.json` `"native"` → `"wazoo"`; treemap SVGs regenerated from the same numbers (labels only)
- W3C runner engine field: `native` → `wazoo` in `runner.ts`, consumed by `w3c-main.ts`; `memory-probe.ts` CLI arg `native` → `wazoo`
- Docs prose: README, ARCHITECTURE, CONTEXT, AGENTS, all `docs/*.md`, `test/w3c/README.md`

**Deliberately preserved** (English, not brand):
- oxigraph's "native indexes" (compiled indexes) in README + docs/07
- "platform-native path" in `src/parser/generate-parser.ts`

**Verified**: `deno task ci` green (parser:check, fmt:check, lint, check, 400 unit/parity tests, bench:check, exists-ref, sparql12, sparql12:gap, rdf11, rdf12); `test:ref` 45/45; `test:w3c` **345/345** pass with the renamed fields.

Note: this will conflict with the unmerged figures PR (#103) on the shared bench/docs files — happy to rebase it once this lands.