### PR TITLE
docs: footer shows the main commit the wiki was generated from

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -82,6 +82,24 @@
         {% include prev-next.html %}
       </main>
     </div>
+
+    <footer class="site-footer">
+      {%- if site.github and site.github.build_revision -%}
+        Generated from
+        <a
+          href="https://github.com/wazootech/sparql-engine/commit/{{ site.github.build_revision }}"
+          target="_blank"
+          rel="noopener noreferrer"
+        >main@{{ site.github.build_revision | slice: 0, 7 }}</a>
+        on {{ site.time | date: "%Y-%m-%d" }}. This reflects the repo state at
+        that commit — see
+        <a href="{{ site.baseurl }}/08-maintenance.html">08 — Wiki Maintenance</a>
+        for how the docs are kept in sync with `main`.
+      {%- else -%}
+        Generated {{ site.time | date: "%Y-%m-%d %H:%M" }} (local build).
+      {%- endif -%}
+    </footer>
+
     <noscript>
       <style>
       /* Without JS the collapsible nav would be unreachable on phones. */

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -659,6 +659,22 @@ pre code {
   }
 }
 
+/* ---------- site footer ---------- */
+
+.site-footer {
+  padding: 14px 24px 18px;
+  border-top: 1px solid var(--border);
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.site-footer a {
+  color: var(--accent-text);
+}
+
 /* ---------- reduced motion ---------- */
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Adds a footer to every wiki page showing **which `main` commit the site was built from** — `site.github.build_revision` (the SHA the GitHub Pages build ran on) linked to the commit, plus the build date — so it's obvious when the wiki is out of date. Falls back to a build-time stamp for local builds. Styled to match the design system (muted mono, 1px border-top, dark/light aware). Two files: `docs/_layouts/default.html`, `docs/assets/css/style.css`.