### PR TITLE
docs: document the variadic hasLang superset surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Wazoo SPARQL 1.1 & 1.2 Query & Update Engine over RDF/JS Quad Stores.
   quad store. Gated by the W3C SPARQL 1.1 evaluation suite (differential vs
   Comunica): **345/345**.
 - **SPARQL 1.2 — working-draft surface implemented.** Direction functions
-  (`LANGDIR`, `STRLANGDIR`, `hasLang`, `hasLangDir`), RDF 1.2 reified triple
-  terms (`<< s p o >>`) in patterns, paths, and updates, and the 1.2
-  lexical/grammar surface (a single Turtle/TriG/N-Triples/N-Quads superset
-  grammar backing `LOAD`). Gated by the W3C SPARQL 1.2 evaluation suite
-  (**249/249**), the RDF 1.2 eval-triple-terms gap suite (**41/41**), and the
-  RDF 1.1/1.2 grammar gates.
+  (`LANGDIR`, `STRLANGDIR`, `hasLang`, `hasLangDir`; `hasLang` is variadic, 1–3
+  args, as a documented superset extension), RDF 1.2 reified triple terms
+  (`<< s p o >>`) in patterns, paths, and updates, and the 1.2 lexical/grammar
+  surface (a single Turtle/TriG/N-Triples/N-Quads superset grammar backing
+  `LOAD`). Gated by the W3C SPARQL 1.2 evaluation suite (**249/249**), the RDF
+  1.2 eval-triple-terms gap suite (**41/41**), and the RDF 1.1/1.2 grammar
+  gates.
 - **CI-enforced.** Every gate above runs in the `w3c-parity` CI job — a
   spec-required behavior that regresses fails the build rather than silently
   drifting.

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -79,9 +79,10 @@ SPARQL string (request.query)
 
 The grammar is sparqljs 3.7.4's, vendored and patched in-repo with the SPARQL
 1.2 surface: the four direction functions (`LANGDIR`, `STRLANGDIR`, `hasLang`,
-`hasLangDir`) and RDF 1.2 triple-term/reifier/annotation syntax
-(`<<( s p o )>>`, `<< s p o ~ r >>`, `{| ... |}`). Details and the exact lexer
-patch are in `src/parser/README.md`.
+`hasLangDir` — `hasLang` also accepts 2–3 args as a documented superset
+extension) and RDF 1.2 triple-term/reifier/annotation syntax (`<<( s p o )>>`,
+`<< s p o ~ r >>`, `{| ... |}`). Details and the exact lexer patch are in
+`src/parser/README.md`.
 
 The AST (`src/parser/ast.ts`) is **sparqljs-shaped**, so the parser is a drop-in
 replacement for the `sparqljs` export. `SparqlQuery` is a union of `Query`

--- a/docs/03-api-contracts.md
+++ b/docs/03-api-contracts.md
@@ -141,7 +141,13 @@ paths: `^ / | ? * + !` (negated property sets).
   triple-term expressions `<<( ?s ?p ?o )>>`, and `EXISTS` / `NOT EXISTS`
   (correlated, graph-scoped).
 - **SPARQL 1.2 direction functions**: `LANGDIR`, `STRLANGDIR`, `hasLang`,
-  `hasLangDir`.
+  `hasLangDir`. `hasLang` is variadic — all three arities parse and evaluate:
+  `hasLang(langString)`, `hasLang(langString, language)`, and
+  `hasLang(simpleLiteral, language, direction)`. The binary/ternary forms are a
+  **documented superset extension** (the published SPARQL 1.2 grammar defines
+  only the unary form); arity-2 matches the language tag case-insensitively and
+  arity-3 additionally matches the base direction (canonicalized to lowercase,
+  consistent with `STRLANGDIR`).
 
 Unsupported expression kinds (e.g. unknown `functionCall` IRIs) raise a clear
 error rather than silently mis-evaluating.


### PR DESCRIPTION
Syncs the wiki + README with the shipped hasLang arities (PR #111, merged as `e4ec070`).

- **docs/03-api-contracts.md** — the API surface bullet now spells out the full contract: all three arities (`hasLang(langString)`, `hasLang(langString, language)`, `hasLang(simpleLiteral, language, direction)`), the superset-extension framing (published 1.2 grammar is unary-only), case-insensitive tag match, and direction canonicalization consistent with `STRLANGDIR`.
- **docs/02-architecture.md** — grammar-surface note gains a parenthetical that `hasLang` accepts 2–3 args as a superset extension.
- **README.md** — Compatibility bullet carries a tight variadic note (deno fmt rewrapped the bullet; no other changes).

Generated with Codebuff 🤖