### PR TITLE
docs: wiki nits — aligned pipeline diagram, consolidated footer, heading copy-links, scrollable tables

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -15,58 +15,58 @@ backends.
 ```
 SPARQL string (request.query)
   │
-  ▼
-┌───────────────────────────────────────────────────────────────┐
-│ WazooSparqlEngine.execute()   src/wazoo-sparql-engine.ts L56  │
-│   raw = request.query                                          │
-│   ast  = parser.parse(raw)                                     │
-│   update? → UpdateEvaluator.executeUpdate(ast)   → {kind:"void"}│
-│   query?  → SparqlEvaluator.evaluateQuery(ast)  → typed result │
-└───────────────┬───────────────────────────────────────────────┘
-                ▼
-┌───────────────────────────────────────────────────────────────┐
-│ SparqlParser.parse()  src/parser/sparql-parser.ts L9          │
-│   vendored sparqljs 3.7.4 jison grammar + SPARQL 1.2 patches  │
-│   (src/parser/sparql.jison → generated src/parser/parser.ts)  │
-│   produces the sparqljs-compatible AST (src/parser/ast.ts)    │
-└───────────────┬───────────────────────────────────────────────┘
-                ▼
-┌───────────────────────────────────────────────────────────────┐
+                  ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ WazooSparqlEngine.execute()   src/wazoo-sparql-engine.ts L56       │
+│   raw = request.query                                              │
+│   ast  = parser.parse(raw)                                         │
+│   update? → UpdateEvaluator.executeUpdate(ast)   → {kind:"void"}   │
+│   query?  → SparqlEvaluator.evaluateQuery(ast)  → typed result     │
+└─────────────────┬──────────────────────────────────────────────────┘
+                  ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ SparqlParser.parse()  src/parser/sparql-parser.ts L9               │
+│   vendored sparqljs 3.7.4 jison grammar + SPARQL 1.2 patches       │
+│   (src/parser/sparql.jison → generated src/parser/parser.ts)       │
+│   produces the sparqljs-compatible AST (src/parser/ast.ts)         │
+└─────────────────┬──────────────────────────────────────────────────┘
+                  ▼
+┌────────────────────────────────────────────────────────────────────┐
 │ SparqlEvaluator.evaluateQuery()  src/evaluator/sparql-evaluator.ts │
-│   SELECT → evaluateSelect → evaluateSelectTermBindings         │
-│   ASK    → evaluateAsk        (bindings.length > 0)            │
-│   CONSTRUCT → evaluateConstruct (template × bindings)          │
-│   DESCRIBE  → evaluateDescribe (outgoing arcs of resources)    │
-└───────────────┬───────────────────────────────────────────────┘
-                ▼
-┌───────────────────────────────────────────────────────────────┐
-│ BgpEvaluator.evaluateBgp()  src/evaluator/bgp-evaluator.ts    │
-│   resolve EXISTS snapshot  (when EXISTS/NOT EXISTS present)   │
-│   evaluateGroup(): walk patterns, thread solution bindings    │
-│     bgp      → joinBgp()   → scanEntry / joinTriplePattern    │
-│     path     → scanPathEntry / joinPathPattern                │
-│     filter   → ExpressionEvaluator.filterPasses()             │
-│     optional → leftJoin()  (FILTERs hoisted as join filters)  │
-│     minus    → minus()     (shared-variable anti-join)        │
-│     union    → innerJoin() with branch results                │
-│     graph    → GraphScopedStore view, recursive group eval    │
-│     bind     → Extend (per-solution expression extend)        │
-│     values   → innerJoin() with the data block                │
-│     query    → fresh SparqlEvaluator, innerJoin() the results │
-└───────────────┬───────────────────────────────────────────────┘
-                ▼
-┌───────────────────────────────────────────────────────────────┐
-│ applySelectPipeline()  src/evaluator/select-pipeline.ts       │
-│   VALUES join → GROUP BY/aggregates → HAVING → ORDER BY →     │
-│   projection → DISTINCT/REDUCED → OFFSET → LIMIT              │
-└───────────────┬───────────────────────────────────────────────┘
-                ▼
-┌───────────────────────────────────────────────────────────────┐
-│ rdfTermToSparqlValue()  src/term/convert.ts L44               │
-│   TermBinding (RDF/JS terms) → SparqlValue wire format        │
-│   (uri / bnode / literal / triple)                            │
-└───────────────┬───────────────────────────────────────────────┘
-                ▼
+│   SELECT → evaluateSelect → evaluateSelectTermBindings             │
+│   ASK    → evaluateAsk        (bindings.length > 0)                │
+│   CONSTRUCT → evaluateConstruct (template × bindings)              │
+│   DESCRIBE  → evaluateDescribe (outgoing arcs of resources)        │
+└─────────────────┬──────────────────────────────────────────────────┘
+                  ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ BgpEvaluator.evaluateBgp()  src/evaluator/bgp-evaluator.ts         │
+│   resolve EXISTS snapshot  (when EXISTS/NOT EXISTS present)        │
+│   evaluateGroup(): walk patterns, thread solution bindings         │
+│     bgp      → joinBgp()   → scanEntry / joinTriplePattern         │
+│     path     → scanPathEntry / joinPathPattern                     │
+│     filter   → ExpressionEvaluator.filterPasses()                  │
+│     optional → leftJoin()  (FILTERs hoisted as join filters)       │
+│     minus    → minus()     (shared-variable anti-join)             │
+│     union    → innerJoin() with branch results                     │
+│     graph    → GraphScopedStore view, recursive group eval         │
+│     bind     → Extend (per-solution expression extend)             │
+│     values   → innerJoin() with the data block                     │
+│     query    → fresh SparqlEvaluator, innerJoin() the results      │
+└─────────────────┬──────────────────────────────────────────────────┘
+                  ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ applySelectPipeline()  src/evaluator/select-pipeline.ts            │
+│   VALUES join → GROUP BY/aggregates → HAVING → ORDER BY →          │
+│   projection → DISTINCT/REDUCED → OFFSET → LIMIT                   │
+└─────────────────┬──────────────────────────────────────────────────┘
+                  ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ rdfTermToSparqlValue()  src/term/convert.ts L44                    │
+│   TermBinding (RDF/JS terms) → SparqlValue wire format             │
+│   (uri / bnode / literal / triple)                                 │
+└─────────────────┬──────────────────────────────────────────────────┘
+                  ▼
   SparqlResponse  {kind:"select"|"ask"|"construct"|"void"}
 ```
 

--- a/docs/06-supplemental-context.md
+++ b/docs/06-supplemental-context.md
@@ -113,20 +113,3 @@ label identity.
   concurrent evaluations stay isolated.
 - **Correlated evaluation** — inner patterns see the outer solution's bindings;
   inner bindings never leak out.
-
-## Known gaps and next steps
-
-- `timeoutMs` in
-  [`SparqlRequest`](https://jsr.io/@wazoo/sparql-engine/doc/~/SparqlRequest) is
-  accepted but not yet enforced by the wazoo engine (Comunica enforces it).
-  `baseIri` is accepted; the wazoo engine derives the base from the query's
-  `BASE` directive instead.
-- [`SqliteStore`](https://github.com/wazootech/sparql-engine/blob/main/src/store/sqlite-store.ts)
-  ships as a deep-import prototype; the durable-transactions notes
-  (`docs/durable-transactions.md`) list next steps: a dedicated `./sqlite`
-  entrypoint, fsync/busy-timeout policy, update-throughput benchmarks, and
-  `INSERT … ON CONFLICT` batching.
-- `SERVICE` patterns evaluate locally (as a plain group) rather than over the
-  network; `SILENT` swallows evaluation errors.
-- `DESCRIBE` returns each resource's outgoing arcs — the Comunica-parity shape —
-  which the spec leaves to the implementation.

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -66,15 +66,6 @@
             </a>
           {% endfor %}
         </nav>
-
-        <div class="sidebar-foot">
-          <a
-            class="repo-link"
-            href="https://github.com/wazootech/sparql-engine"
-            target="_blank"
-            rel="noopener noreferrer"
-          >github.com/wazootech/sparql-engine</a>
-        </div>
       </aside>
 
       <main class="content">
@@ -84,8 +75,13 @@
     </div>
 
     <footer class="site-footer">
+      <a
+        href="https://github.com/wazootech/sparql-engine"
+        target="_blank"
+        rel="noopener noreferrer"
+      >github.com/wazootech/sparql-engine</a>
       {%- if site.github and site.github.build_revision -%}
-        Generated from
+        — generated from
         <a
           href="https://github.com/wazootech/sparql-engine/commit/{{ site.github.build_revision }}"
           target="_blank"
@@ -96,7 +92,7 @@
         <a href="{{ site.baseurl }}/08-maintenance.html">08 — Wiki Maintenance</a>
         for how the docs are kept in sync with `main`.
       {%- else -%}
-        Generated {{ site.time | date: "%Y-%m-%d %H:%M" }} (local build).
+        — generated {{ site.time | date: "%Y-%m-%d %H:%M" }} (local build).
       {%- endif -%}
     </footer>
 
@@ -137,6 +133,66 @@
       });
       window.addEventListener("resize", function () {
         if (window.innerWidth > 900) setOpen(false);
+      });
+    })();
+    </script>
+    <script>
+    // Heading copy-links: clicking a heading with an id copies the page URL
+    // plus its #fragment to the clipboard and flashes a toast. Selection drags
+    // and clicks on links inside the heading are left alone.
+    (function () {
+      var headings = document.querySelectorAll(
+        "main h1[id], main h2[id], main h3[id], main h4[id], main h5[id], main h6[id]",
+      );
+      if (!headings.length) return;
+      var toast = null;
+      function showToast(text) {
+        if (!toast) {
+          toast = document.createElement("div");
+          toast.className = "copy-toast";
+          toast.setAttribute("role", "status");
+          document.body.appendChild(toast);
+        }
+        toast.textContent = text;
+        toast.classList.add("show");
+        clearTimeout(toast._timer);
+        toast._timer = setTimeout(function () {
+          toast.classList.remove("show");
+        }, 1400);
+      }
+      function copyText(text) {
+        if (navigator.clipboard && window.isSecureContext) {
+          return navigator.clipboard.writeText(text).then(function () {
+            return true;
+          });
+        }
+        var area = document.createElement("textarea");
+        area.value = text;
+        area.setAttribute("readonly", "");
+        area.style.position = "absolute";
+        area.style.left = "-9999px";
+        document.body.appendChild(area);
+        area.select();
+        var ok = false;
+        try {
+          ok = document.execCommand("copy");
+        } catch (error) {
+          ok = false;
+        }
+        document.body.removeChild(area);
+        return Promise.resolve(ok);
+      }
+      headings.forEach(function (heading) {
+        heading.addEventListener("click", function (event) {
+          if (event.target.closest("a")) return;
+          var selection = window.getSelection();
+          if (selection && selection.toString()) return;
+          var url = location.origin + location.pathname + location.search +
+            "#" + heading.id;
+          copyText(url).then(function (ok) {
+            showToast(ok ? "Link copied" : "Press Ctrl/Cmd+C to copy");
+          });
+        });
       });
     })();
     </script>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -262,17 +262,6 @@ a:hover {
   border-radius: 1px;
 }
 
-.sidebar-foot {
-  margin-top: auto;
-  padding-top: 1rem;
-  border-top: 1px solid var(--border);
-  font-size: var(--caption);
-}
-
-.repo-link {
-  color: var(--text-muted);
-}
-
 /* ---------- content typography ---------- */
 
 .content h1 {
@@ -459,13 +448,19 @@ pre code {
 /* ---------- tables ---------- */
 
 .content table {
+  /* Wide tables scroll horizontally on narrow (mobile) viewports instead
+   * of overflowing the page: block-display lets the table grow to its
+   * min-content width, and overflow-x makes that growth scrollable. */
+  display: block;
   border-collapse: collapse;
   width: 100%;
+  max-width: 100%;
   margin: 0 0 1.25rem;
   font-size: var(--caption);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  overflow: hidden;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .content th,
@@ -606,10 +601,6 @@ pre code {
     display: flex;
   }
 
-  .sidebar-foot {
-    display: none;
-  }
-
   .content {
     padding: 1.5rem 1.25rem 3rem;
   }
@@ -673,6 +664,69 @@ pre code {
 
 .site-footer a {
   color: var(--accent-text);
+}
+
+/* ---------- heading copy-links ---------- */
+
+.content h1[id],
+.content h2[id],
+.content h3[id],
+.content h4[id],
+.content h5[id],
+.content h6[id] {
+  position: relative;
+  cursor: pointer;
+}
+
+.content h1[id]::before,
+.content h2[id]::before,
+.content h3[id]::before,
+.content h4[id]::before,
+.content h5[id]::before,
+.content h6[id]::before {
+  content: "¶";
+  position: absolute;
+  right: 100%;
+  padding-right: 0.45em;
+  color: var(--accent-text);
+  opacity: 0;
+  visibility: hidden;
+  user-select: none;
+  transition: opacity var(--fast) ease, visibility var(--fast) ease;
+}
+
+.content h1[id]:hover::before,
+.content h2[id]:hover::before,
+.content h3[id]:hover::before,
+.content h4[id]:hover::before,
+.content h5[id]:hover::before,
+.content h6[id]:hover::before {
+  opacity: 0.7;
+  visibility: visible;
+}
+
+.copy-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 1.5rem;
+  transform: translateX(-50%) translateY(0.5rem);
+  background: var(--surface);
+  color: var(--white);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.5rem 0.9rem;
+  font-family: var(--font-body);
+  font-size: var(--caption);
+  letter-spacing: -0.02em;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 50;
+  transition: opacity var(--normal) ease, transform var(--normal) ease;
+}
+
+.copy-toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
 }
 
 /* ---------- reduced motion ---------- */


### PR DESCRIPTION
Follow-ups on the code-wiki review. All four changes are CSS/layout/docs-only — no source, no `.sync-base` bump (docs nits, not a sync).

## What's in here
1. **Pipeline diagram alignment** (`02-architecture.md`) — rebuilt the "pipeline at a glance" ASCII block so all six boxes are a uniform 70 monospace columns and the `▼`/`┬` connectors align; right edges no longer ragged.
2. **Sidebar/footer consolidation** (`_layouts/default.html`, `assets/css/style.css`) — the standalone sidebar GitHub link is folded into the footer provenance line ("generated from `main@…` … see 08 — Wiki Maintenance"); dead `.sidebar-foot`/`.repo-link` CSS removed.
3. **Click-to-copy heading links** (layout + CSS) — headings with ids copy `URL#fragment` on click with a "Link copied" toast; `¶` marker hidden from the a11y tree until hover.
4. **Scrollable tables** (CSS) — tables use the `display: block; overflow-x: auto` pattern so wide tables scroll horizontally on mobile instead of overflowing the page (verified at a simulated 335px viewport with the real `04-source-map.md` table).
5. **Known gaps → issues** (`06-supplemental-context.md`) — audited each "Known gaps and next steps" item against filed issues: `baseIri` was untracked → filed **#117**; `timeoutMs` (#113), SqliteStore (#56), SERVICE (#28/#47), DESCRIBE (#28/#43) already tracked. Section deleted.

## Validation
- `deno fmt --check docs/` green
- `deno task docs:link-check` green (62 links, 0 broken)
- Layout rendered + interacted with locally (heading copy-link, table scroll, footer)