### PR TITLE
feat: support custom IRI function calls via a pluggable function registry

### DIFF
--- a/docs/03-api-contracts.md
+++ b/docs/03-api-contracts.md
@@ -99,12 +99,15 @@ export interface WazooSparqlEngineOptions {
   store: rdfjs.Store; // required: any RDF/JS store
   createTransaction?: () => WazooSparqlTransaction; // optional: atomic updates
   reorderPatterns?: boolean; // default true: dynamic join ordering
+  functions?: IriFunctionMap; // optional: custom IRI function registry
 }
 ```
 
 `store` is the only required option. `reorderPatterns: false` preserves the
 written order of BGP triple patterns. `createTransaction` upgrades updates from
 direct `addQuad`/`removeQuad` calls to one atomic transaction per request.
+`functions` registers custom IRI functions (SPARQL 1.1 §17.4.3.1); see
+[Custom functions & operators](#4-custom-functions--operators).
 
 ## Supported SPARQL surface
 
@@ -246,18 +249,43 @@ capture it once so a concurrent `execute()`'s cache rebuild is never observable
 mid-evaluation (issue
 [#72](https://github.com/wazootech/sparql-engine/issues/72)).
 
-### 4. Custom functions & operators
+### 4. Custom functions & operatorsCustom IRI functions are registered through `WazooSparqlEngineOptions.functions`:
 
-There is **no plugin registry** for user-defined functions: the operator and
-function surface lives in `ExpressionEvaluator.evaluateOperation()` /
-`evaluateFunctionCall()` (`src/evaluator/expression-evaluator.ts`). The dispatch
-is a single `switch`, so extending it is a code change in one file — both the
-operation table (operators, L262) and the XSD constructor dispatch (L1173). The
-same holds for aggregates
-([`aggregateValue`](https://github.com/wazootech/sparql-engine/blob/main/src/evaluator/aggregate.ts),
-`src/evaluator/
-aggregate.ts`) and update operation types (`applyOperation`,
-`src/evaluator/update-evaluator.ts`).
+a map from function IRI to evaluator, injected like Comunica's function factory.
+An `IriFunction` receives the function's evaluated arguments (`undefined` for
+unbound variables and runtime type errors) and returns a result term, or
+`undefined` to signal a type error — the same contract as the builtin surface:
+FILTER drops the row, ORDER BY sorts it lowest. Registered functions win over
+the builtin XSD-constructor mapping; unregistered IRIs keep raising
+`Unsupported SPARQL expression: functionCall <iri>`.
+
+```typescript
+export type IriFunction = (
+  args: ReadonlyArray<rdfjs.Term | undefined>,
+) => rdfjs.Term | undefined;
+
+export type IriFunctionMap = Readonly<Record<string, IriFunction>>;
+
+const engine = new WazooSparqlEngine({
+  store,
+  functions: {
+    "http://example.org/startsWithA": (args) => {
+      const name = args[0];
+      if (name === undefined || name.termType !== "Literal") return undefined;
+      return literal(
+        String(name.value.startsWith("a")),
+        namedNode("http://www.w3.org/2001/XMLSchema#boolean"),
+      );
+    },
+  },
+});
+```
+
+The rest of the expression surface (operators, XSD constructors, aggregates,
+update operation types) lives in `ExpressionEvaluator.evaluateOperation()` /
+`evaluateFunctionCall()` (`src/evaluator/expression-evaluator.ts`) and
+[`aggregateValue`](https://github.com/wazootech/sparql-engine/blob/main/src/evaluator/aggregate.ts)
+/ `applyOperation` (`src/evaluator/update-evaluator.ts`).
 
 ## Term utilities (exported from `src/mod.ts`)
 
@@ -287,6 +315,7 @@ Types:
 [`SparqlBinding`](https://jsr.io/@wazoo/sparql-engine/doc/~/SparqlBinding),
 [`WazooSparqlEngineOptions`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngineOptions),
 [`WazooSparqlTransaction`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlTransaction),
+`IriFunction`, `IriFunctionMap` (link on JSR once published),
 [`CanonicalTerm`](https://jsr.io/@wazoo/sparql-engine/doc/~/CanonicalTerm).
 
 Values/classes:

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -9,6 +9,7 @@ import { DataFactory } from "@/term/mod.ts";
 import {
   type ExpressionEvaluationContext,
   ExpressionEvaluator,
+  type IriFunctionMap,
 } from "@/evaluator/expression-evaluator.ts";
 import { expressionContainsExists } from "@/evaluator/expression-utils.ts";
 import {
@@ -74,6 +75,13 @@ export interface BgpEvaluatorOptions {
    * exactly.
    */
   reorderPatterns?: boolean;
+
+  /**
+   * functions registers custom IRI functions (SPARQL 1.1 §17.4.3.1),
+   * threaded through to the expression evaluator; see
+   * WazooSparqlEngineOptions.functions.
+   */
+  functions?: IriFunctionMap;
 }
 
 /**
@@ -90,6 +98,9 @@ export interface BgpEvaluatorOptions {
 export class BgpEvaluator {
   private readonly reorderPatterns: boolean;
 
+  /** functions is the custom IRI function registry (see options). */
+  private readonly functions: IriFunctionMap;
+
   /**
    * existsQuads and existsIndex are the drained, indexed snapshot of the
    * evaluator's store that the synchronous EXISTS hooks probe. They are
@@ -102,13 +113,17 @@ export class BgpEvaluator {
   private existsVersion: number | null = null;
 
   /** expressionEvaluator evaluates FILTER expressions against solutions. */
-  private readonly expressionEvaluator = new ExpressionEvaluator();
+  private readonly expressionEvaluator: ExpressionEvaluator;
 
   public constructor(
     private readonly store: rdfjs.Source<rdfjs.Quad>,
     options: BgpEvaluatorOptions = {},
   ) {
     this.reorderPatterns = options.reorderPatterns ?? true;
+    this.functions = options.functions ?? {};
+    this.expressionEvaluator = new ExpressionEvaluator({
+      functions: options.functions,
+    });
   }
 
   /**
@@ -679,6 +694,7 @@ export class BgpEvaluator {
   public forStore(store: rdfjs.Source<rdfjs.Quad>): BgpEvaluator {
     return new BgpEvaluator(store, {
       reorderPatterns: this.reorderPatterns,
+      functions: this.functions,
     });
   }
 
@@ -899,6 +915,7 @@ export class BgpEvaluator {
         );
         const subEvaluator = new SparqlEvaluator(store, {
           reorderPatterns: this.reorderPatterns,
+          functions: this.functions,
         });
         const subResults = await subEvaluator.evaluateSelectTermBindings(
           pattern as unknown as import("@/parser/sparql-parser.ts").SelectQuery,

--- a/src/evaluator/expression-evaluator.ts
+++ b/src/evaluator/expression-evaluator.ts
@@ -144,11 +144,47 @@ export interface ExpressionEvaluationContext {
 }
 
 /**
+ * IriFunction evaluates a custom SPARQL 1.1 extension function (§17.4.3.1)
+ * registered under a function IRI. It receives the function's evaluated
+ * arguments (undefined for unbound variables and runtime type errors) and
+ * returns a result term, or undefined to signal an error — the same
+ * contract as the builtin expression surface: FILTER drops the binding,
+ * ORDER BY sorts it lowest.
+ */
+export type IriFunction = (
+  args: ReadonlyArray<rdfjs.Term | undefined>,
+) => rdfjs.Term | undefined;
+
+/**
+ * IriFunctionMap maps function IRIs to their evaluators. Injected through
+ * WazooSparqlEngineOptions.functions; unregistered IRIs keep raising the
+ * "Unsupported SPARQL expression: functionCall <iri>" error.
+ */
+export type IriFunctionMap = Readonly<Record<string, IriFunction>>;
+
+/** ExpressionEvaluatorOptions configures ExpressionEvaluator. */
+export interface ExpressionEvaluatorOptions {
+  /**
+   * functions registers custom IRI functions (SPARQL 1.1 §17.4.3.1),
+   * mirroring Comunica's injectable function factory. Registered functions
+   * are consulted before the builtin XSD constructors.
+   */
+  functions?: IriFunctionMap;
+}
+
+/**
  * ExpressionEvaluator evaluates SPARQL 1.1 expression trees (operators,
  * functions, and constants) against a single solution binding, returning a
  * value term or a typed error term for runtime failures.
  */
 export class ExpressionEvaluator {
+  /** functions is the registry of custom IRI function evaluators. */
+  private readonly functions: IriFunctionMap;
+
+  public constructor(options: ExpressionEvaluatorOptions = {}) {
+    this.functions = options.functions ?? {};
+  }
+
   /**
    * bnodeCounter mints fresh labels for zero-argument BNODE() calls, so two
    * calls in one query produce distinct blank nodes. Labels are opaque per
@@ -1219,6 +1255,16 @@ export class ExpressionEvaluator {
       throw new Error(
         "Unsupported SPARQL expression: functionCall without an IRI function",
       );
+    }
+    // Registered custom IRI functions win over the builtin mapping: the
+    // engine options registry (SPARQL 1.1 §17.4.3.1) is an explicit
+    // injection, so it takes precedence even under a builtin namespace.
+    const registered = this.functions[fnIri];
+    if (registered !== undefined) {
+      const args = expression.args.map((arg) =>
+        this.evaluateWith(arg, binding, aggregates, context)
+      );
+      return registered(args);
     }
     const value = this.evaluateWith(
       expression.args[0] as Expression,

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -30,7 +30,10 @@ import {
   matchQuads,
   simplePredicate,
 } from "@/quad-store.ts";
-import { ExpressionEvaluator } from "@/evaluator/expression-evaluator.ts";
+import {
+  ExpressionEvaluator,
+  type IriFunctionMap,
+} from "@/evaluator/expression-evaluator.ts";
 import type { ExpressionEvaluationContext } from "@/evaluator/expression-evaluator.ts";
 import {
   compareRdfTerms,
@@ -49,6 +52,13 @@ export interface SparqlEvaluatorOptions {
    * joining. Defaults to true. See BgpEvaluatorOptions.reorderPatterns.
    */
   reorderPatterns?: boolean;
+
+  /**
+   * functions registers custom IRI functions (SPARQL 1.1 §17.4.3.1),
+   * threaded through to every expression evaluator; see
+   * WazooSparqlEngineOptions.functions.
+   */
+  functions?: IriFunctionMap;
 }
 
 /**
@@ -68,7 +78,7 @@ export class SparqlEvaluator {
   private readonly bgpEvaluator: BgpEvaluator;
 
   /** expressionEvaluator evaluates ORDER BY expressions against solutions. */
-  private readonly expressionEvaluator = new ExpressionEvaluator();
+  private readonly expressionEvaluator: ExpressionEvaluator;
 
   /**
    * nextConstructBnodeId mints fresh labels for CONSTRUCT template blank
@@ -83,8 +93,12 @@ export class SparqlEvaluator {
     options: SparqlEvaluatorOptions = {},
   ) {
     this.store = store;
+    this.expressionEvaluator = new ExpressionEvaluator({
+      functions: options.functions,
+    });
     this.bgpEvaluator = new BgpEvaluator(store, {
       reorderPatterns: options.reorderPatterns,
+      functions: options.functions,
     });
   }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -13,6 +13,10 @@ export type {
   WazooSparqlEngineOptions,
   WazooSparqlTransaction,
 } from "@/wazoo-sparql-engine.ts";
+export type {
+  IriFunction,
+  IriFunctionMap,
+} from "@/evaluator/expression-evaluator.ts";
 
 export { MemoryStore, MemoryStream } from "@/store/memory-store.ts";
 export { DataFactory, dataFactory } from "@/term/mod.ts";

--- a/src/wazoo-sparql-engine.test.ts
+++ b/src/wazoo-sparql-engine.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
-import { DataFactory } from "@/term/mod.ts";
+import { DataFactory, XSD_BOOLEAN } from "@/term/mod.ts";
 import { MemoryStore as Store } from "@/store/memory-store.ts";
 import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
 
@@ -478,6 +478,135 @@ Deno.test(
     );
   },
 );
+
+Deno.test("WazooSparqlEngine - custom IRI functions evaluate through the registry", async () => {
+  const store = new Store();
+  const ex = (s: string) => namedNode(`http://example.org/${s}`);
+  const addName = (s: string, o: string) =>
+    store.addQuad(quad(ex(s), ex("name"), literal(o)));
+  addName("a", "alice");
+  addName("b", "bob");
+  addName("c", "carol");
+  const engine = new WazooSparqlEngine({
+    store,
+    functions: {
+      "http://example.org/startsWithA": (args) => {
+        const name = args[0];
+        if (name === undefined || name.termType !== "Literal") {
+          return undefined;
+        }
+        return literal(
+          String(name.value.startsWith("a")),
+          namedNode(XSD_BOOLEAN),
+        );
+      },
+      "http://example.org/upper": (args) => {
+        const name = args[0];
+        if (name === undefined || name.termType !== "Literal") {
+          return undefined;
+        }
+        return literal(name.value.toUpperCase());
+      },
+      "http://example.org/tag": (args) =>
+        literal(
+          `t:${args[0]?.value ?? "?"}/${args[1]?.value ?? "?"}`,
+        ),
+    },
+  });
+
+  // FILTER: the registered function narrows the rows (alice only).
+  const filtered = await engine.execute({
+    query: "SELECT ?s WHERE { ?s <http://example.org/name> ?n " +
+      "FILTER(<http://example.org/startsWithA>(?n)) }",
+  });
+  assertEquals(filtered.kind, "select");
+  if (filtered.kind === "select") {
+    assertEquals(
+      filtered.data.results.bindings.map((b) => b.s.value),
+      ["http://example.org/a"],
+    );
+  }
+
+  // Projection expression: the function result becomes a projected value.
+  const projected = await engine.execute({
+    query: "SELECT ?s (<http://example.org/startsWithA>(?n) AS ?flag) " +
+      "WHERE { ?s <http://example.org/name> ?n }",
+  });
+  assertEquals(projected.kind, "select");
+  if (projected.kind === "select") {
+    assertEquals(
+      projected.data.results.bindings.map((b) =>
+        `${b.s.value}:${(b.flag as { value: string }).value}`
+      ).sort(),
+      [
+        "http://example.org/a:true",
+        "http://example.org/b:false",
+        "http://example.org/c:false",
+      ],
+    );
+  }
+
+  // BIND in the WHERE clause: the function binds a fresh variable.
+  const bound = await engine.execute({
+    query: "SELECT ?s WHERE { ?s <http://example.org/name> ?n " +
+      'BIND(<http://example.org/upper>(?n) AS ?u) FILTER(?u = "BOB") }',
+  });
+  assertEquals(bound.kind, "select");
+  if (bound.kind === "select") {
+    assertEquals(
+      bound.data.results.bindings.map((b) => b.s.value),
+      ["http://example.org/b"],
+    );
+  }
+
+  // ORDER BY: the function sorts without raising (descending upper-cased
+  // names: CAROL > BOB > ALICE).
+  const ordered = await engine.execute({
+    query: "SELECT ?s WHERE { ?s <http://example.org/name> ?n } " +
+      "ORDER BY DESC(<http://example.org/upper>(?n))",
+  });
+  assertEquals(ordered.kind, "select");
+  if (ordered.kind === "select") {
+    assertEquals(
+      ordered.data.results.bindings.map((b) => b.s.value),
+      ["http://example.org/c", "http://example.org/b", "http://example.org/a"],
+    );
+  }
+
+  // Multi-argument functions receive each evaluated argument.
+  const multi = await engine.execute({
+    query: "SELECT (<http://example.org/tag>(?s, ?n) AS ?t) " +
+      "WHERE { ?s <http://example.org/name> ?n } ORDER BY ?s LIMIT 1",
+  });
+  assertEquals(multi.kind, "select");
+  if (multi.kind === "select") {
+    assertEquals(
+      (multi.data.results.bindings[0].t as { value: string }).value,
+      "t:http://example.org/a/alice",
+    );
+  }
+
+  // A type error (undefined) drops the row in FILTER — the builtin contract.
+  const typeError = await engine.execute({
+    query: "SELECT ?s WHERE { ?s <http://example.org/name> ?n " +
+      "FILTER(<http://example.org/startsWithA>(?s)) }",
+  });
+  assertEquals(typeError.kind, "select");
+  if (typeError.kind === "select") {
+    assertEquals(typeError.data.results.bindings, []);
+  }
+
+  // Unregistered IRIs keep raising the clear error.
+  await assertRejects(
+    () =>
+      engine.execute({
+        query: "SELECT ?s WHERE { ?s <http://example.org/name> ?n " +
+          "FILTER(<http://example.org/notRegistered>(?n)) }",
+      }),
+    Error,
+    "Unsupported SPARQL expression: functionCall",
+  );
+});
 
 Deno.test("WazooSparqlEngine - OPTIONAL extends matches and keeps unmatched unbound", async () => {
   const store = new Store();

--- a/src/wazoo-sparql-engine.ts
+++ b/src/wazoo-sparql-engine.ts
@@ -8,6 +8,12 @@ import { SparqlParser } from "@/parser/sparql-parser.ts";
 import type { SparqlQuery } from "@/parser/ast.ts";
 import { SparqlEvaluator } from "@/evaluator/sparql-evaluator.ts";
 import { UpdateEvaluator } from "@/evaluator/update-evaluator.ts";
+import type { IriFunctionMap } from "@/evaluator/expression-evaluator.ts";
+
+export type {
+  IriFunction,
+  IriFunctionMap,
+} from "@/evaluator/expression-evaluator.ts";
 
 /**
  * WazooSparqlTransaction is the minimal write contract the engine uses for updates.
@@ -49,6 +55,16 @@ export interface WazooSparqlEngineOptions {
    * first. Defaults to true. Disabling it preserves written order exactly.
    */
   reorderPatterns?: boolean;
+
+  /**
+   * functions registers custom IRI functions (SPARQL 1.1 §17.4.3.1): a map
+   * from function IRI to evaluator, injected like Comunica's function
+   * factory. A registered function receives its evaluated arguments and
+   * returns a term, or undefined for a type error (FILTER drops the row,
+   * ORDER BY sorts it lowest). Unregistered IRIs keep raising
+   * "Unsupported SPARQL expression: functionCall".
+   */
+  functions?: IriFunctionMap;
 }
 
 /**
@@ -73,6 +89,7 @@ export class WazooSparqlEngine implements SparqlEngineInterface {
     this.parser = new SparqlParser();
     this.evaluator = new SparqlEvaluator(options.store, {
       reorderPatterns: options.reorderPatterns,
+      functions: options.functions,
     });
     this.updateEvaluator = new UpdateEvaluator({
       store: options.store,


### PR DESCRIPTION
Closes #60. Wayfinder task (claimed by @EthanThatOneKid).

## What
`FILTER(<http://example.org/unsupported>(?name))` previously raised `Unsupported SPARQL expression: functionCall`. Now custom IRI functions (SPARQL 1.1 §17.4.3.1) are registered through a new `WazooSparqlEngineOptions.functions` map — mirroring Comunica's injectable function factory:

```ts
const engine = new WazooSparqlEngine({
  store,
  functions: {
    "http://example.org/startsWithA": (args) => {
      const name = args[0];
      if (name === undefined || name.termType !== "Literal") return undefined;
      return literal(String(name.value.startsWith("a")), namedNode(XSD_BOOLEAN));
    },
  },
});
```

- `IriFunction = (args) => term | undefined` — receives evaluated arguments; `undefined` is a type error (FILTER drops the row, ORDER BY sorts lowest), the builtin contract.
- Registered functions win over the builtin XSD-constructor mapping; unregistered IRIs keep raising the clear error.
- Threaded through `SparqlEvaluator` → `BgpEvaluator` (including FROM-dataset and subquery-in-EXISTS evaluators); `IriFunction`/`IriFunctionMap` exported from the package root.
- `03-api-contracts.md` updated (options block, custom-functions section, export inventory). JSR doc links for the new symbols land on the next publish.

## Tests
New engine-level test covers FILTER, projection expression, WHERE `BIND`, `ORDER BY`, multi-argument functions, type-error → row drop, and the unregistered-IRI error. Full suite 404/404; fmt/lint/check/link-check green locally.