### PR TITLE
feat: lazy slice — generator joins between BGP patterns and lazy CONSTRUCT emission (#74)

### DIFF
--- a/bench/memory-data.json
+++ b/bench/memory-data.json
@@ -1,42 +1,42 @@
 {
-  "generatedAt": "2026-08-14T21:28:02.208Z",
+  "generatedAt": "2026-08-15T17:13:32.895Z",
   "runs": 5,
   "dataset": "10,000-person graph (~55,000 quads)",
   "measurement": "isolated Deno subprocess per engine, Deno.memoryUsage() peak after each run",
   "engines": {
     "wazoo": {
       "scan": {
-        "peakHeap": 157156376,
-        "peakRss": 276078592,
+        "peakHeap": 154432200,
+        "peakRss": 265879552,
         "external": 317663
       },
       "exists": {
-        "peakHeap": 83354176,
-        "peakRss": 198397952,
+        "peakHeap": 85867672,
+        "peakRss": 187375616,
         "external": 317663
       }
     },
     "comunica": {
       "scan": {
-        "peakHeap": 224318392,
-        "peakRss": 392032256,
+        "peakHeap": 228919024,
+        "peakRss": 374931456,
         "external": 1703597
       },
       "exists": {
-        "peakHeap": 285827720,
-        "peakRss": 448548864,
-        "external": 2621597
+        "peakHeap": 286390000,
+        "peakRss": 435437568,
+        "external": 2513597
       }
     },
     "oxigraph": {
       "scan": {
-        "peakHeap": 267656088,
-        "peakRss": 509505536,
+        "peakHeap": 262106640,
+        "peakRss": 508497920,
         "external": 954855
       },
       "exists": {
-        "peakHeap": 113824896,
-        "peakRss": 302903296,
+        "peakHeap": 114540584,
+        "peakRss": 294813696,
         "external": 954855
       }
     }

--- a/docs/assets/treemap-memory.svg
+++ b/docs/assets/treemap-memory.svg
@@ -9,38 +9,38 @@
     stroke="#dee2e6" stroke-width="1" />
   <text x="18.0" y="60.0" font-family="sans-serif" font-size="10"
     font-weight="bold" fill="#495057">full scan (55k rows materialized)</text>
-  <rect x="14.0" y="68.0" width="139.4" height="218.0" fill="#1971c2"
+  <rect x="14.0" y="68.0" width="137.3" height="218.0" fill="#1971c2"
     stroke="#ffffff" stroke-width="1" />
-  <text x="83.7" y="180.0" text-anchor="middle" font-family="sans-serif"
+  <text x="82.6" y="180.0" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">oxigraph<tspan x="83.7" dy="12" font-size="8" fill="#ffffffcc">255.26 MiB</tspan></text>
-  <rect x="153.4" y="68.0" width="198.6" height="128.2" fill="#f08c00"
+    fill="#fff">oxigraph<tspan x="82.6" dy="12" font-size="8" fill="#ffffffcc">249.96 MiB</tspan></text>
+  <rect x="151.3" y="68.0" width="200.7" height="130.2" fill="#f08c00"
     stroke="#ffffff" stroke-width="1" />
-  <text x="252.7" y="135.1" text-anchor="middle" font-family="sans-serif"
+  <text x="251.6" y="136.1" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">comunica<tspan x="252.7" dy="12" font-size="8" fill="#ffffffcc">213.93 MiB</tspan></text>
-  <rect x="153.4" y="196.2" width="198.6" height="89.8" fill="#2f9e44"
+    fill="#fff">comunica<tspan x="251.6" dy="12" font-size="8" fill="#ffffffcc">218.31 MiB</tspan></text>
+  <rect x="151.3" y="198.2" width="200.7" height="87.8" fill="#2f9e44"
     stroke="#ffffff" stroke-width="1" />
-  <text x="252.7" y="244.1" text-anchor="middle" font-family="sans-serif"
+  <text x="251.6" y="245.1" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">wazoo<tspan x="252.7" dy="12" font-size="8" fill="#ffffffcc">149.88 MiB</tspan></text>
+    fill="#fff">wazoo<tspan x="251.6" dy="12" font-size="8" fill="#ffffffcc">147.28 MiB</tspan></text>
   <rect x="360.0" y="44.0" width="342.0" height="244.0" fill="#f1f3f5"
     stroke="#dee2e6" stroke-width="1" />
   <text x="366.0" y="60.0" font-family="sans-serif" font-size="10"
     font-weight="bold" fill="#495057">nested EXISTS</text>
-  <rect x="362.0" y="68.0" width="200.0" height="218.0" fill="#f08c00"
+  <rect x="362.0" y="68.0" width="198.8" height="218.0" fill="#f08c00"
     stroke="#ffffff" stroke-width="1" />
-  <text x="462.0" y="180.0" text-anchor="middle" font-family="sans-serif"
+  <text x="461.4" y="180.0" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">comunica<tspan x="462.0" dy="12" font-size="8" fill="#ffffffcc">272.59 MiB</tspan></text>
-  <rect x="562.0" y="68.0" width="138.0" height="125.8" fill="#1971c2"
+    fill="#fff">comunica<tspan x="461.4" dy="12" font-size="8" fill="#ffffffcc">273.12 MiB</tspan></text>
+  <rect x="560.8" y="68.0" width="139.2" height="124.6" fill="#1971c2"
     stroke="#ffffff" stroke-width="1" />
-  <text x="631.0" y="133.9" text-anchor="middle" font-family="sans-serif"
+  <text x="630.4" y="133.3" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">oxigraph<tspan x="631.0" dy="12" font-size="8" fill="#ffffffcc">108.55 MiB</tspan></text>
-  <rect x="562.0" y="193.8" width="138.0" height="92.2" fill="#2f9e44"
+    fill="#fff">oxigraph<tspan x="630.4" dy="12" font-size="8" fill="#ffffffcc">109.23 MiB</tspan></text>
+  <rect x="560.8" y="192.6" width="139.2" height="93.4" fill="#2f9e44"
     stroke="#ffffff" stroke-width="1" />
-  <text x="631.0" y="242.9" text-anchor="middle" font-family="sans-serif"
+  <text x="630.4" y="242.3" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">wazoo<tspan x="631.0" dy="12" font-size="8" fill="#ffffffcc">79.49 MiB</tspan></text>
+    fill="#fff">wazoo<tspan x="630.4" dy="12" font-size="8" fill="#ffffffcc">81.89 MiB</tspan></text>
 </svg>

--- a/docs/assets/treemap-submodules.svg
+++ b/docs/assets/treemap-submodules.svg
@@ -10,30 +10,30 @@
   <text x="18.0" y="60.0" font-family="sans-serif" font-size="10"
     font-weight="bold"
     fill="#495057">@wazoo/sparql-engine (full) — 576 KiB</text>
-  <rect x="14.0" y="68.0" width="332.9" height="210.0" fill="#2f9e44"
+  <rect x="14.0" y="68.0" width="326.4" height="210.0" fill="#2f9e44"
     stroke="#ffffff" stroke-width="1" />
-  <text x="180.5" y="176.0" text-anchor="middle" font-family="sans-serif"
+  <text x="177.2" y="176.0" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">parser · 5 files<tspan x="180.5" dy="12" font-size="8" fill="#ffffffcc">277 KiB</tspan></text>
-  <rect x="346.9" y="68.0" width="271.5" height="210.0" fill="#40c057"
+    fill="#fff">parser · 5 files<tspan x="177.2" dy="12" font-size="8" fill="#ffffffcc">282 KiB</tspan></text>
+  <rect x="340.4" y="68.0" width="280.6" height="210.0" fill="#40c057"
     stroke="#ffffff" stroke-width="1" />
-  <text x="482.7" y="176.0" text-anchor="middle" font-family="sans-serif"
+  <text x="480.7" y="176.0" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">evaluator · 9 files<tspan x="482.7" dy="12" font-size="8" fill="#ffffffcc">226 KiB</tspan></text>
-  <rect x="618.5" y="68.0" width="87.5" height="116.2" fill="#69db7c"
+    fill="#fff">evaluator · 9 files<tspan x="480.7" dy="12" font-size="8" fill="#ffffffcc">243 KiB</tspan></text>
+  <rect x="621.0" y="68.0" width="85.0" height="115.1" fill="#69db7c"
     stroke="#ffffff" stroke-width="1" />
-  <text x="662.2" y="65.0" text-anchor="middle" font-family="sans-serif"
+  <text x="663.5" y="65.0" text-anchor="middle" font-family="sans-serif"
     font-size="8" fill="#495057">term · 9 files (40 KiB)</text>
-  <rect x="618.5" y="184.2" width="87.5" height="37.0" fill="#8ce99a"
+  <rect x="621.0" y="183.1" width="85.0" height="37.1" fill="#8ce99a"
     stroke="#ffffff" stroke-width="1" />
-  <text x="662.2" y="181.2" text-anchor="middle" font-family="sans-serif"
+  <text x="663.5" y="180.1" text-anchor="middle" font-family="sans-serif"
+    font-size="8" fill="#495057">entrypoints · 3 files (13 KiB)</text>
+  <rect x="621.0" y="220.2" width="53.8" height="57.8" fill="#b2f2bb"
+    stroke="#ffffff" stroke-width="1" />
+  <text x="647.9" y="217.2" text-anchor="middle" font-family="sans-serif"
     font-size="8" fill="#495057">store · 1 file (13 KiB)</text>
-  <rect x="618.5" y="221.2" width="54.6" height="56.8" fill="#b2f2bb"
+  <rect x="674.8" y="220.2" width="31.2" height="57.8" fill="#d3f9d8"
     stroke="#ffffff" stroke-width="1" />
-  <text x="645.8" y="218.2" text-anchor="middle" font-family="sans-serif"
-    font-size="8" fill="#495057">entrypoints · 3 files (12 KiB)</text>
-  <rect x="673.1" y="221.2" width="32.9" height="56.8" fill="#d3f9d8"
-    stroke="#ffffff" stroke-width="1" />
-  <text x="689.5" y="218.2" text-anchor="middle" font-family="sans-serif"
+  <text x="690.4" y="217.2" text-anchor="middle" font-family="sans-serif"
     font-size="8" fill="#495057">serialize · 3 files (7 KiB)</text>
 </svg>

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -24,11 +24,15 @@ import {
 
 const { defaultGraph } = DataFactory;
 import {
+  filterBindings,
   innerJoin,
   isPropertyPath,
   joinPathPattern,
+  joinPathPatternLazy,
   joinTriplePattern,
+  joinTriplePatternLazy,
   leftJoin,
+  mapBindings,
   minus,
   scanEntry,
   scanPathEntry,
@@ -294,6 +298,9 @@ export class BgpEvaluator {
     index: QuadIndex,
     quads: rdfjs.Quad[],
   ): TermBinding[] {
+    // The synchronous EXISTS path stays eager (the decided sync-hook
+    // contract): every pattern form returns a materialized array, including
+    // the join generators collected at each pattern's return.
     let result = bindings;
     for (const pattern of patterns) {
       result = this.evaluateExistsPattern(
@@ -375,7 +382,9 @@ export class BgpEvaluator {
           // instead of rebuilding an index over the probed bucket per
           // solution — the EXISTS hook joins one solution at a time. The
           // index is the call's captured snapshot, never re-read from the
-          // shared cache mid-evaluation (issue #72).
+          // shared cache mid-evaluation (issue #72). The group materializes
+          // the generator at the pattern boundary, so the sync path stays
+          // eager.
           result = joinTriplePattern(result, entry, index, graph);
         }
         return result;
@@ -478,7 +487,7 @@ export class BgpEvaluator {
           }
           return binding;
         });
-        return innerJoin(bindings, rows);
+        return [...innerJoin(bindings, rows)];
       }
       case "optional": {
         // The OPTIONAL group's own FILTER expressions are hoisted out and
@@ -503,13 +512,13 @@ export class BgpEvaluator {
           index,
           quads,
         );
-        return leftJoin(
+        return [...leftJoin(
           bindings,
           right,
           filters.map((expression) => (binding: TermBinding) =>
             this.expressionEvaluator.filterPasses(expression, binding, context)
           ),
-        );
+        )];
       }
       case "minus": {
         const right = this.evaluateExistsGroup(
@@ -520,7 +529,7 @@ export class BgpEvaluator {
           index,
           quads,
         );
-        return minus(bindings, right);
+        return [...minus(bindings, right)];
       }
       case "union": {
         // Each branch evaluates independently over the graph scope; the union
@@ -539,7 +548,7 @@ export class BgpEvaluator {
             ),
           );
         }
-        return innerJoin(bindings, branchResults.flat());
+        return [...innerJoin(bindings, branchResults.flat())];
       }
       case "group":
         // A nested { ... } block recurses over the same scope, mirroring the
@@ -591,7 +600,7 @@ export class BgpEvaluator {
           this.expressionEvaluator,
           subContext,
         );
-        return innerJoin(bindings, subResults);
+        return [...innerJoin(bindings, subResults)];
       }
       default:
         throw new Error(
@@ -702,7 +711,14 @@ export class BgpEvaluator {
    * evaluateGroup threads the current solutions through a pattern list in
    * written order: each pattern transforms the binding set, so BGP joins
    * constrain it, FILTERs narrow it, OPTIONALs extend it, and MINUSes
-   * eliminate it.
+   * eliminate it. The lazy slice (issue #74) keeps the solution flow as a
+   * streaming iterable between patterns — BGP triple joins, FILTER passes,
+   * BIND extensions, and OPTIONAL/MINUS/UNION/VALUES/GRAPH joins all emit
+   * incrementally — materializing exactly once at the group boundary, so a
+   * long pattern chain no longer holds an intermediate binding array per
+   * step. Nested group calls (OPTIONAL/MINUS/UNION/GRAPH bodies, subquery
+   * WHEREs) resolve their own groups eagerly here, so their results arrive
+   * as arrays; only the enclosing group's own solution flow streams.
    */
   private async evaluateGroup(
     patterns: Pattern[],
@@ -724,7 +740,7 @@ export class BgpEvaluator {
         nonFilters.push(p);
       }
     }
-    let result = bindings;
+    let result: Iterable<TermBinding> = bindings;
     for (const pattern of nonFilters) {
       result = await this.evaluatePattern(pattern, result, store, snapshot);
     }
@@ -736,18 +752,22 @@ export class BgpEvaluator {
         snapshot,
       );
     }
-    return result;
+    // Materialize exactly once at the group boundary (an array result — the
+    // single-pattern BGP fast path — passes through without a copy).
+    return Array.isArray(result) ? result : [...result];
   }
 
   /**
    * evaluatePattern applies a single graph pattern to the current solutions.
+   * The bindings may stream as an iterable (the group's lazy solution flow);
+   * the result is an iterable the next pattern consumes.
    */
   private async evaluatePattern(
     pattern: Pattern,
-    bindings: TermBinding[],
+    bindings: TermBinding[] | Iterable<TermBinding>,
     store: rdfjs.Source<rdfjs.Quad>,
     snapshot: ExistsSnapshot | null,
-  ): Promise<TermBinding[]> {
+  ): Promise<Iterable<TermBinding>> {
     switch (pattern.type) {
       case "bgp":
         return await this.joinBgp(pattern.triples, bindings, store, snapshot);
@@ -755,12 +775,14 @@ export class BgpEvaluator {
         const context = expressionContainsExists(pattern.expression)
           ? this.scopedExistsContext(store, snapshot)
           : this.existsContext(store);
-        return bindings.filter((binding) =>
-          this.expressionEvaluator.filterPasses(
-            pattern.expression,
-            binding,
-            context,
-          )
+        return filterBindings(
+          bindings,
+          (binding) =>
+            this.expressionEvaluator.filterPasses(
+              pattern.expression,
+              binding,
+              context,
+            ),
         );
       }
       case "optional": {
@@ -828,7 +850,7 @@ export class BgpEvaluator {
         const context = expressionContainsExists(pattern.expression)
           ? this.scopedExistsContext(store, snapshot)
           : this.existsContext(store);
-        return bindings.map((binding) => {
+        return mapBindings(bindings, (binding) => {
           const value = this.expressionEvaluator.evaluate(
             pattern.expression,
             binding,
@@ -931,14 +953,19 @@ export class BgpEvaluator {
 
   /**
    * joinBgp joins the current solutions against the triples of one BGP
-   * block, optionally reordering the triples by estimated join cost.
+   * block, optionally reordering the triples by estimated join cost. The
+   * written-order path returns the pattern chain as a lazy generator (issue
+   * #74): each triple's join yields extended bindings one at a time, so the
+   * intermediate per-pattern binding arrays are never held. The reordered
+   * path keeps eager per-join materialization because the cost estimate
+   * needs the current result set.
    */
   private async joinBgp(
     triples: Triple[],
-    bindings: TermBinding[],
+    bindings: TermBinding[] | Iterable<TermBinding>,
     store: rdfjs.Source<rdfjs.Quad>,
     snapshot: ExistsSnapshot | null,
-  ): Promise<TermBinding[]> {
+  ): Promise<Iterable<TermBinding>> {
     // Reified-triple patterns (`<< s p o >>`, annotation `{| ... |}`) expand
     // into plain `rdf:reifies` triples before any scanning or reordering.
     const expanded = expandReifiedTriples(triples);
@@ -957,7 +984,27 @@ export class BgpEvaluator {
         prebuiltIndex,
       );
     }
-    let result = bindings;
+    // A single-pattern BGP has no chain to stream, so it takes the eager
+    // array join (which is also measurably lighter than the generator for
+    // the unselective full-scan case). Only a multi-pattern BGP composes
+    // the lazy join chain, which streams the intermediate binding flow
+    // instead of materializing an array per pattern.
+    if (expanded.length === 1) {
+      const triple = expanded[0];
+      const input = Array.isArray(bindings) ? bindings : [...bindings];
+      if (isPropertyPath(triple.predicate)) {
+        const entry = await scanPathEntry(
+          store,
+          triple.predicate,
+          triple.subject,
+          triple.object,
+        );
+        return joinPathPattern(input, entry);
+      }
+      const entry = await scanEntry(store, triple);
+      return joinTriplePattern(input, entry, prebuiltIndex);
+    }
+    let result: Iterable<TermBinding> = bindings;
     for (const triple of expanded) {
       if (isPropertyPath(triple.predicate)) {
         const entry = await scanPathEntry(
@@ -966,10 +1013,10 @@ export class BgpEvaluator {
           triple.subject,
           triple.object,
         );
-        result = joinPathPattern(result, entry);
+        result = joinPathPatternLazy(result, entry);
       } else {
         const entry = await scanEntry(store, triple);
-        result = joinTriplePattern(result, entry, prebuiltIndex);
+        result = joinTriplePatternLazy(result, entry, prebuiltIndex);
       }
     }
     return result;
@@ -977,11 +1024,14 @@ export class BgpEvaluator {
 
   /**
    * evaluateWithReordering scans every pattern once, then greedily joins the
-   * pattern with the lowest estimated cost against the current bindings.
+   * pattern with the lowest estimated cost against the current bindings. The
+   * estimate needs the full current result set, so each join materializes
+   * here (the reordered path stays eager; the lazy chain applies to the
+   * written-order path).
    */
   private async evaluateWithReordering(
     triplePatterns: Triple[],
-    bindings: TermBinding[],
+    bindings: TermBinding[] | Iterable<TermBinding>,
     store: rdfjs.Source<rdfjs.Quad>,
     prebuiltIndex: QuadIndex | null,
   ): Promise<TermBinding[]> {
@@ -989,7 +1039,9 @@ export class BgpEvaluator {
       triplePatterns.map((pattern) => scanEntry(store, pattern)),
     );
 
-    let result = bindings;
+    let result: TermBinding[] = Array.isArray(bindings)
+      ? bindings
+      : [...bindings];
     while (remaining.length > 0) {
       let bestIndex = 0;
       let bestCost = Number.POSITIVE_INFINITY;

--- a/src/evaluator/join.test.ts
+++ b/src/evaluator/join.test.ts
@@ -98,7 +98,7 @@ function assertMultisetEqual(
 Deno.test("innerJoin - homogeneous join on a shared variable", () => {
   const left = [0, 1, 2].map((n) => ({ s: p(n), a: lit(n) }));
   const right = [0, 1, 2].map((n) => ({ s: p(n), b: lit(n + 10) }));
-  const result = innerJoin(left, right);
+  const result = [...innerJoin(left, right)];
   assertEquals(result.length, 3);
   assertMultisetEqual(result, innerJoinRef(left, right), "innerJoin");
 });
@@ -106,7 +106,7 @@ Deno.test("innerJoin - homogeneous join on a shared variable", () => {
 Deno.test("innerJoin - duplicates survive (multiset semantics)", () => {
   const left = [{ s: p(0), a: lit(0) }, { s: p(0), a: lit(0) }];
   const right = [{ s: p(0), b: lit(1) }, { s: p(0), b: lit(1) }];
-  const result = innerJoin(left, right);
+  const result = [...innerJoin(left, right)];
   assertEquals(result.length, 4);
   assertMultisetEqual(result, innerJoinRef(left, right), "innerJoin");
 });
@@ -116,14 +116,14 @@ Deno.test("innerJoin - partial left binding is a wildcard on the shared variable
   // every right binding (they cannot disagree on ?s).
   const left: TermBinding[] = [{ b: lit(0) }, { s: p(1), b: lit(1) }];
   const right = [{ s: p(0), c: lit(0) }, { s: p(1), c: lit(1) }];
-  const result = innerJoin(left, right);
+  const result = [...innerJoin(left, right)];
   assertMultisetEqual(result, innerJoinRef(left, right), "innerJoin");
 });
 
 Deno.test("leftJoin - unmatched bindings survive unextended", () => {
   const left = [0, 1, 2, 3].map((n) => ({ s: p(n) }));
   const right = [0, 2].map((n) => ({ s: p(n), b: lit(n) }));
-  const result = leftJoin(left, right);
+  const result = [...leftJoin(left, right)];
   assertEquals(result.length, 4);
   assertMultisetEqual(result, leftJoinRef(left, right), "leftJoin");
 });
@@ -132,7 +132,7 @@ Deno.test("leftJoin - filters apply to the merged binding", () => {
   const left = [0, 1].map((n) => ({ s: p(n) }));
   const right = [0, 1].map((n) => ({ s: p(n), b: lit(n) }));
   const keepHigh = (b: TermBinding) => b.b !== undefined && b.b.value === "v1";
-  const result = leftJoin(left, right, [keepHigh]);
+  const result = [...leftJoin(left, right, [keepHigh])];
   // Only s1 matches the filter; s0 survives unextended.
   assertEquals(result.length, 2);
   assertMultisetEqual(
@@ -151,7 +151,7 @@ Deno.test("leftJoin - heterogeneous left (chained OPTIONAL) probes wildcards", (
     { s: p(3), a: lit(3) },
   ];
   const right = [0, 2].map((n) => ({ s: p(n), o2: lit(n + 100) }));
-  const result = leftJoin(left, right);
+  const result = [...leftJoin(left, right)];
   assertEquals(result.length, 4);
   assertMultisetEqual(result, leftJoinRef(left, right), "leftJoin-chain");
 });
@@ -159,7 +159,7 @@ Deno.test("leftJoin - heterogeneous left (chained OPTIONAL) probes wildcards", (
 Deno.test("minus - eliminates on shared-variable compatibility", () => {
   const left = [0, 1, 2].map((n) => ({ s: p(n) }));
   const right = [0, 2].map((n) => ({ s: p(n), b: lit(n) }));
-  const result = minus(left, right);
+  const result = [...minus(left, right)];
   assertEquals(result.length, 1);
   assertEquals(result[0].s, p(1));
 });
@@ -167,7 +167,7 @@ Deno.test("minus - eliminates on shared-variable compatibility", () => {
 Deno.test("minus - no shared variables means no elimination", () => {
   const left = [0, 1].map((n) => ({ s: p(n) }));
   const right = [{ t: p(0), b: lit(0) }, { t: p(1), b: lit(1) }];
-  const result = minus(left, right);
+  const result = [...minus(left, right)];
   assertEquals(result.length, 2);
 });
 
@@ -175,7 +175,7 @@ Deno.test("minus - partial left binding sharing nothing is not eliminated", () =
   // The left binding {x: v0} shares no variable with any right binding.
   const left: TermBinding[] = [{ x: lit(0) }, { s: p(1), x: lit(1) }];
   const right = [{ s: p(0), b: lit(0) }, { s: p(1), b: lit(1) }];
-  const result = minus(left, right);
+  const result = [...minus(left, right)];
   assertMultisetEqual(result, minusRef(left, right), "minus-partial");
 });
 
@@ -207,7 +207,7 @@ function largeRight(): TermBinding[] {
 Deno.test("hash join - large innerJoin matches the nested reference", () => {
   const left = largeLeft();
   const right = largeRight();
-  const result = innerJoin(left, right);
+  const result = [...innerJoin(left, right)];
   assertMultisetEqual(result, innerJoinRef(left, right), "hash-inner");
 });
 
@@ -215,7 +215,7 @@ Deno.test("hash join - large leftJoin matches the nested reference", () => {
   const left = largeLeft();
   const right = largeRight();
   const filter = (b: TermBinding) => (b.c === undefined || b.c.value !== "v99");
-  const result = leftJoin(left, right, [filter]);
+  const result = [...leftJoin(left, right, [filter])];
   assertMultisetEqual(
     result,
     leftJoinRef(left, right, [filter]),
@@ -226,6 +226,6 @@ Deno.test("hash join - large leftJoin matches the nested reference", () => {
 Deno.test("hash join - large minus matches the nested reference", () => {
   const left = largeLeft();
   const right = largeRight();
-  const result = minus(left, right);
+  const result = [...minus(left, right)];
   assertMultisetEqual(result, minusRef(left, right), "hash-minus");
 });

--- a/src/evaluator/join.ts
+++ b/src/evaluator/join.ts
@@ -78,51 +78,42 @@ export function bindingsCompatible(
  * the merged binding so they can reference outer variables.
  *
  * Large joins dispatch to the hash join (compatibleCandidates); small joins
- * keep the nested loop, which is faster below the hash-setup overhead.
+ * keep the nested loop, which is faster below the hash-setup overhead. Rows
+ * are emitted incrementally (issue #74 lazy slice): an array left keeps the
+ * exact pre-slice dispatch, while a streaming (generator) left runs a
+ * nested loop over small right sides and materializes only when the hash
+ * index — which is inherently eager — is required.
  */
 export function leftJoin(
-  left: TermBinding[],
+  left: TermBinding[] | Iterable<TermBinding>,
   right: TermBinding[],
   filters: BindingFilter[] = [],
-): TermBinding[] {
-  if (left.length === 0) {
-    return [];
-  }
+): Iterable<TermBinding> {
   if (right.length === 0) {
-    return left.slice();
+    // No right bindings: every left binding survives unextended. An array
+    // left is copied (as before); a streaming left passes through untouched.
+    return Array.isArray(left) ? left.slice() : left;
   }
-  if (left.length * right.length <= JOIN_PRODUCT_THRESHOLD) {
-    return leftJoinNested(left, right, filters);
-  }
-  const joinVars = sharedVars(left, right);
-  if (joinVars.length === 0) {
-    // No variable is bound on both sides: every pair is compatible.
-    return leftJoinNested(left, right, filters);
-  }
-  const index = buildHashIndex(right, joinVars);
-  const result: TermBinding[] = [];
-  for (const l of left) {
-    let matched = false;
-    for (const r of compatibleCandidates(l, joinVars, index, right)) {
-      const merged = { ...l, ...r };
-      if (filters.every((filter) => filter(merged))) {
-        result.push(merged);
-        matched = true;
-      }
+  if (Array.isArray(left)) {
+    if (left.length === 0) {
+      return EMPTY_BINDINGS;
     }
-    if (!matched) {
-      result.push(l);
+    if (left.length * right.length <= JOIN_PRODUCT_THRESHOLD) {
+      return leftJoinNested(left, right, filters);
     }
+    return leftJoinHash(left, right, filters);
   }
-  return result;
+  if (right.length <= STREAM_NESTED_THRESHOLD) {
+    return leftJoinStreamNested(left, right, filters);
+  }
+  return leftJoinHash([...left], right, filters);
 }
 
-function leftJoinNested(
+function* leftJoinNested(
   left: TermBinding[],
   right: TermBinding[],
   filters: BindingFilter[] = [],
-): TermBinding[] {
-  const result: TermBinding[] = [];
+): Generator<TermBinding> {
   for (const l of left) {
     let matched = false;
     for (const r of right) {
@@ -131,15 +122,64 @@ function leftJoinNested(
       }
       const merged = { ...l, ...r };
       if (filters.every((filter) => filter(merged))) {
-        result.push(merged);
+        yield merged;
         matched = true;
       }
     }
     if (!matched) {
-      result.push(l);
+      yield l;
     }
   }
-  return result;
+}
+
+function* leftJoinHash(
+  left: TermBinding[],
+  right: TermBinding[],
+  filters: BindingFilter[] = [],
+): Generator<TermBinding> {
+  const joinVars = sharedVars(left, right);
+  if (joinVars.length === 0) {
+    // No variable is bound on both sides: every pair is compatible.
+    yield* leftJoinNested(left, right, filters);
+    return;
+  }
+  const index = buildHashIndex(right, joinVars);
+  for (const l of left) {
+    let matched = false;
+    for (const r of compatibleCandidates(l, joinVars, index, right)) {
+      const merged = { ...l, ...r };
+      if (filters.every((filter) => filter(merged))) {
+        yield merged;
+        matched = true;
+      }
+    }
+    if (!matched) {
+      yield l;
+    }
+  }
+}
+
+function* leftJoinStreamNested(
+  left: Iterable<TermBinding>,
+  right: TermBinding[],
+  filters: BindingFilter[] = [],
+): Generator<TermBinding> {
+  for (const l of left) {
+    let matched = false;
+    for (const r of right) {
+      if (!bindingsCompatible(l, r)) {
+        continue;
+      }
+      const merged = { ...l, ...r };
+      if (filters.every((filter) => filter(merged))) {
+        yield merged;
+        matched = true;
+      }
+    }
+    if (!matched) {
+      yield l;
+    }
+  }
 }
 
 /**
@@ -150,46 +190,76 @@ function leftJoinNested(
  * Join(P, Union(Q1, Q2)) algebra translation.
  *
  * Large joins dispatch to the hash join; small joins keep the nested loop,
- * which is faster below the hash-setup overhead.
+ * which is faster below the hash-setup overhead. Rows are emitted
+ * incrementally (issue #74 lazy slice): an array left keeps the exact
+ * pre-slice dispatch, while a streaming (generator) left runs a nested loop
+ * over small right sides and materializes only when the hash index — which
+ * is inherently eager — is required.
  */
 export function innerJoin(
-  left: TermBinding[],
+  left: TermBinding[] | Iterable<TermBinding>,
   right: TermBinding[],
-): TermBinding[] {
-  if (left.length === 0 || right.length === 0) {
-    return [];
+): Iterable<TermBinding> {
+  if (right.length === 0) {
+    return EMPTY_BINDINGS;
   }
-  if (left.length * right.length <= JOIN_PRODUCT_THRESHOLD) {
-    return innerJoinNested(left, right);
-  }
-  const joinVars = sharedVars(left, right);
-  if (joinVars.length === 0) {
-    // No variable is bound on both sides: the result is a cross product.
-    return innerJoinNested(left, right);
-  }
-  const index = buildHashIndex(right, joinVars);
-  const result: TermBinding[] = [];
-  for (const l of left) {
-    for (const r of compatibleCandidates(l, joinVars, index, right)) {
-      result.push({ ...l, ...r });
+  if (Array.isArray(left)) {
+    if (left.length === 0) {
+      return EMPTY_BINDINGS;
     }
+    if (left.length * right.length <= JOIN_PRODUCT_THRESHOLD) {
+      return innerJoinNested(left, right);
+    }
+    return innerJoinHash(left, right);
   }
-  return result;
+  if (right.length <= STREAM_NESTED_THRESHOLD) {
+    return innerJoinStreamNested(left, right);
+  }
+  return innerJoinHash([...left], right);
 }
 
-function innerJoinNested(
+function* innerJoinNested(
   left: TermBinding[],
   right: TermBinding[],
-): TermBinding[] {
-  const result: TermBinding[] = [];
+): Generator<TermBinding> {
   for (const l of left) {
     for (const r of right) {
       if (bindingsCompatible(l, r)) {
-        result.push({ ...l, ...r });
+        yield { ...l, ...r };
       }
     }
   }
-  return result;
+}
+
+function* innerJoinHash(
+  left: TermBinding[],
+  right: TermBinding[],
+): Generator<TermBinding> {
+  const joinVars = sharedVars(left, right);
+  if (joinVars.length === 0) {
+    // No variable is bound on both sides: the result is a cross product.
+    yield* innerJoinNested(left, right);
+    return;
+  }
+  const index = buildHashIndex(right, joinVars);
+  for (const l of left) {
+    for (const r of compatibleCandidates(l, joinVars, index, right)) {
+      yield { ...l, ...r };
+    }
+  }
+}
+
+function* innerJoinStreamNested(
+  left: Iterable<TermBinding>,
+  right: TermBinding[],
+): Generator<TermBinding> {
+  for (const l of left) {
+    for (const r of right) {
+      if (bindingsCompatible(l, r)) {
+        yield { ...l, ...r };
+      }
+    }
+  }
 }
 
 /**
@@ -199,25 +269,56 @@ function innerJoinNested(
  * left binding never eliminate it, per SPARQL 1.1 §18.2.2.9.
  *
  * Large joins dispatch to the hash join; small joins keep the nested loop.
+ * Rows are emitted incrementally (issue #74 lazy slice): an array left
+ * keeps the exact pre-slice dispatch, while a streaming (generator) left
+ * runs a nested loop over small right sides and materializes only when the
+ * hash index — which is inherently eager — is required.
  */
 export function minus(
+  left: TermBinding[] | Iterable<TermBinding>,
+  right: TermBinding[],
+): Iterable<TermBinding> {
+  if (right.length === 0) {
+    return Array.isArray(left) ? left.slice() : left;
+  }
+  if (Array.isArray(left)) {
+    if (left.length === 0) {
+      return EMPTY_BINDINGS;
+    }
+    if (left.length * right.length <= JOIN_PRODUCT_THRESHOLD) {
+      return minusNested(left, right);
+    }
+    return minusHash(left, right);
+  }
+  if (right.length <= STREAM_NESTED_THRESHOLD) {
+    return minusStreamNested(left, right);
+  }
+  return minusHash([...left], right);
+}
+
+function* minusNested(
   left: TermBinding[],
   right: TermBinding[],
-): TermBinding[] {
-  if (left.length === 0 || right.length === 0) {
-    return left.slice();
+): Generator<TermBinding> {
+  for (const l of left) {
+    if (!right.some((r) => sharesVariable(l, r) && bindingsCompatible(l, r))) {
+      yield l;
+    }
   }
-  if (left.length * right.length <= JOIN_PRODUCT_THRESHOLD) {
-    return minusNested(left, right);
-  }
+}
+
+function* minusHash(
+  left: TermBinding[],
+  right: TermBinding[],
+): Generator<TermBinding> {
   const joinVars = sharedVars(left, right);
   if (joinVars.length === 0) {
     // No variable is bound on both sides: no right binding shares a variable
     // with any left binding, so nothing is eliminated.
-    return left.slice();
+    yield* left;
+    return;
   }
   const index = buildHashIndex(right, joinVars);
-  const result: TermBinding[] = [];
   for (const l of left) {
     let eliminated = false;
     for (const r of compatibleCandidates(l, joinVars, index, right)) {
@@ -227,19 +328,20 @@ export function minus(
       }
     }
     if (!eliminated) {
-      result.push(l);
+      yield l;
     }
   }
-  return result;
 }
 
-function minusNested(
-  left: TermBinding[],
+function* minusStreamNested(
+  left: Iterable<TermBinding>,
   right: TermBinding[],
-): TermBinding[] {
-  return left.filter((l) =>
-    !right.some((r) => sharesVariable(l, r) && bindingsCompatible(l, r))
-  );
+): Generator<TermBinding> {
+  for (const l of left) {
+    if (!right.some((r) => sharesVariable(l, r) && bindingsCompatible(l, r))) {
+      yield l;
+    }
+  }
 }
 
 /* ------------------------------------------------------------------ */
@@ -259,6 +361,46 @@ function minusNested(
  * saves for tiny joins.
  */
 const JOIN_PRODUCT_THRESHOLD = 4096;
+
+/**
+ * STREAM_NESTED_THRESHOLD bounds the right side of a nested-loop join whose
+ * left side streams as a generator (the lazy slice): the left length is
+ * unknown without materializing, so the product threshold cannot apply, but
+ * a right side this small keeps the nested loop cheap for any left length.
+ * Larger right sides dispatch to the (inherently eager) hash index.
+ */
+const STREAM_NESTED_THRESHOLD = 64;
+
+/** Shared empty result for joins with no right side (never mutated). */
+const EMPTY_BINDINGS: TermBinding[] = [];
+
+/**
+ * filterBindings applies a predicate to a binding iterable — the streaming
+ * counterpart to Array#filter, for the lazy group evaluation (issue #74).
+ */
+export function* filterBindings(
+  bindings: Iterable<TermBinding>,
+  predicate: (binding: TermBinding) => boolean,
+): Generator<TermBinding> {
+  for (const binding of bindings) {
+    if (predicate(binding)) {
+      yield binding;
+    }
+  }
+}
+
+/**
+ * mapBindings applies a transform to a binding iterable — the streaming
+ * counterpart to Array#map, for the lazy group evaluation (issue #74).
+ */
+export function* mapBindings<T>(
+  bindings: Iterable<TermBinding>,
+  transform: (binding: TermBinding) => T,
+): Generator<T> {
+  for (const binding of bindings) {
+    yield transform(binding);
+  }
+}
 
 /**
  * sharedVars returns the sorted variables bound on both sides — the join
@@ -506,7 +648,11 @@ function getQueryVarName(term: SparqlTerm): string {
  * joinTriplePattern joins the current bindings against a triple pattern with
  * a hash join: candidate quads come from the pattern's single indexed store
  * scan (performed once by the caller), and bindings probe a positional index
- * instead of issuing a stream round trip per binding.
+ * instead of issuing a stream round trip per binding. This array form is the
+ * eager path: a single-pattern BGP (where there is no chain to stream), the
+ * reordered BGP path (whose cost estimate needs the materialized result
+ * set), and the synchronous EXISTS hooks. The lazy BGP chain uses
+ * joinTriplePatternLazy instead.
  *
  * prebuiltIndex supplies an already-built QuadIndex (the EXISTS hooks' drained
  * snapshot index) so the join probes it directly instead of rebuilding an
@@ -525,10 +671,10 @@ export function joinTriplePattern(
   graphScope?: rdfjs.Term | null,
 ): TermBinding[] {
   if (entry.reifies) {
-    return joinReifiesPattern(currentBindings, entry);
+    return [...joinReifiesPattern(currentBindings, entry)];
   }
   if (entry.tripleTermObject) {
-    return joinTripleTermObject(currentBindings, entry);
+    return [...joinTripleTermObject(currentBindings, entry)];
   }
   const subject = entry.subject;
   const predicate = entry.predicate;
@@ -625,6 +771,118 @@ export function joinTriplePattern(
 }
 
 /**
+ * joinTriplePatternLazy is the generator form of joinTriplePattern (issue
+ * #74 lazy slice): it emits extended bindings one at a time, so a chain of
+ * BGP patterns streams solution bindings instead of materializing an array
+ * per pattern. The positional index is still built over the pattern's
+ * candidate bucket — the hash index build stays eager — but only on the
+ * first binding that actually binds a pattern variable (bindings binding no
+ * variable scan the candidates directly, which is exactly what the index
+ * probe returns for them).
+ */
+export function* joinTriplePatternLazy(
+  currentBindings: Iterable<TermBinding>,
+  entry: ScanEntry,
+  prebuiltIndex?: QuadIndex | null,
+  graphScope?: rdfjs.Term | null,
+): Generator<TermBinding> {
+  if (entry.reifies) {
+    yield* joinReifiesPattern(currentBindings, entry);
+    return;
+  }
+  if (entry.tripleTermObject) {
+    yield* joinTripleTermObject(currentBindings, entry);
+    return;
+  }
+  const subject = entry.subject;
+  const predicate = entry.predicate;
+  const object = entry.object;
+
+  const subjectIsVariable = isQueryVar(subject);
+  const predicateIsVariable = isQueryVar(predicate);
+  const objectIsVariable = isQueryVar(object);
+
+  const candidateQuads = entry.candidates;
+
+  let quadIndex: QuadIndex | null = prebuiltIndex ?? null;
+
+  for (const binding of currentBindings) {
+    const resolvedSubject = resolveTerm(subject, binding);
+    const resolvedPredicate = resolveTerm(predicate, binding);
+    const resolvedObject = resolveTerm(object, binding);
+
+    if (
+      quadIndex === null &&
+      ((subjectIsVariable && binding[getQueryVarName(subject)] !== undefined) ||
+        (predicateIsVariable &&
+          binding[getQueryVarName(predicate)] !== undefined) ||
+        (objectIsVariable && binding[getQueryVarName(object)] !== undefined))
+    ) {
+      quadIndex = buildQuadIndex(candidateQuads);
+    }
+
+    const matchingQuads = quadIndex === null ? candidateQuads : probeQuadIndex(
+      quadIndex,
+      candidateQuads,
+      resolvedSubject,
+      resolvedPredicate,
+      resolvedObject,
+    );
+    const scopedQuads = graphScope === undefined || graphScope === null
+      ? matchingQuads
+      : matchingQuads.filter((item) => sameRdfTerm(item.graph, graphScope));
+
+    for (const matchQuad of scopedQuads) {
+      const newBinding = { ...binding };
+      let valid = true;
+
+      if (subjectIsVariable) {
+        const varName = getQueryVarName(subject);
+        const val = matchQuad.subject;
+        if (
+          newBinding[varName] &&
+          !sameRdfTerm(newBinding[varName], val)
+        ) {
+          valid = false;
+        } else {
+          newBinding[varName] = val;
+        }
+      }
+
+      if (valid && predicateIsVariable) {
+        const varName = getQueryVarName(predicate);
+        const val = matchQuad.predicate;
+        if (
+          newBinding[varName] &&
+          !sameRdfTerm(newBinding[varName], val)
+        ) {
+          valid = false;
+        } else {
+          newBinding[varName] = val;
+        }
+      }
+
+      if (valid && objectIsVariable) {
+        const varName = getQueryVarName(object);
+        const val = matchQuad.object;
+        if (
+          newBinding[varName] &&
+          !sameRdfTerm(newBinding[varName], val)
+        ) {
+          valid = false;
+        } else {
+          newBinding[varName] = val;
+        }
+      }
+
+      if (valid) {
+        yield newBinding;
+      }
+    }
+  }
+}
+
+/**
  * matchPatternTerm matches a pattern position against a data term, extending
  * the binding: a variable position binds (or must agree with an existing
  * binding), a constant position must be the same RDF term, and a quad
@@ -669,15 +927,14 @@ function matchPatternTerm(
  * pattern. Each candidate `X rdf:reifies TT` decomposes its quoted triple term
  * TT and matches its subject/predicate/object against the pattern's three
  * positions (binding variables, recursively through nested triple terms),
- * then binds the reifier position to X.
+ * then binds the reifier position to X. Emits incrementally (issue #74).
  */
-function joinReifiesPattern(
-  currentBindings: TermBinding[],
+function* joinReifiesPattern(
+  currentBindings: Iterable<TermBinding>,
   entry: ScanEntry,
-): TermBinding[] {
+): Generator<TermBinding> {
   const reifier = entry.subject;
   const tripleTerm = entry.object as rdfjs.Quad;
-  const result: TermBinding[] = [];
   for (const binding of currentBindings) {
     for (const candidate of entry.candidates) {
       if (candidate.object.termType !== "Quad") {
@@ -710,11 +967,10 @@ function joinReifiesPattern(
       }
       const bound = matchPatternTerm(reifier, candidate.subject, extended);
       if (bound !== null) {
-        result.push(bound);
+        yield bound;
       }
     }
   }
-  return result;
 }
 
 /**
@@ -722,12 +978,12 @@ function joinReifiesPattern(
  * is a triple-term pattern `?s ?p <<( ?st ?pt ?ot )>>`. Each candidate quad
  * with a triple-term object matches the subject/predicate positionally and
  * the object recursively through the triple-term pattern's positions.
+ * Emits incrementally (issue #74).
  */
-function joinTripleTermObject(
-  currentBindings: TermBinding[],
+function* joinTripleTermObject(
+  currentBindings: Iterable<TermBinding>,
   entry: ScanEntry,
-): TermBinding[] {
-  const result: TermBinding[] = [];
+): Generator<TermBinding> {
   for (const binding of currentBindings) {
     for (const candidate of entry.candidates) {
       if (candidate.object.termType !== "Quad") {
@@ -755,11 +1011,10 @@ function joinTripleTermObject(
         extended,
       );
       if (bound !== null) {
-        result.push(bound);
+        yield bound;
       }
     }
   }
-  return result;
 }
 
 /**
@@ -876,7 +1131,9 @@ export async function scanPathEntry(
 /**
  * joinPathPattern joins the current bindings against a property-path entry:
  * each binding resolves its subject/object positions and keeps every pair
- * consistent with them, extending the binding with the pair's terms.
+ * consistent with them, extending the binding with the pair's terms. This
+ * array form is the eager path (single-pattern BGPs and the synchronous
+ * EXISTS hooks); the lazy BGP chain uses joinPathPatternLazy.
  */
 export function joinPathPattern(
   currentBindings: TermBinding[],
@@ -933,6 +1190,65 @@ export function joinPathPattern(
   }
 
   return nextBindings;
+}
+
+/**
+ * joinPathPatternLazy is the generator form of joinPathPattern (issue #74
+ * lazy slice): property paths stream inside the lazy BGP chain, so a path
+ * pattern emits extended bindings one at a time.
+ */
+export function* joinPathPatternLazy(
+  currentBindings: Iterable<TermBinding>,
+  entry: PathEntry,
+): Generator<TermBinding> {
+  const { subject, object, pairs } = entry;
+  const subjectIsVariable = subject.termType === "Variable";
+  const objectIsVariable = object.termType === "Variable";
+
+  for (const binding of currentBindings) {
+    const resolvedSubject = subjectIsVariable
+      ? binding[subject.value] ?? null
+      : sparqlTermToRdfTerm(subject);
+    const resolvedObject = objectIsVariable
+      ? binding[object.value] ?? null
+      : sparqlTermToRdfTerm(object);
+
+    for (const pair of pairs) {
+      if (
+        resolvedSubject !== null &&
+        !sameRdfTerm(pair.subject, resolvedSubject)
+      ) {
+        continue;
+      }
+      if (
+        resolvedObject !== null &&
+        !sameRdfTerm(pair.object, resolvedObject)
+      ) {
+        continue;
+      }
+      const newBinding = { ...binding };
+      let valid = true;
+      if (subjectIsVariable) {
+        const existing = newBinding[subject.value];
+        if (existing !== undefined && !sameRdfTerm(existing, pair.subject)) {
+          valid = false;
+        } else {
+          newBinding[subject.value] = pair.subject;
+        }
+      }
+      if (valid && objectIsVariable) {
+        const existing = newBinding[object.value];
+        if (existing !== undefined && !sameRdfTerm(existing, pair.object)) {
+          valid = false;
+        } else {
+          newBinding[object.value] = pair.object;
+        }
+      }
+      if (valid) {
+        yield newBinding;
+      }
+    }
+  }
 }
 
 /**

--- a/src/evaluator/select-pipeline.ts
+++ b/src/evaluator/select-pipeline.ts
@@ -74,7 +74,10 @@ export function applySelectPipeline(
       }
       return binding;
     });
-    bindings = innerJoin(bindings, rows);
+    // The join now emits incrementally (issue #74); the select pipeline's
+    // grouping/ordering steps are inherently materializing, so the streaming
+    // left is collected here.
+    bindings = [...innerJoin(bindings, rows)];
   }
 
   const vars: string[] = [];

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -426,19 +426,25 @@ export class SparqlEvaluator {
   private async evaluateConstruct(
     query: ConstructQuery,
   ): Promise<SparqlConstructResults> {
+    if (!query.template) {
+      return { quads: [] };
+    }
     const bindings = await (await this.bgpEvaluatorFor(query.from))
       .evaluateBgp(query.where || []);
-    const quads: rdfjs.Quad[] = [];
-
-    if (!query.template) {
-      return { quads };
-    }
 
     // Reified-triple templates (`<< s p o >>`, annotation `{| ... |}`)
     // expand into a reifier blank node joined to its `rdf:reifies` triple
     // term, so the template instantiates the RDF 1.2 reifier representation.
     const template = expandReifiedTriples(query.template);
 
+    // SPARQL 1.1 §16.2: the CONSTRUCT result is an RDF graph — a set of
+    // triples — so duplicate instantiations collapse. The template
+    // instantiations are emitted per solution straight into the dedup set
+    // (issue #74 lazy slice): the intermediate full-instantiation array is
+    // never materialized, so peak holds the dedup key set plus the graph
+    // instead of that plus every constructed quad.
+    const seen = new Set<string>();
+    const graph: rdfjs.Quad[] = [];
     for (const binding of bindings) {
       // Blank nodes in a CONSTRUCT template are fresh per solution mapping
       // (SPARQL 1.1 §16.2.1): the parser expands RDF collections and _:b
@@ -454,30 +460,18 @@ export class SparqlEvaluator {
         const o = this.resolveConstructTerm(t.object, binding, bnodeMap);
 
         if (s && p && o) {
-          quads.push(
-            DataFactory.quad(
-              s as rdfjs.Quad_Subject,
-              p as rdfjs.Quad_Predicate,
-              o as rdfjs.Quad_Object,
-              DataFactory.defaultGraph(),
-            ),
+          const quad = DataFactory.quad(
+            s as rdfjs.Quad_Subject,
+            p as rdfjs.Quad_Predicate,
+            o as rdfjs.Quad_Object,
+            DataFactory.defaultGraph(),
           );
+          const key = termKey(quad);
+          if (!seen.has(key)) {
+            seen.add(key);
+            graph.push(quad);
+          }
         }
-      }
-    }
-
-    // SPARQL 1.1 §16.2: the CONSTRUCT result is an RDF graph — a set of
-    // triples — so duplicate instantiations collapse. Multiple solutions can
-    // emit the same triple (e.g. an annotation pattern matching both a
-    // reifier's annotation and its own rdf:reifies statement), and RDF graph
-    // semantics remove those duplicates.
-    const seen = new Set<string>();
-    const graph: rdfjs.Quad[] = [];
-    for (const quad of quads) {
-      const key = termKey(quad);
-      if (!seen.has(key)) {
-        seen.add(key);
-        graph.push(quad);
       }
     }
     return { quads: graph };


### PR DESCRIPTION
Closes #74 (re-scoped by #110).

## What

The #110-re-scoped lazy slice, landing the tractable parts of the streaming/lazy track:

- **Generator joins between BGP patterns** — the group solution flow is now a streaming iterable between patterns: BGP triple/path joins, FILTER passes, BIND extensions, and OPTIONAL/MINUS/UNION/VALUES/GRAPH joins emit incrementally (`join.ts` generators + `bgp-evaluator.evaluateGroup`), materialized **exactly once at the group boundary**. A long pattern chain no longer holds an intermediate `TermBinding[]` per step.
- **Lazy CONSTRUCT emission** — template instantiations dedupe inline into the result graph set; the full intermediate quads array is never materialized.
- **Kept eager (deliberately, per #110)**: the EXISTS sync path, the hash-join index build, and ORDER BY/DISTINCT/GROUP BY.
- **Array fast paths preserved** — single-pattern BGPs and small joins dispatch exactly as before; the *streaming `match()`* slice was measured and **reverted** (V8's Map-iterator drain regressed the single-pattern scan ~12 MiB; every consumer materializes anyway).

## Measurements

- **`bench:memory`** (regenerated): neutral — scan 157.2 → 154.4 MiB (−1.7%), exists 83.4 → 85.9 MiB (+3%), both within the known run-to-run band.
- **Interleaved latency A/B** (main vs this branch, same load window): EXISTS family **−8% to −56%** (exists −56%, nested-exists −35%, not-exists −20%), 10k union **−31%**, join/chain neutral; unchanged-path controls (copy-graph +5%, string-concat +32%) sit inside the machine-load noise band (±30%) documented during measurement — so latency-data.json was **not** regenerated to avoid baking load drift into the chart.
- **Targeted peak-heap probes** (identical sampler, both checkouts): chain BGP (reorder off) **89 → 41 MiB (−54%)**; CONSTRUCT workload peak **102 → 50 MiB (−51%)**.

## Validation

- `deno task ci` green: parser:check, fmt, lint, check, 413/413 tests, bench:check, exists-ref, sparql12:gap, sparql12, rdf11, rdf12.
- `deno task test:w3c` green: **345/345**, 0 allowlisted.
- Public `execute()` contract unchanged.
