### PR TITLE
feat(planner): cost-model estimator surface (piece 1 of #75)

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -202,11 +202,18 @@ engine's optimizer. It is a _dynamic_ greedy planner, not a static rewrite:
    — so the planner uses the pattern's _true_ store cardinality
    (`entry.candidates.length`), never a heuristic estimate.
 3. A greedy loop repeatedly joins the remaining pattern with the lowest
-   `estimateJoinCost()` against the current bindings:
+   estimated cost against the current bindings. The estimate comes from an
+   injectable
+   [`JoinCostEstimator`](https://jsr.io/@wazoo/sparql-engine/doc/~/JoinCostEstimator)
+   (`src/planner/join-cost-estimator.ts`; default `BaselineJoinCostEstimator`,
+   wired via `WazooSparqlEngineOptions.estimator`):
    - no pattern variable bound → `bindings.length × candidates.length`;
    - a pattern variable bound in the incoming solutions → the positional index
      is probed, costing `bindings.length × average bucket size`
      (`candidates.length ÷ distinct bound values`).
+
+   The estimate affects only join order, never results (SPARQL §18.2.2 — joins
+   commute), so an estimator swap is guarded by the W3C differential gate.
 
 ### Worked example: the `reorder-chain` benchmark
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -202,9 +202,8 @@ engine's optimizer. It is a _dynamic_ greedy planner, not a static rewrite:
    — so the planner uses the pattern's _true_ store cardinality
    (`entry.candidates.length`), never a heuristic estimate.
 3. A greedy loop repeatedly joins the remaining pattern with the lowest
-   estimated cost against the current bindings. The estimate comes from an   injectable
-   [`JoinCostEstimator`](https://github.com/wazootech/sparql-engine/blob/main/src/planner/join-cost-estimator.ts)
-   (`src/planner/join-cost-estimator.ts`; default `BaselineJoinCostEstimator`,
+   estimated cost against the current bindings. The estimate comes from an   injectable `JoinCostEstimator` (`src/planner/join-cost-estimator.ts`;
+   default `BaselineJoinCostEstimator`,
    wired via `WazooSparqlEngineOptions.estimator`):
    - no pattern variable bound → `bindings.length × candidates.length`;
    - a pattern variable bound in the incoming solutions → the positional index

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -202,9 +202,8 @@ engine's optimizer. It is a _dynamic_ greedy planner, not a static rewrite:
    — so the planner uses the pattern's _true_ store cardinality
    (`entry.candidates.length`), never a heuristic estimate.
 3. A greedy loop repeatedly joins the remaining pattern with the lowest
-   estimated cost against the current bindings. The estimate comes from an
-   injectable
-   [`JoinCostEstimator`](https://jsr.io/@wazoo/sparql-engine/doc/~/JoinCostEstimator)
+   estimated cost against the current bindings. The estimate comes from an   injectable
+   [`JoinCostEstimator`](https://github.com/wazootech/sparql-engine/blob/main/src/planner/join-cost-estimator.ts)
    (`src/planner/join-cost-estimator.ts`; default `BaselineJoinCostEstimator`,
    wired via `WazooSparqlEngineOptions.estimator`):
    - no pattern variable bound → `bindings.length × candidates.length`;

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -202,9 +202,9 @@ engine's optimizer. It is a _dynamic_ greedy planner, not a static rewrite:
    — so the planner uses the pattern's _true_ store cardinality
    (`entry.candidates.length`), never a heuristic estimate.
 3. A greedy loop repeatedly joins the remaining pattern with the lowest
-   estimated cost against the current bindings. The estimate comes from an   injectable `JoinCostEstimator` (`src/planner/join-cost-estimator.ts`;
-   default `BaselineJoinCostEstimator`,
-   wired via `WazooSparqlEngineOptions.estimator`):
+   estimated cost against the current bindings. The estimate comes from an
+   injectable `JoinCostEstimator` (`src/planner/join-cost-estimator.ts`; default
+   `BaselineJoinCostEstimator`, wired via `WazooSparqlEngineOptions.estimator`):
    - no pattern variable bound → `bindings.length × candidates.length`;
    - a pattern variable bound in the incoming solutions → the positional index
      is probed, costing `bindings.length × average bucket size`

--- a/docs/03-api-contracts.md
+++ b/docs/03-api-contracts.md
@@ -347,12 +347,14 @@ Types:
 [`WazooSparqlEngineOptions`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngineOptions),
 [`WazooSparqlTransaction`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlTransaction),
 `IriFunction`, `IriFunctionMap` (link on JSR once published),
-[`JoinCostEstimator`](https://jsr.io/@wazoo/sparql-engine/doc/~/JoinCostEstimator),
+[`JoinCostEstimator`](https://github.com/wazootech/sparql-engine/blob/main/src/planner/join-cost-estimator.ts)
+(link on JSR once published),
 [`CanonicalTerm`](https://jsr.io/@wazoo/sparql-engine/doc/~/CanonicalTerm).
 
 Values/classes:
 [`WazooSparqlEngine`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngine),
-[`BaselineJoinCostEstimator`](https://jsr.io/@wazoo/sparql-engine/doc/~/BaselineJoinCostEstimator),
+[`BaselineJoinCostEstimator`](https://github.com/wazootech/sparql-engine/blob/main/src/planner/join-cost-estimator.ts)
+(link on JSR once published),
 [`MemoryStore`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStore),
 [`MemoryStream`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStream),
 [`DataFactory`](https://jsr.io/@wazoo/sparql-engine/doc/~/DataFactory),

--- a/docs/03-api-contracts.md
+++ b/docs/03-api-contracts.md
@@ -100,6 +100,7 @@ export interface WazooSparqlEngineOptions {
   createTransaction?: () => WazooSparqlTransaction; // optional: atomic updates
   reorderPatterns?: boolean; // default true: dynamic join ordering
   functions?: IriFunctionMap; // optional: custom IRI function registry
+  estimator?: JoinCostEstimator; // default: baseline greedy formula
 }
 ```
 
@@ -107,7 +108,9 @@ export interface WazooSparqlEngineOptions {
 written order of BGP triple patterns. `createTransaction` upgrades updates from
 direct `addQuad`/`removeQuad` calls to one atomic transaction per request.
 `functions` registers custom IRI functions (SPARQL 1.1 §17.4.3.1); see
-[Custom functions & operators](#4-custom-functions--operators).
+[Custom functions & operators](#4-custom-functions--operators). `estimator`
+swaps the join-cost model behind the greedy reorderer (the default is the
+baseline greedy formula); see [Join-cost estimator](#5-join-cost-estimator).
 
 ## Supported SPARQL surface
 
@@ -287,6 +290,34 @@ update operation types) lives in `ExpressionEvaluator.evaluateOperation()` /
 [`aggregateValue`](https://github.com/wazootech/sparql-engine/blob/main/src/evaluator/aggregate.ts)
 / `applyOperation` (`src/evaluator/update-evaluator.ts`).
 
+### 5. Join-cost estimator
+
+The greedy BGP reorderer (`BgpEvaluator.evaluateWithReordering`) picks the next
+pattern to join by estimated cost. That estimate comes from an injectable
+`JoinCostEstimator` (`src/planner/join-cost-estimator.ts`):
+
+```typescript
+export interface JoinCostEstimator {
+  estimateJoinCost(entry: ScanEntry, bindings: TermBinding[]): number;
+}
+```
+
+The default is `BaselineJoinCostEstimator` — the shipped greedy formula: no
+bound pattern variable costs `bindings.length × candidates.length`; a bound
+pattern variable costs `bindings.length × average bucket size`
+(`candidates.length ÷ distinct bound values`, bounded below by 1), using the
+bound variable with the fewest distinct values. Swap it via
+`WazooSparqlEngineOptions.estimator`.
+
+**Contract:** the estimator receives the pattern's `ScanEntry` (whose
+`candidates` array holds the pattern's true store cardinality from the up-front
+scan) and the current bindings, and nothing else — no store access, no
+statistics beyond the entry's candidates. It must be pure and deterministic.
+Crucially, the estimate affects **only join order, never results** (SPARQL 1.1
+§18.2.2: joins commute, so every order yields the same solution multiset); the
+W3C differential gate is the guard. Planner pieces 2–3 (statistics source,
+join-order search) plug in behind this seam.
+
 ## Term utilities (exported from `src/mod.ts`)
 
 The engine also exports its term algebra for consumers that need RDF/JS term
@@ -316,10 +347,12 @@ Types:
 [`WazooSparqlEngineOptions`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngineOptions),
 [`WazooSparqlTransaction`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlTransaction),
 `IriFunction`, `IriFunctionMap` (link on JSR once published),
+[`JoinCostEstimator`](https://jsr.io/@wazoo/sparql-engine/doc/~/JoinCostEstimator),
 [`CanonicalTerm`](https://jsr.io/@wazoo/sparql-engine/doc/~/CanonicalTerm).
 
 Values/classes:
 [`WazooSparqlEngine`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngine),
+[`BaselineJoinCostEstimator`](https://jsr.io/@wazoo/sparql-engine/doc/~/BaselineJoinCostEstimator),
 [`MemoryStore`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStore),
 [`MemoryStream`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStream),
 [`DataFactory`](https://jsr.io/@wazoo/sparql-engine/doc/~/DataFactory),

--- a/docs/03-api-contracts.md
+++ b/docs/03-api-contracts.md
@@ -347,14 +347,12 @@ Types:
 [`WazooSparqlEngineOptions`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngineOptions),
 [`WazooSparqlTransaction`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlTransaction),
 `IriFunction`, `IriFunctionMap` (link on JSR once published),
-[`JoinCostEstimator`](https://github.com/wazootech/sparql-engine/blob/main/src/planner/join-cost-estimator.ts)
-(link on JSR once published),
+`JoinCostEstimator` (link on JSR once published),
 [`CanonicalTerm`](https://jsr.io/@wazoo/sparql-engine/doc/~/CanonicalTerm).
 
 Values/classes:
 [`WazooSparqlEngine`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngine),
-[`BaselineJoinCostEstimator`](https://github.com/wazootech/sparql-engine/blob/main/src/planner/join-cost-estimator.ts)
-(link on JSR once published),
+`BaselineJoinCostEstimator` (link on JSR once published),
 [`MemoryStore`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStore),
 [`MemoryStream`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStream),
 [`DataFactory`](https://jsr.io/@wazoo/sparql-engine/doc/~/DataFactory),

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -42,6 +42,10 @@ import { applySelectPipeline } from "@/evaluator/select-pipeline.ts";
 import type { ScanEntry, TermBinding } from "@/evaluator/join.ts";
 import { sameRdfTerm, sparqlTermToRdfTerm, termKey } from "@/term/mod.ts";
 import {
+  BaselineJoinCostEstimator,
+  type JoinCostEstimator,
+} from "@/planner/join-cost-estimator.ts";
+import {
   expandReifiedTriples,
   isReifiesPattern,
   RDF_REIFIES,
@@ -86,6 +90,16 @@ export interface BgpEvaluatorOptions {
    * WazooSparqlEngineOptions.functions.
    */
   functions?: IriFunctionMap;
+
+  /**
+   * estimator supplies the join-cost estimator the greedy reorderer uses
+   * to pick the next pattern to join (see JoinCostEstimator for the
+   * contract). Defaults to BaselineJoinCostEstimator. The estimate affects
+   * only join order — never results (SPARQL 1.1 §18.2.2). Planner pieces
+   * 2–3 (#129/#130) plug the statistics source and join-order search
+   * behind this same seam.
+   */
+  estimator?: JoinCostEstimator;
 }
 
 /**
@@ -104,6 +118,9 @@ export class BgpEvaluator {
 
   /** functions is the custom IRI function registry (see options). */
   private readonly functions: IriFunctionMap;
+
+  /** estimator scores pattern joins for the greedy reorderer (see options). */
+  private readonly estimator: JoinCostEstimator;
 
   /**
    * existsQuads and existsIndex are the drained, indexed snapshot of the
@@ -125,6 +142,7 @@ export class BgpEvaluator {
   ) {
     this.reorderPatterns = options.reorderPatterns ?? true;
     this.functions = options.functions ?? {};
+    this.estimator = options.estimator ?? new BaselineJoinCostEstimator();
     this.expressionEvaluator = new ExpressionEvaluator({
       functions: options.functions,
     });
@@ -704,6 +722,7 @@ export class BgpEvaluator {
     return new BgpEvaluator(store, {
       reorderPatterns: this.reorderPatterns,
       functions: this.functions,
+      estimator: this.estimator,
     });
   }
 
@@ -938,6 +957,7 @@ export class BgpEvaluator {
         const subEvaluator = new SparqlEvaluator(store, {
           reorderPatterns: this.reorderPatterns,
           functions: this.functions,
+          estimator: this.estimator,
         });
         const subResults = await subEvaluator.evaluateSelectTermBindings(
           pattern as unknown as import("@/parser/sparql-parser.ts").SelectQuery,
@@ -1046,7 +1066,7 @@ export class BgpEvaluator {
       let bestIndex = 0;
       let bestCost = Number.POSITIVE_INFINITY;
       for (let index = 0; index < remaining.length; index++) {
-        const cost = this.estimateJoinCost(remaining[index], result);
+        const cost = this.estimator.estimateJoinCost(remaining[index], result);
         if (cost < bestCost) {
           bestCost = cost;
           bestIndex = index;
@@ -1056,52 +1076,6 @@ export class BgpEvaluator {
       result = joinTriplePattern(result, chosen, prebuiltIndex);
     }
     return result;
-  }
-
-  /**
-   * estimateJoinCost estimates the number of quad iterations joining the
-   * given pattern against the current bindings will perform. Bindings that
-   * bind no pattern variable iterate every candidate quad; bindings that bind
-   * a pattern variable probe the positional index, costing roughly the
-   * average bucket size for the most selective bound variable (candidate
-   * count divided by its number of distinct bound values).
-   */
-  private estimateJoinCost(
-    entry: ScanEntry,
-    bindings: TermBinding[],
-  ): number {
-    if (bindings.length === 0) {
-      return 0;
-    }
-    let mostSelectiveDistinct = Number.POSITIVE_INFINITY;
-    for (const term of [entry.subject, entry.predicate, entry.object]) {
-      if (term.termType !== "Variable") {
-        continue;
-      }
-      const distinct = new Set<string>();
-      for (const binding of bindings) {
-        const value = binding[term.value];
-        if (value !== undefined) {
-          distinct.add(termKey(value));
-        }
-      }
-      if (distinct.size === 0) {
-        continue;
-      }
-      if (distinct.size < mostSelectiveDistinct) {
-        mostSelectiveDistinct = distinct.size;
-      }
-    }
-    if (mostSelectiveDistinct === Number.POSITIVE_INFINITY) {
-      // No bound pattern variable: every binding iterates all candidates.
-      return bindings.length * entry.candidates.length;
-    }
-    const averageBucket = Math.max(
-      1,
-      entry.candidates.length /
-        mostSelectiveDistinct,
-    );
-    return bindings.length * averageBucket;
   }
 }
 

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -34,6 +34,7 @@ import {
   ExpressionEvaluator,
   type IriFunctionMap,
 } from "@/evaluator/expression-evaluator.ts";
+import type { JoinCostEstimator } from "@/planner/join-cost-estimator.ts";
 import type { ExpressionEvaluationContext } from "@/evaluator/expression-evaluator.ts";
 import {
   compareRdfTerms,
@@ -59,6 +60,13 @@ export interface SparqlEvaluatorOptions {
    * WazooSparqlEngineOptions.functions.
    */
   functions?: IriFunctionMap;
+
+  /**
+   * estimator supplies the BGP join-cost estimator (see
+   * JoinCostEstimator); defaults to the baseline greedy formula. Only
+   * affects join order, never results.
+   */
+  estimator?: JoinCostEstimator;
 }
 
 /**
@@ -99,6 +107,7 @@ export class SparqlEvaluator {
     this.bgpEvaluator = new BgpEvaluator(store, {
       reorderPatterns: options.reorderPatterns,
       functions: options.functions,
+      estimator: options.estimator,
     });
   }
 

--- a/src/evaluator/update-evaluator.ts
+++ b/src/evaluator/update-evaluator.ts
@@ -23,6 +23,7 @@ import { sameRdfTerm, sparqlTermToRdfTerm, termKey } from "@/term/mod.ts";
 import { expandReifiedTriples } from "@/evaluator/reified.ts";
 import { DataFactory } from "@/term/mod.ts";
 import { parseTurtleQuads } from "@/parser/turtle-parser.ts";
+import type { JoinCostEstimator } from "@/planner/join-cost-estimator.ts";
 
 const { blankNode, quad, defaultGraph } = DataFactory;
 
@@ -57,6 +58,13 @@ export interface UpdateEvaluatorOptions {
    * the WHERE evaluation of update forms. Defaults to true.
    */
   reorderPatterns?: boolean;
+
+  /**
+   * estimator supplies the BGP join-cost estimator (see
+   * JoinCostEstimator); defaults to the baseline greedy formula. Only
+   * affects join order, never results.
+   */
+  estimator?: JoinCostEstimator;
 }
 
 type GraphRef = {
@@ -102,6 +110,7 @@ export class UpdateEvaluator {
   public constructor(private readonly options: UpdateEvaluatorOptions) {
     this.bgpEvaluator = new BgpEvaluator(options.store, {
       reorderPatterns: options.reorderPatterns,
+      estimator: options.estimator,
     });
   }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -18,6 +18,8 @@ export type {
   IriFunction,
   IriFunctionMap,
 } from "@/evaluator/expression-evaluator.ts";
+export { BaselineJoinCostEstimator } from "@/planner/join-cost-estimator.ts";
+export type { JoinCostEstimator } from "@/planner/join-cost-estimator.ts";
 
 export { MemoryStore, MemoryStream } from "@/store/memory-store.ts";
 export { DataFactory, dataFactory } from "@/term/mod.ts";

--- a/src/planner/join-cost-estimator.test.ts
+++ b/src/planner/join-cost-estimator.test.ts
@@ -1,0 +1,211 @@
+import { assertEquals } from "@std/assert";
+import type * as rdfjs from "@rdfjs/types";
+import { DataFactory } from "@/term/mod.ts";
+import type { ScanEntry, TermBinding } from "@/evaluator/join.ts";
+import { BaselineJoinCostEstimator } from "@/planner/join-cost-estimator.ts";
+import { MemoryStore as Store } from "@/store/memory-store.ts";
+import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
+import type { JoinCostEstimator } from "@/planner/join-cost-estimator.ts";
+import type { Term as SparqlTerm } from "@/parser/sparql-parser.ts";
+
+const { namedNode, variable, quad } = DataFactory;
+
+/** candidateQuads returns an array of n distinct candidate quads. */
+function candidateQuads(count: number): rdfjs.Quad[] {
+  const quads: rdfjs.Quad[] = [];
+  for (let index = 0; index < count; index++) {
+    quads.push(
+      quad(
+        namedNode(`http://example.org/s${index}`),
+        namedNode(`http://example.org/p`),
+        namedNode(`http://example.org/o${index}`),
+      ),
+    );
+  }
+  return quads;
+}
+
+/** entry builds a ScanEntry for the given pattern positions and candidates. */
+function entry(
+  subject: SparqlTerm,
+  predicate: SparqlTerm,
+  object: SparqlTerm,
+  candidates: rdfjs.Quad[],
+): ScanEntry {
+  return { subject, predicate, object, candidates };
+}
+
+const patternVar = variable("x");
+const otherVar = variable("y");
+const constant = namedNode("http://example.org/constant");
+const baseline = new BaselineJoinCostEstimator();
+
+Deno.test("BaselineJoinCostEstimator - empty bindings cost zero", () => {
+  const cost = baseline.estimateJoinCost(
+    entry(patternVar, constant, otherVar, candidateQuads(100)),
+    [],
+  );
+  assertEquals(cost, 0);
+});
+
+Deno.test(
+  "BaselineJoinCostEstimator - no bound pattern variable iterates every candidate",
+  () => {
+    // Both pattern variables are unbound in every binding.
+    const bindings: TermBinding[] = [{ a: namedNode("http://example.org/a") }];
+    const cost = baseline.estimateJoinCost(
+      entry(patternVar, constant, otherVar, candidateQuads(50)),
+      bindings,
+    );
+    assertEquals(cost, 50);
+  },
+);
+
+Deno.test(
+  "BaselineJoinCostEstimator - bound variable costs bindings times the average bucket",
+  () => {
+    // One bound pattern variable with 2 distinct values across 4 bindings:
+    // bucket = candidates / distinct = 100 / 2 = 50.
+    const bindings: TermBinding[] = [
+      { x: namedNode("http://example.org/v1") },
+      { x: namedNode("http://example.org/v2") },
+      { x: namedNode("http://example.org/v1") },
+      { x: namedNode("http://example.org/v2") },
+    ];
+    const cost = baseline.estimateJoinCost(
+      entry(patternVar, constant, otherVar, candidateQuads(100)),
+      bindings,
+    );
+    assertEquals(cost, 4 * 50);
+  },
+);
+
+Deno.test(
+  "BaselineJoinCostEstimator - duplicate bound values widen the bucket",
+  () => {
+    // The same 4 bindings all carrying one distinct value: bucket = 100 / 1.
+    const bindings: TermBinding[] = Array.from({ length: 4 }, () => ({
+      x: namedNode("http://example.org/v1"),
+    }));
+    const cost = baseline.estimateJoinCost(
+      entry(patternVar, constant, otherVar, candidateQuads(100)),
+      bindings,
+    );
+    assertEquals(cost, 4 * 100);
+  },
+);
+
+Deno.test(
+  "BaselineJoinCostEstimator - the fewest-distinct bound variable bounds the cost",
+  () => {
+    // Both pattern variables are bound; ?x has 2 distinct values, ?y has 4,
+    // so ?x (fewer distinct, wider bucket) bounds the estimate.
+    const bindings: TermBinding[] = [
+      {
+        x: namedNode("http://example.org/x1"),
+        y: namedNode("http://example.org/y1"),
+      },
+      {
+        x: namedNode("http://example.org/x2"),
+        y: namedNode("http://example.org/y2"),
+      },
+      {
+        x: namedNode("http://example.org/x1"),
+        y: namedNode("http://example.org/y3"),
+      },
+      {
+        x: namedNode("http://example.org/x2"),
+        y: namedNode("http://example.org/y4"),
+      },
+    ];
+    const cost = baseline.estimateJoinCost(
+      entry(patternVar, constant, otherVar, candidateQuads(100)),
+      bindings,
+    );
+    assertEquals(cost, 4 * 50);
+  },
+);
+
+Deno.test(
+  "BaselineJoinCostEstimator - fully bound constants never count as variables",
+  () => {
+    // Every pattern position is a constant: no bound pattern variable to
+    // probe, so every binding iterates all candidates.
+    const bindings: TermBinding[] = [{ a: namedNode("http://example.org/a") }];
+    const cost = baseline.estimateJoinCost(
+      entry(constant, constant, constant, candidateQuads(7)),
+      bindings,
+    );
+    assertEquals(cost, 7);
+  },
+);
+
+Deno.test(
+  "WazooSparqlEngine - injected estimator drives reordering without changing results",
+  async () => {
+    const store = new Store();
+    store.addQuad(
+      quad(
+        namedNode("http://example.org/s1"),
+        namedNode("http://example.org/p"),
+        namedNode("http://example.org/o1"),
+      ),
+    );
+    store.addQuad(
+      quad(
+        namedNode("http://example.org/s2"),
+        namedNode("http://example.org/p"),
+        namedNode("http://example.org/o2"),
+      ),
+    );
+    const query =
+      "SELECT ?s ?o WHERE { ?s <http://example.org/p> ?o . ?s ?p ?o }";
+
+    const calls: number[] = [];
+    const estimator: JoinCostEstimator = {
+      estimateJoinCost(scan, bindings): number {
+        calls.push(bindings.length);
+        return scan.candidates.length;
+      },
+    };
+    const engine = new WazooSparqlEngine({ store, estimator });
+    const result = await engine.execute({ query });
+    assertEquals(result.kind, "select");
+    // The greedy loop consults the estimator once per remaining pattern.
+    assertEquals(calls.length >= 2, true);
+
+    const expected = await new WazooSparqlEngine({ store }).execute({ query });
+    assertEquals(result, expected);
+  },
+);
+
+Deno.test(
+  "WazooSparqlEngine - reorderPatterns:false never consults the estimator",
+  async () => {
+    const store = new Store();
+    store.addQuad(
+      quad(
+        namedNode("http://example.org/s1"),
+        namedNode("http://example.org/p"),
+        namedNode("http://example.org/o1"),
+      ),
+    );
+    let calls = 0;
+    const estimator: JoinCostEstimator = {
+      estimateJoinCost(): number {
+        calls += 1;
+        return 0;
+      },
+    };
+    const engine = new WazooSparqlEngine({
+      store,
+      estimator,
+      reorderPatterns: false,
+    });
+    const result = await engine.execute({
+      query: "SELECT ?s ?o WHERE { ?s <http://example.org/p> ?o . ?s ?p ?o }",
+    });
+    assertEquals(result.kind, "select");
+    assertEquals(calls, 0);
+  },
+);

--- a/src/planner/join-cost-estimator.ts
+++ b/src/planner/join-cost-estimator.ts
@@ -1,0 +1,81 @@
+import type { ScanEntry, TermBinding } from "@/evaluator/join.ts";
+import { termKey } from "@/term/mod.ts";
+
+/**
+ * JoinCostEstimator estimates the cost of joining one BGP triple pattern
+ * against the current solution bindings. The estimate drives the greedy
+ * join-order selection in BgpEvaluator.evaluateWithReordering — it must
+ * never change results, only the order in which patterns are joined
+ * (SPARQL 1.1 §18.2.2: joins commute, so every order yields the same
+ * solution multiset).
+ *
+ * Contract: an estimator receives the pattern's ScanEntry — whose
+ * candidates array holds the pattern's true store cardinality from the
+ * up-front scan in evaluateWithReordering — plus the current bindings. It
+ * may assume nothing else: no store access, and no statistics beyond the
+ * entry's candidates (planner piece 2 adds an optional store statistics
+ * hook that feeds richer per-pattern stats behind this same seam). The
+ * estimator must be pure and deterministic: the same entry and bindings
+ * always produce the same cost, and calling it must have no side effects.
+ */
+export interface JoinCostEstimator {
+  /**
+   * estimateJoinCost returns the estimated number of quad iterations
+   * joining the given pattern against the current bindings will perform.
+   * Lower is cheaper. A cost of 0 (for example, no bindings left to join)
+   * is valid.
+   */
+  estimateJoinCost(entry: ScanEntry, bindings: TermBinding[]): number;
+}
+
+/**
+ * BaselineJoinCostEstimator is the default JoinCostEstimator: the greedy
+ * formula the engine shipped before the estimator seam existed, preserved
+ * behavior-identical. Bindings that bind no pattern variable iterate every
+ * candidate quad; bindings that bind a pattern variable probe the
+ * positional index, costing roughly the average bucket size for the bound
+ * variable with the fewest distinct bound values (candidate count divided
+ * by that variable's distinct count) — a conservative per-binding bound.
+ */
+export class BaselineJoinCostEstimator implements JoinCostEstimator {
+  /**
+   * estimateJoinCost estimates the number of quad iterations joining the
+   * given pattern against the current bindings will perform.
+   */
+  public estimateJoinCost(
+    entry: ScanEntry,
+    bindings: TermBinding[],
+  ): number {
+    if (bindings.length === 0) {
+      return 0;
+    }
+    let mostSelectiveDistinct = Number.POSITIVE_INFINITY;
+    for (const term of [entry.subject, entry.predicate, entry.object]) {
+      if (term.termType !== "Variable") {
+        continue;
+      }
+      const distinct = new Set<string>();
+      for (const binding of bindings) {
+        const value = binding[term.value];
+        if (value !== undefined) {
+          distinct.add(termKey(value));
+        }
+      }
+      if (distinct.size === 0) {
+        continue;
+      }
+      if (distinct.size < mostSelectiveDistinct) {
+        mostSelectiveDistinct = distinct.size;
+      }
+    }
+    if (mostSelectiveDistinct === Number.POSITIVE_INFINITY) {
+      // No bound pattern variable: every binding iterates all candidates.
+      return bindings.length * entry.candidates.length;
+    }
+    const averageBucket = Math.max(
+      1,
+      entry.candidates.length / mostSelectiveDistinct,
+    );
+    return bindings.length * averageBucket;
+  }
+}

--- a/src/wazoo-sparql-engine.ts
+++ b/src/wazoo-sparql-engine.ts
@@ -9,6 +9,7 @@ import type { SparqlQuery } from "@/parser/ast.ts";
 import { SparqlEvaluator } from "@/evaluator/sparql-evaluator.ts";
 import { UpdateEvaluator } from "@/evaluator/update-evaluator.ts";
 import type { IriFunctionMap } from "@/evaluator/expression-evaluator.ts";
+import type { JoinCostEstimator } from "@/planner/join-cost-estimator.ts";
 
 export type {
   IriFunction,
@@ -65,6 +66,15 @@ export interface WazooSparqlEngineOptions {
    * "Unsupported SPARQL expression: functionCall".
    */
   functions?: IriFunctionMap;
+
+  /**
+   * estimator supplies the BGP join-cost estimator (see JoinCostEstimator);
+   * defaults to the baseline greedy formula. The estimate affects only
+   * join order — never results (SPARQL 1.1 §18.2.2). Planner pieces 2–3
+   * (#129/#130) plug the statistics source and join-order search behind
+   * this seam.
+   */
+  estimator?: JoinCostEstimator;
 }
 
 /**
@@ -90,11 +100,13 @@ export class WazooSparqlEngine implements SparqlEngineInterface {
     this.evaluator = new SparqlEvaluator(options.store, {
       reorderPatterns: options.reorderPatterns,
       functions: options.functions,
+      estimator: options.estimator,
     });
     this.updateEvaluator = new UpdateEvaluator({
       store: options.store,
       createTransaction: options.createTransaction,
       reorderPatterns: options.reorderPatterns,
+      estimator: options.estimator,
     });
   }
 


### PR DESCRIPTION
Closes #128 — planner piece 1 of 3 (splits #75).

## What

Land the **estimator surface**: a documented `JoinCostEstimator` contract plus
`BaselineJoinCostEstimator` holding the shipped greedy formula
behavior-identical. The estimator is injectable via
`WazooSparqlEngineOptions.estimator` and threaded down to every
`BgpEvaluator` (select, update, FROM-dataset, and subquery paths) behind the
existing `reorderPatterns` seam.

Contract documented in `docs/03-api-contracts.md` (§5 Join-cost estimator) and
`docs/02-architecture.md` (Stage 3): the estimator receives the pattern's
`ScanEntry` (true store cardinality from the up-front scan) and current
bindings, and nothing else — pure, deterministic, and **never changing
results, only join order** (SPARQL §18.2.2; the W3C differential gate is the
guard).

## Checks

- `deno task ci` green (421 passed; fmt/lint/check/bench:check + all W3C
  gates)
- `deno task test:w3c` green (345/345)
- 8 new unit tests: baseline formula (bound/unbound, empty bindings,
  duplicate values, fewest-distinct bounding, all-constant), seam injection
  (results unchanged vs default), `reorderPatterns: false` skips the
  estimator

Pieces 2–3 (#129 statistics source, #130 join-order search) plug in behind
this seam.