### PR TITLE
feat: honor baseIri on SparqlRequest (Fork B — directive wins)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,6 +50,7 @@ transaction objects.
 The interface is intentionally duplicated in both packages under an
 identical-spec policy: the two copies must stay identical. Behavioral deltas
 today: `ComunicaSparqlEngine` enforces `timeoutMs` and accepts a request-level
-`baseIri`, while the wazoo engine derives the base IRI from the query's `BASE`
-directive and does not yet enforce a timeout. Keep these differences in mind
-when swapping engines.
+`baseIri`; the wazoo engine now also honors request `baseIri` (the query's
+`BASE` directive wins when both are present — decision #117, Fork B) and does
+not yet enforce a timeout (tracked in #122). Keep these differences in mind when
+swapping engines.

--- a/docs/03-api-contracts.md
+++ b/docs/03-api-contracts.md
@@ -20,14 +20,19 @@ export interface SparqlEngineInterface {
 
 export interface SparqlRequest {
   query: string; // raw SPARQL query or update string
-  baseIri?: string; // accepted; wazoo engine derives base from BASE directive
-  timeoutMs?: number; // accepted; not yet enforced by the wazoo engine
+  baseIri?: string; // base for relative IRIs; the query's BASE directive wins (Fork B, #117)
+  timeoutMs?: number; // accepted; not yet enforced by the wazoo engine (tracked in #122)
 }
 ```
 
 `execute()` is **the** entry point. It parses the request, dispatches queries to
 `SparqlEvaluator.evaluateQuery()` and updates to
 `UpdateEvaluator.executeUpdate()`, and returns a discriminated union:
+
+`baseIri` is the base for relative IRIs (`IRI()`/`URI()`, relative `PREFIX`
+IRIs, and relative `LOAD` sources). The query's own `BASE` directive wins when
+both are present (decision #117, Fork B — the directive is authoritative per
+SPARQL §4.2, matching Comunica).
 
 ```typescript
 export type SparqlResponse =

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -132,9 +132,15 @@ export class BgpEvaluator {
 
   /**
    * evaluateBgp evaluates a WHERE-clause pattern list from the empty
-   * binding, producing all solution bindings (as RDF/JS terms).
+   * binding, producing all solution bindings (as RDF/JS terms). The
+   * optional baseIri is the effective query base (the BASE directive, or
+   * the request-level base when the query has no directive) threaded into
+   * every expression context so IRI()/relative IRIs resolve uniformly.
    */
-  public async evaluateBgp(patterns: Pattern[]): Promise<TermBinding[]> {
+  public async evaluateBgp(
+    patterns: Pattern[],
+    baseIri?: string,
+  ): Promise<TermBinding[]> {
     // EXISTS support: when any pattern in the tree uses EXISTS/NOT EXISTS,
     // the store's quads are drained once into a synchronous index that the
     // injected hooks probe (the decided sync-hook contract). The snapshot is
@@ -152,7 +158,7 @@ export class BgpEvaluator {
     const defaultScope = this.store instanceof GraphScopedStore
       ? this.store
       : new GraphScopedStore(this.store, defaultGraph());
-    return await this.evaluateGroup(patterns, [{}], defaultScope);
+    return await this.evaluateGroup(patterns, [{}], defaultScope, baseIri);
   }
 
   /**
@@ -228,6 +234,7 @@ export class BgpEvaluator {
     pattern: Pattern,
     solution: TermBinding,
     graph?: rdfjs.Term,
+    baseIri?: string,
   ): boolean {
     // Capture the current snapshot once at entry, so a concurrent call's
     // rebuild (issue #72) cannot swap it while this probe is in flight.
@@ -252,6 +259,7 @@ export class BgpEvaluator {
       scopeGraph,
       index,
       quads,
+      baseIri,
     );
   }
 
@@ -269,6 +277,7 @@ export class BgpEvaluator {
     graph: rdfjs.Term,
     index: QuadIndex,
     quads: rdfjs.Quad[],
+    baseIri?: string,
   ): boolean {
     const patterns = pattern.type === "group" ? pattern.patterns : [pattern];
     return this.evaluateExistsGroup(
@@ -278,6 +287,7 @@ export class BgpEvaluator {
       graph,
       index,
       quads,
+      baseIri,
     ).length > 0;
   }
 
@@ -297,6 +307,7 @@ export class BgpEvaluator {
     graph: rdfjs.Term,
     index: QuadIndex,
     quads: rdfjs.Quad[],
+    baseIri?: string,
   ): TermBinding[] {
     // The synchronous EXISTS path stays eager (the decided sync-hook
     // contract): every pattern form returns a materialized array, including
@@ -310,6 +321,7 @@ export class BgpEvaluator {
         graph,
         index,
         quads,
+        baseIri,
       );
     }
     return result;
@@ -322,6 +334,7 @@ export class BgpEvaluator {
     graph: rdfjs.Term,
     index: QuadIndex,
     quads: rdfjs.Quad[],
+    baseIri?: string,
   ): TermBinding[] {
     const context: ExpressionEvaluationContext = {
       evaluateExists: (subPattern, solution) =>
@@ -332,7 +345,9 @@ export class BgpEvaluator {
           graph,
           index,
           quads,
+          baseIri,
         ),
+      baseIri,
     };
     switch (pattern.type) {
       case "bgp": {
@@ -411,6 +426,7 @@ export class BgpEvaluator {
             graphTerm,
             index,
             quads,
+            baseIri,
           );
         }
         if (name.termType === "Variable") {
@@ -432,6 +448,7 @@ export class BgpEvaluator {
                   boundGraph,
                   index,
                   quads,
+                  baseIri,
                 ),
               );
             } else {
@@ -446,6 +463,7 @@ export class BgpEvaluator {
                   graphTerm,
                   index,
                   quads,
+                  baseIri,
                 );
                 for (const innerBinding of inner) {
                   innerBinding[name.value] = graphTerm;
@@ -511,6 +529,7 @@ export class BgpEvaluator {
           graph,
           index,
           quads,
+          baseIri,
         );
         return [...leftJoin(
           bindings,
@@ -528,6 +547,7 @@ export class BgpEvaluator {
           graph,
           index,
           quads,
+          baseIri,
         );
         return [...minus(bindings, right)];
       }
@@ -545,6 +565,7 @@ export class BgpEvaluator {
               graph,
               index,
               quads,
+              baseIri,
             ),
           );
         }
@@ -560,6 +581,7 @@ export class BgpEvaluator {
           graph,
           index,
           quads,
+          baseIri,
         );
       case "query": {
         // A subquery inside EXISTS evaluates independently of the enclosing
@@ -580,8 +602,9 @@ export class BgpEvaluator {
               graph,
               index,
               quads,
+              baseIri,
             ),
-          baseIri: selectQuery.base,
+          baseIri: baseIri ?? selectQuery.base,
         };
         const subRaw = this.evaluateExistsGroup(
           selectQuery.where ?? [],
@@ -590,6 +613,7 @@ export class BgpEvaluator {
           graph,
           index,
           quads,
+          baseIri,
         );
         // The synchronous EXISTS index is guaranteed prepared here — this
         // code only runs from evaluateExists, which guards on it — so
@@ -617,13 +641,15 @@ export class BgpEvaluator {
    */
   private existsContext(
     store: rdfjs.Source<rdfjs.Quad>,
+    baseIri?: string,
   ): ExpressionEvaluationContext {
     const graph = store instanceof GraphScopedStore
       ? store.graph
       : defaultGraph();
     return {
       evaluateExists: (pattern, solution) =>
-        this.evaluateExists(pattern, solution, graph),
+        this.evaluateExists(pattern, solution, graph, baseIri),
+      baseIri,
     };
   }
 
@@ -638,6 +664,7 @@ export class BgpEvaluator {
   private scopedExistsContext(
     store: rdfjs.Source<rdfjs.Quad>,
     snapshot: ExistsSnapshot | null,
+    baseIri?: string,
   ): ExpressionEvaluationContext {
     if (snapshot === null) {
       throw new Error(
@@ -662,7 +689,9 @@ export class BgpEvaluator {
           graph,
           index,
           quads,
+          baseIri,
         ),
+      baseIri,
     };
   }
 
@@ -724,6 +753,7 @@ export class BgpEvaluator {
     patterns: Pattern[],
     bindings: TermBinding[],
     store: rdfjs.Source<rdfjs.Quad>,
+    baseIri?: string,
   ): Promise<TermBinding[]> {
     // Resolve the EXISTS snapshot once for this group and thread it down, so
     // every hook in the group shares one snapshot reference (issue #72). The
@@ -742,7 +772,13 @@ export class BgpEvaluator {
     }
     let result: Iterable<TermBinding> = bindings;
     for (const pattern of nonFilters) {
-      result = await this.evaluatePattern(pattern, result, store, snapshot);
+      result = await this.evaluatePattern(
+        pattern,
+        result,
+        store,
+        snapshot,
+        baseIri,
+      );
     }
     for (const filterPattern of filters) {
       result = await this.evaluatePattern(
@@ -750,6 +786,7 @@ export class BgpEvaluator {
         result,
         store,
         snapshot,
+        baseIri,
       );
     }
     // Materialize exactly once at the group boundary (an array result — the
@@ -767,14 +804,15 @@ export class BgpEvaluator {
     bindings: TermBinding[] | Iterable<TermBinding>,
     store: rdfjs.Source<rdfjs.Quad>,
     snapshot: ExistsSnapshot | null,
+    baseIri?: string,
   ): Promise<Iterable<TermBinding>> {
     switch (pattern.type) {
       case "bgp":
         return await this.joinBgp(pattern.triples, bindings, store, snapshot);
       case "filter": {
         const context = expressionContainsExists(pattern.expression)
-          ? this.scopedExistsContext(store, snapshot)
-          : this.existsContext(store);
+          ? this.scopedExistsContext(store, snapshot, baseIri)
+          : this.existsContext(store, baseIri);
         return filterBindings(
           bindings,
           (binding) =>
@@ -799,10 +837,15 @@ export class BgpEvaluator {
             innerPatterns.push(inner);
           }
         }
-        const right = await this.evaluateGroup(innerPatterns, [{}], store);
+        const right = await this.evaluateGroup(
+          innerPatterns,
+          [{}],
+          store,
+          baseIri,
+        );
         const context = filters.some(expressionContainsExists)
-          ? this.scopedExistsContext(store, snapshot)
-          : this.existsContext(store);
+          ? this.scopedExistsContext(store, snapshot, baseIri)
+          : this.existsContext(store, baseIri);
         return leftJoin(
           bindings,
           right,
@@ -812,7 +855,12 @@ export class BgpEvaluator {
         );
       }
       case "minus": {
-        const right = await this.evaluateGroup(pattern.patterns, [{}], store);
+        const right = await this.evaluateGroup(
+          pattern.patterns,
+          [{}],
+          store,
+          baseIri,
+        );
         return minus(bindings, right);
       }
       case "union": {
@@ -821,7 +869,9 @@ export class BgpEvaluator {
         // the incoming solutions — matching Join(P, Union(Q1, Q2)).
         const branchResults: TermBinding[][] = [];
         for (const branch of pattern.patterns) {
-          branchResults.push(await this.evaluateGroup([branch], [{}], store));
+          branchResults.push(
+            await this.evaluateGroup([branch], [{}], store, baseIri),
+          );
         }
         return innerJoin(bindings, branchResults.flat());
       }
@@ -848,8 +898,8 @@ export class BgpEvaluator {
         // evaluation error or a variable already bound (from an outer
         // scope) leaves the solution unchanged.
         const context = expressionContainsExists(pattern.expression)
-          ? this.scopedExistsContext(store, snapshot)
-          : this.existsContext(store);
+          ? this.scopedExistsContext(store, snapshot, baseIri)
+          : this.existsContext(store, baseIri);
         return mapBindings(bindings, (binding) => {
           const value = this.expressionEvaluator.evaluate(
             pattern.expression,
@@ -898,6 +948,7 @@ export class BgpEvaluator {
             innerPatterns,
             [{}],
             scopedStore,
+            baseIri,
           );
           for (const binding of inner) {
             if (graphName.termType === "Variable") {
@@ -918,13 +969,19 @@ export class BgpEvaluator {
           pattern.patterns,
           [{}],
           store,
+          baseIri,
         );
         return innerJoin(bindings, groupResult);
       }
       case "service": {
         const silent = Boolean(pattern.silent);
         try {
-          const inner = await this.evaluateGroup(pattern.patterns, [{}], store);
+          const inner = await this.evaluateGroup(
+            pattern.patterns,
+            [{}],
+            store,
+            baseIri,
+          );
           return innerJoin(bindings, inner);
         } catch (err) {
           if (silent) return bindings;
@@ -941,6 +998,7 @@ export class BgpEvaluator {
         });
         const subResults = await subEvaluator.evaluateSelectTermBindings(
           pattern as unknown as import("@/parser/sparql-parser.ts").SelectQuery,
+          baseIri,
         );
         return innerJoin(bindings, subResults);
       }

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -161,9 +161,13 @@ export class SparqlEvaluator {
 
   public async evaluateSelectTermBindings(
     query: SelectQuery,
+    baseIri?: string,
   ): Promise<TermBinding[]> {
     const evaluator = await this.bgpEvaluatorFor(query.from);
-    const rawBindings = await evaluator.evaluateBgp(query.where || []);
+    const rawBindings = await evaluator.evaluateBgp(
+      query.where || [],
+      baseIri,
+    );
     // Projection / HAVING / ORDER BY expressions share one default-graph
     // scoped candidate set across every solution (once per query) instead of
     // re-filtering the snapshot per expression evaluation. Only queries that
@@ -172,14 +176,20 @@ export class SparqlEvaluator {
     const pipelineSnapshot = needsPipelineExists
       ? await evaluator.prepareExistsIndex()
       : null;
+    const effectiveBase = baseIri ?? query.base;
     const existsContext: ExpressionEvaluationContext = {
       ...(needsPipelineExists
         ? evaluator.pipelineExistsContext(pipelineSnapshot!)
         : {
           evaluateExists: (pattern: Pattern, solution: TermBinding) =>
-            evaluator.evaluateExists(pattern, solution),
+            evaluator.evaluateExists(
+              pattern,
+              solution,
+              undefined,
+              effectiveBase,
+            ),
         }),
-      baseIri: query.base,
+      baseIri: effectiveBase,
     };
     // The post-BGP SELECT pipeline (VALUES, grouping/aggregates, HAVING,
     // ORDER BY, projection, DISTINCT/REDUCED, OFFSET/LIMIT) is shared with
@@ -196,7 +206,10 @@ export class SparqlEvaluator {
   private async evaluateSelect(
     query: SelectQuery,
   ): Promise<SparqlSelectResults> {
-    const termBindings = await this.evaluateSelectTermBindings(query);
+    const termBindings = await this.evaluateSelectTermBindings(
+      query,
+      query.base,
+    );
     const projected: SparqlBinding[] = termBindings.map((b) => {
       const sb: SparqlBinding = {};
       for (const k of Object.keys(b)) {
@@ -333,7 +346,7 @@ export class SparqlEvaluator {
 
   private async evaluateAsk(query: AskQuery): Promise<SparqlAskResults> {
     const bindings = await (await this.bgpEvaluatorFor(query.from))
-      .evaluateBgp(query.where || []);
+      .evaluateBgp(query.where || [], query.base);
     return {
       head: { link: null },
       boolean: bindings.length > 0,
@@ -375,7 +388,10 @@ export class SparqlEvaluator {
     query: DescribeQuery,
   ): Promise<SparqlConstructResults> {
     const bindings = query.where?.length
-      ? await (await this.bgpEvaluatorFor(query.from)).evaluateBgp(query.where)
+      ? await (await this.bgpEvaluatorFor(query.from)).evaluateBgp(
+        query.where,
+        query.base,
+      )
       : [];
 
     const resources = new Set<rdfjs.Term>();
@@ -430,7 +446,7 @@ export class SparqlEvaluator {
       return { quads: [] };
     }
     const bindings = await (await this.bgpEvaluatorFor(query.from))
-      .evaluateBgp(query.where || []);
+      .evaluateBgp(query.where || [], query.base);
 
     // Reified-triple templates (`<< s p o >>`, annotation `{| ... |}`)
     // expand into a reifier blank node joined to its `rdf:reifies` triple

--- a/src/evaluator/update-evaluator.ts
+++ b/src/evaluator/update-evaluator.ts
@@ -106,9 +106,16 @@ export class UpdateEvaluator {
   }
 
   /**
-   * executeUpdate applies a parsed SPARQL update request to the store.
+   * executeUpdate applies a parsed SPARQL update request to the store. The
+   * optional baseIri is the request-level base (Fork B, recorded on #117):
+   * it resolves relative LOAD source IRIs and is the base for relative IRIs
+   * inside the loaded document, while a BASE directive in the query wins
+   * over it.
    */
-  public async executeUpdate(ast: UpdateQuery): Promise<void> {
+  public async executeUpdate(
+    ast: UpdateQuery,
+    baseIri?: string,
+  ): Promise<void> {
     const transaction = this.options.createTransaction?.();
     if (!transaction) {
       const writeStore = this.options.store as QuadWriteStore;
@@ -126,6 +133,7 @@ export class UpdateEvaluator {
           operation,
           (item) => writeStore.addQuad(item),
           (item) => writeStore.removeQuad(item),
+          baseIri,
         );
       }
       return;
@@ -137,6 +145,7 @@ export class UpdateEvaluator {
           operation,
           (item) => transaction.add(item),
           (item) => transaction.delete(item),
+          baseIri,
         );
       }
       await transaction.commit();
@@ -153,6 +162,7 @@ export class UpdateEvaluator {
     operation: UpdateOperation,
     add: (item: rdfjs.Quad) => unknown,
     remove: (item: rdfjs.Quad) => unknown,
+    baseIri?: string,
   ): Promise<void> {
     const op = operation as unknown as Record<string, unknown>;
     const opType = (op.updateType || op.type || op.action) as
@@ -192,6 +202,7 @@ export class UpdateEvaluator {
           operation as Extract<UpdateOperation, { updateType: "insertdelete" }>,
           add,
           remove,
+          baseIri,
         );
         return;
       }
@@ -199,6 +210,7 @@ export class UpdateEvaluator {
         await this.applyDeleteWhere(
           operation as Extract<UpdateOperation, { updateType: "deletewhere" }>,
           remove,
+          baseIri,
         );
         return;
       }
@@ -243,7 +255,7 @@ export class UpdateEvaluator {
         return;
       }
       case "load": {
-        await this.applyLoad(op, add);
+        await this.applyLoad(op, add, baseIri);
         return;
       }
       default:
@@ -348,12 +360,21 @@ export class UpdateEvaluator {
   private async applyLoad(
     op: Record<string, unknown>,
     add: (item: rdfjs.Quad) => unknown,
+    baseIri?: string,
   ): Promise<void> {
     const silent = Boolean(op.silent);
-    const sourceIri = typeof op.source === "string"
+    let sourceIri = typeof op.source === "string"
       ? op.source
       : (op.source as { value?: string })?.value;
     if (!sourceIri) return;
+
+    // A relative LOAD source resolves against the request-level base (Fork
+    // B, #117); the resolved document IRI is also the base for relative
+    // IRIs inside the loaded document. Absolute sources pass through.
+    const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(sourceIri);
+    if (!hasScheme && baseIri) {
+      sourceIri = new URL(sourceIri, baseIri).href;
+    }
 
     try {
       let text = "";
@@ -367,9 +388,12 @@ export class UpdateEvaluator {
         }
         text = await res.text();
       } else {
-        const cleanPath = sourceIri.startsWith("file://")
+        let cleanPath = sourceIri.startsWith("file://")
           ? sourceIri.slice(7)
           : sourceIri;
+        // Normalize the file-URL form a URL resolution can produce on
+        // Windows (file:///C:/x) back to a readable drive path (C:/x).
+        cleanPath = cleanPath.replace(/^\/([A-Za-z]:)/, "$1");
         text = await Deno.readTextFile(cleanPath);
       }
 
@@ -484,6 +508,7 @@ export class UpdateEvaluator {
     operation: InsertDeleteOperation,
     add: (item: rdfjs.Quad) => unknown,
     remove: (item: rdfjs.Quad) => unknown,
+    baseIri?: string,
   ): Promise<void> {
     const withGraph = operation.graph
       ? sparqlTermToRdfTerm(operation.graph)
@@ -508,7 +533,10 @@ export class UpdateEvaluator {
       evaluator = this.bgpEvaluator.forStore(scopedStore);
     }
 
-    const bindings = await evaluator.evaluateBgp(operation.where ?? []);
+    const bindings = await evaluator.evaluateBgp(
+      operation.where ?? [],
+      baseIri,
+    );
 
     for (const pattern of operation.delete ?? []) {
       await this.deleteMatches(pattern, bindings, remove, withGraph);
@@ -537,9 +565,13 @@ export class UpdateEvaluator {
   private async applyDeleteWhere(
     operation: InsertDeleteOperation,
     remove: (item: rdfjs.Quad) => unknown,
+    baseIri?: string,
   ): Promise<void> {
     const wherePatterns = (operation.delete ?? []) as Pattern[];
-    const bindings = await this.bgpEvaluator.evaluateBgp(wherePatterns);
+    const bindings = await this.bgpEvaluator.evaluateBgp(
+      wherePatterns,
+      baseIri,
+    );
     for (const pattern of operation.delete ?? []) {
       await this.deleteMatches(pattern, bindings, remove);
     }

--- a/src/parser/ast.ts
+++ b/src/parser/ast.ts
@@ -282,6 +282,12 @@ export type UpdateOperation =
 export interface UpdateQuery {
   type: "update";
   prefixes?: Record<string, string>;
+  /**
+   * base is the effective base IRI the grammar recorded at parse time (the
+   * query's BASE directive, or the parser's base option when there is no
+   * directive). Update ASTs carry it like query ASTs.
+   */
+  base?: string;
   updates: UpdateOperation[];
 }
 

--- a/src/parser/mod.ts
+++ b/src/parser/mod.ts
@@ -75,7 +75,9 @@ export interface SparqlParserOptions {
  * during every parse.
  */
 export class Parser {
-  private readonly parser: { parse(input: string): SparqlQuery };
+  private readonly parser: {
+    parse(input: string, options?: { baseIRI?: string }): SparqlQuery;
+  };
 
   public constructor(options: SparqlParserOptions = {}) {
     const prefixes = options.prefixes ?? {};
@@ -93,8 +95,15 @@ export class Parser {
       ...prefixes,
     };
 
-    generated.parse = function (input: string): SparqlQuery {
-      GeneratedParser.base = baseIRI;
+    generated.parse = function (
+      input: string,
+      parseOptions: { baseIRI?: string } = {},
+    ): SparqlQuery {
+      // The per-parse base overrides the construction-time base, and the
+      // grammar's BASE directive action in turn overrides both (resolving
+      // the directive against the current base) — so the directive always
+      // wins and the option is the fallback, matching sparqljs upstream.
+      GeneratedParser.base = parseOptions.baseIRI ?? baseIRI;
       GeneratedParser.prefixes = Object.create(prefixTable);
       GeneratedParser.factory = DataFactory;
       GeneratedParser.sparqlStar = sparqlStar;
@@ -106,10 +115,17 @@ export class Parser {
     this.parser = generated;
   }
 
-  /** Parse a raw SPARQL query/update string into a sparqljs AST. */
-  public parse(query: string): SparqlQuery {
+  /**
+   * Parse a raw SPARQL query/update string into a sparqljs AST. The optional
+   * baseIRI is the base for relative IRIs when the query has no BASE
+   * directive (the directive wins when both are present).
+   */
+  public parse(
+    query: string,
+    options: { baseIRI?: string } = {},
+  ): SparqlQuery {
     try {
-      return this.parser.parse(query);
+      return this.parser.parse(query, options);
     } catch (error) {
       if (error instanceof SparqlSyntaxError) {
         throw error;

--- a/src/parser/sparql-parser.ts
+++ b/src/parser/sparql-parser.ts
@@ -22,9 +22,14 @@ export class SparqlParser {
   }
 
   /**
-   * parse converts a raw SPARQL string into a typed SparqlQuery AST.
+   * parse converts a raw SPARQL string into a typed SparqlQuery AST. The
+   * optional baseIri is the base for relative IRIs when the query has no
+   * BASE directive (the directive wins when both are present).
    */
-  public parse(query: string): SparqlQuery {
-    return this.parser.parse(query);
+  public parse(
+    query: string,
+    options?: { baseIRI?: string },
+  ): SparqlQuery {
+    return this.parser.parse(query, options);
   }
 }

--- a/src/wazoo-sparql-engine.test.ts
+++ b/src/wazoo-sparql-engine.test.ts
@@ -4170,3 +4170,82 @@ Deno.test("WazooSparqlEngine - bare ~ matches any reifier of the triple", async 
     assertEquals(result.data.results.bindings.length, 2);
   }
 });
+
+Deno.test("WazooSparqlEngine - request baseIri resolves relative IRI() when no BASE directive", async () => {
+  const engine = new WazooSparqlEngine({ store: new Store() });
+  const result = await engine.execute({
+    query: `SELECT ?iri WHERE { BIND(IRI("rel/path") AS ?iri) }`,
+    baseIri: "http://example.org/root/",
+  });
+  assertEquals(result.kind, "select");
+  if (result.kind === "select") {
+    assertEquals(
+      result.data.results.bindings[0].iri.value,
+      "http://example.org/root/rel/path",
+    );
+  }
+});
+
+Deno.test("WazooSparqlEngine - the query's BASE directive wins over request baseIri", async () => {
+  const engine = new WazooSparqlEngine({ store: new Store() });
+  const result = await engine.execute({
+    query: `BASE <http://directive.example/>
+SELECT ?iri WHERE { BIND(IRI("rel/path") AS ?iri) }`,
+    baseIri: "http://request.example/",
+  });
+  assertEquals(result.kind, "select");
+  if (result.kind === "select") {
+    assertEquals(
+      result.data.results.bindings[0].iri.value,
+      "http://directive.example/rel/path",
+    );
+  }
+});
+
+Deno.test("WazooSparqlEngine - query cache distinguishes baseIri", async () => {
+  // The parse depends on the base (query.base and prefix resolution), so the
+  // same query string with different request bases must not share a cache
+  // entry (issue #117).
+  const engine = new WazooSparqlEngine({ store: new Store() });
+  const query = `SELECT ?iri WHERE { BIND(IRI("rel/path") AS ?iri) }`;
+  const first = await engine.execute({
+    query,
+    baseIri: "http://first.example/",
+  });
+  const second = await engine.execute({
+    query,
+    baseIri: "http://second.example/",
+  });
+  assertEquals(first.kind, "select");
+  assertEquals(second.kind, "select");
+  if (first.kind === "select" && second.kind === "select") {
+    assertEquals(
+      first.data.results.bindings[0].iri.value,
+      "http://first.example/rel/path",
+    );
+    assertEquals(
+      second.data.results.bindings[0].iri.value,
+      "http://second.example/rel/path",
+    );
+  }
+});
+
+Deno.test("WazooSparqlEngine - relative LOAD source resolves against request baseIri", async () => {
+  const dir = await Deno.makeTempDir();
+  const turtlePath = `${dir}/data.ttl`;
+  await Deno.writeTextFile(
+    turtlePath,
+    "<http://example.org/s> <p> <http://example.org/o> .\n",
+  );
+  const store = new Store();
+  const engine = new WazooSparqlEngine({ store });
+  const result = await engine.execute({
+    query: "LOAD <data.ttl>",
+    baseIri: new URL(`file:///${dir.replace(/\\/g, "/")}/`).href,
+  });
+  assertEquals(result.kind, "void");
+  const loaded = store.getQuads(null, null, null, null);
+  assertEquals(loaded.length, 1);
+  assertEquals(loaded[0].subject.value, "http://example.org/s");
+  await Deno.remove(dir, { recursive: true });
+});

--- a/src/wazoo-sparql-engine.ts
+++ b/src/wazoo-sparql-engine.ts
@@ -101,10 +101,17 @@ export class WazooSparqlEngine implements SparqlEngineInterface {
   /** execute runs a SPARQL query/update against the configured store. */
   public async execute(request: SparqlRequest): Promise<SparqlResponse> {
     const raw = request.query;
-    let ast = this.queryCache.get(raw);
+    const baseIri = request.baseIri;
+    // The parse depends on the base (the grammar resolves prefix IRIs and
+    // records query.base from it), so the cache key carries it.
+    const cacheKey = baseIri === undefined ? raw : `${raw}\u0000${baseIri}`;
+    let ast = this.queryCache.get(cacheKey);
     if (ast === undefined) {
-      ast = this.parser.parse(raw);
-      this.queryCache.set(raw, ast);
+      ast = this.parser.parse(
+        raw,
+        baseIri === undefined ? undefined : { baseIRI: baseIri },
+      );
+      this.queryCache.set(cacheKey, ast);
       if (this.queryCache.size > WazooSparqlEngine.QUERY_CACHE_MAX) {
         const oldest = this.queryCache.keys().next().value;
         if (oldest !== undefined) {
@@ -113,7 +120,9 @@ export class WazooSparqlEngine implements SparqlEngineInterface {
       }
     }
     if (ast.type === "update") {
-      await this.updateEvaluator.executeUpdate(ast);
+      // The parser folds the request base into the AST when the query has
+      // no BASE directive, so ast.base is the effective base either way.
+      await this.updateEvaluator.executeUpdate(ast, ast.base ?? baseIri);
       return { kind: "void" };
     }
     return await this.evaluator.evaluateQuery(ast);

--- a/test/parity/parity-harness.ts
+++ b/test/parity/parity-harness.ts
@@ -35,6 +35,12 @@ export interface ParityTestCase {
    * Set this for queries with ORDER BY, where row order is part of the contract.
    */
   orderSensitive?: boolean;
+
+  /**
+   * baseIri is the request-level base IRI sent to both engines (the query's
+   * own BASE directive, when present, wins over it).
+   */
+  baseIri?: string;
 }
 
 /**
@@ -102,7 +108,15 @@ function canonicalComunicaQuadString(item: rdfjs.Quad): string {
  * statically.
  */
 function extractSelectVars(query: string): string[] | null {
-  const ast = new SparqlJsParser().parse(query);
+  // Best-effort: queries that need a base to parse (e.g. a relative PREFIX
+  // IRI without a BASE directive) yield no static projection — the caller
+  // then skips the variable-count cross-check rather than failing the case.
+  let ast;
+  try {
+    ast = new SparqlJsParser().parse(query);
+  } catch {
+    return null;
+  }
   if (ast.type !== "query" || ast.queryType !== "SELECT") {
     return null;
   }
@@ -222,8 +236,12 @@ export async function runComunicaRawSelectBindings(
   engine: QueryEngine,
   query: string,
   store: Store,
+  baseIri?: string,
 ): Promise<Array<Record<string, rdfjs.Term>>> {
-  const stream = await engine.queryBindings(query, { sources: [store] });
+  const stream = await engine.queryBindings(query, {
+    sources: [store],
+    ...(baseIri === undefined ? {} : { baseIRI: baseIri }),
+  });
   const bindings = await stream.toArray();
   return bindings.map((binding) => {
     const record: Record<string, rdfjs.Term> = {};
@@ -246,8 +264,14 @@ async function runComunicaSelect(
   engine: QueryEngine,
   query: string,
   store: Store,
+  baseIri?: string,
 ): Promise<string[]> {
-  const rawBindings = await runComunicaRawSelectBindings(engine, query, store);
+  const rawBindings = await runComunicaRawSelectBindings(
+    engine,
+    query,
+    store,
+    baseIri,
+  );
   return rawBindings.map((record) => {
     const canonical: Record<string, CanonicalTerm> = {};
     for (const name of Object.keys(record)) {
@@ -265,8 +289,12 @@ async function runComunicaConstruct(
   engine: QueryEngine,
   query: string,
   store: Store,
+  baseIri?: string,
 ): Promise<string[]> {
-  const stream = await engine.queryQuads(query, { sources: [store] });
+  const stream = await engine.queryQuads(query, {
+    sources: [store],
+    ...(baseIri === undefined ? {} : { baseIRI: baseIri }),
+  });
   const quads = await stream.toArray();
   return quads.map(canonicalComunicaQuadString);
 }
@@ -290,6 +318,7 @@ async function compareResult(
         comunicaEngine,
         testCase.query,
         comunicaStore,
+        testCase.baseIri,
       );
       const varsMismatch = compareVars(
         extractSelectVars(testCase.query),
@@ -317,7 +346,12 @@ async function compareResult(
       }
       const comunicaBoolean = await comunicaEngine.queryBoolean(
         testCase.query,
-        { sources: [comunicaStore] },
+        {
+          sources: [comunicaStore],
+          ...(testCase.baseIri === undefined
+            ? {}
+            : { baseIRI: testCase.baseIri }),
+        },
       );
       if (comunicaBoolean !== wazooResult.data.boolean) {
         return (
@@ -335,6 +369,7 @@ async function compareResult(
         comunicaEngine,
         testCase.query,
         comunicaStore,
+        testCase.baseIri,
       );
       const wazooQuads = wazooResult.data.quads.map(canonicalQuadString);
       // Issue #87 contract: the reference side is normalized to graph
@@ -355,6 +390,7 @@ async function compareResult(
         comunicaEngine,
         testCase.query,
         comunicaStore,
+        testCase.baseIri,
       );
       // DESCRIBE results are graphs (sets): Comunica's stream may repeat a
       // resource's arcs, so both sides are deduplicated before comparing.
@@ -380,7 +416,10 @@ export async function assertQueryParity(
     store: createQuadStore(testCase.quads),
   });
 
-  const wazooResult = await wazooEngine.execute({ query: testCase.query });
+  const wazooResult = await wazooEngine.execute({
+    query: testCase.query,
+    ...(testCase.baseIri === undefined ? {} : { baseIri: testCase.baseIri }),
+  });
   const mismatch = await compareResult(
     testCase,
     comunicaEngine,

--- a/test/parity/parity.test.ts
+++ b/test/parity/parity.test.ts
@@ -1422,6 +1422,47 @@ Deno.test("parity - IRI and URI function", async () => {
   });
 });
 
+Deno.test("parity - request-level baseIri resolves relative IRIs (no BASE directive)", async () => {
+  const query = `SELECT ?iri WHERE { BIND(IRI("rel/path") AS ?iri) }`;
+  await assertQueryParity({
+    name: "request baseIri resolves relative IRIs",
+    kind: "select",
+    query,
+    quads: [],
+    baseIri: "http://example.org/root/",
+  });
+});
+
+Deno.test("parity - BASE directive wins over request-level baseIri", async () => {
+  const query = `BASE <http://directive.example/>
+SELECT ?iri WHERE { BIND(IRI("rel/path") AS ?iri) }`;
+  await assertQueryParity({
+    name: "BASE directive wins over request baseIri",
+    kind: "select",
+    query,
+    quads: [],
+    baseIri: "http://request.example/",
+  });
+});
+
+Deno.test("parity - relative PREFIX IRI resolves against request baseIri", async () => {
+  const query = `PREFIX ex: <relative/ns#>
+SELECT ?s WHERE { ?s ex:p ?o }`;
+  await assertQueryParity({
+    name: "relative PREFIX resolves against request baseIri",
+    kind: "select",
+    query,
+    quads: [
+      quad(
+        namedNode("http://example.org/root/relative/ns#s1"),
+        namedNode("http://example.org/root/relative/ns#p"),
+        namedNode("http://example.org/o1"),
+      ),
+    ],
+    baseIri: "http://example.org/root/",
+  });
+});
+
 Deno.test("parity - TZ function", async () => {
   const query = `PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 SELECT ?tz1 ?tz2 WHERE {


### PR DESCRIPTION
Closes #117.

## Decision (ratified with evidence)

**Fork B** — the request-level `baseIri` is the base for relative IRIs when
the query has no `BASE` directive, and the directive wins when both are
present. Ratified by three new Comunica parity cases (all green):
1. request baseIri resolves relative `IRI()` with no directive;
2. the `BASE` directive wins over the request baseIri;
3. relative `PREFIX` IRIs resolve against the request baseIri.

This matches Comunica and SPARQL §4.2 (the directive is authoritative), and
the vendored parser already implements exactly this precedence (`query.base`
= directive, or the base option).

## Implementation

- **Parser**: `SparqlParser.parse(query, { baseIRI })` threads a per-parse
  base (previously construction-only).
- **Engine**: `execute()` passes `request.baseIri` to the parse, keys the
  query cache by base (the parse depends on it), and passes the effective
  base (`ast.base` — already folded by the parser) to the update evaluator.
- **Evaluators**: the effective base now reaches **every** expression
  context — WHERE FILTER/BIND/OPTIONAL, the EXISTS family (incl. subqueries
  inside EXISTS), SELECT pipeline projection/HAVING/ORDER BY, ASK/CONSTRUCT/
  DESCRIBE, update WHERE forms, and relative `LOAD` sources (the resolved
  document IRI becomes the TurtleParser base). This also fixes a latent gap:
  relative `IRI()` in a WHERE `BIND` did not resolve even with a `BASE`
  directive before.

## Checks

- `deno task ci` green (420 passed)
- `deno task test:w3c` green (345/345)
- 4 new engine tests (IRI resolution, directive precedence, cache-key
  correctness, relative LOAD) + 3 new Comunica parity cases
- docs updated: `docs/03-api-contracts.md`, `ARCHITECTURE.md` delta note
  now reflects that baseIri is honored