### PR TITLE
feat: graduate SqliteStore — ./sqlite subpath export, benches, crash-recovery suite (#56)

### DIFF
--- a/bench/baseline.json
+++ b/bench/baseline.json
@@ -1,4 +1,24 @@
 {
   "maxAllowedMs": 50.0,
-  "maxRegressionRatio": 0.15
+  "maxRegressionRatio": 0.15,
+  "sqlite": {
+    "notes": "Recorded baseline for the SqliteStore vs MemoryStore comparison (issue #56), measured via deno task bench:sqlite (avg over 5 fresh runs, operation-only timing) on a dev machine 2026-08-15. GitHub Actions runners are roughly 3x slower; treat absolute values as indicative, ratios as the durable-store cost story.",
+    "bulkLoad10kMemoryMs": 40.9,
+    "bulkLoad10kAutocommitMs": 16204.5,
+    "bulkLoad10kOneTransactionMs": 731.7,
+    "matchAll10kMemoryMs": 0.7,
+    "matchAll10kSqliteMs": 106.4,
+    "matchPredicate10kMemoryMs": 0.6,
+    "matchPredicate10kSqliteMs": 71.6,
+    "matchGraphScoped10kMemoryMs": 0.1,
+    "matchGraphScoped10kSqliteMs": 44.8,
+    "countQuads10kMemoryMs": 0.1,
+    "countQuads10kSqliteMs": 88.7,
+    "engineInsertData200MemoryMs": 11.6,
+    "engineInsertData200SqliteMs": 176.9,
+    "engineDeleteWhere100MemoryMs": 65.0,
+    "engineDeleteWhere100SqliteMs": 3286.7,
+    "commit1kFullMs": 52.5,
+    "commit1kNormalMs": 34.1
+  }
 }

--- a/bench/budget.ts
+++ b/bench/budget.ts
@@ -1,5 +1,6 @@
 import { DataFactory } from "@/term/mod.ts";
 import { MemoryStore as Store } from "@/store/memory-store.ts";
+import { SqliteStore } from "@/store/sqlite-store.ts";
 import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
 
 const { namedNode, literal, quad } = DataFactory;
@@ -58,6 +59,64 @@ const tests: BudgetTest[] = [
   },
 ];
 
+/**
+ * sqliteTempPath returns a fresh temp db path for one store budget run.
+ */
+function sqliteTempPath(): string {
+  const dir = Deno.makeTempDirSync();
+  return `${dir}/budget.sqlite`;
+}
+
+/**
+ * SqliteStore sanity budgets (issue #56): the durable store's transactional
+ * load and full-scan match must stay within generous ceilings. Local
+ * dev-machine baselines are ~190 ms for a 5k-quad single-transaction load
+ * and ~18 ms for a 5k match; GitHub runners are ~3x slower, so the budgets
+ * carry ~4x headroom — this gate catches catastrophic regressions (per-row
+ * fsync, per-probe index rebuild, payload decode blowups), not noise.
+ */
+const storeTests: { name: string; budgetMs: number; run: () => void }[] = [
+  {
+    name: "SqliteStore bulk load 5k (one transaction)",
+    budgetMs: 2500,
+    run: () => {
+      const store = new SqliteStore({ path: sqliteTempPath() });
+      const transaction = store.createTransaction();
+      for (let index = 0; index < 5000; index++) {
+        transaction.add(
+          quad(
+            namedNode(`http://example.org/s${index}`),
+            namedNode("http://example.org/p"),
+            literal(`v${index}`),
+          ),
+        );
+      }
+      transaction.commit();
+      store.close();
+    },
+  },
+  {
+    name: "SqliteStore full match over 5k",
+    budgetMs: 2500,
+    run: () => {
+      const store = new SqliteStore({ path: sqliteTempPath() });
+      const transaction = store.createTransaction();
+      for (let index = 0; index < 5000; index++) {
+        transaction.add(
+          quad(
+            namedNode(`http://example.org/s${index}`),
+            namedNode("http://example.org/p"),
+            literal(`v${index}`),
+          ),
+        );
+      }
+      transaction.commit();
+      [...store.match()];
+      store.close();
+    },
+  },
+];
+
 async function main() {
   const store = new Store();
   for (let i = 0; i < 100; i++) {
@@ -92,6 +151,27 @@ async function main() {
   let failed = false;
 
   console.log("Running performance regression budget checks...");
+  for (const test of storeTests) {
+    // Warm up once (pays the table/index setup), then time one run.
+    test.run();
+    const start = performance.now();
+    test.run();
+    const elapsed = performance.now() - start;
+    console.log(
+      `- ${test.name}: ${
+        elapsed.toFixed(0)
+      } ms (budget: <= ${test.budgetMs} ms)`,
+    );
+    if (elapsed > test.budgetMs) {
+      console.error(
+        `  FAIL: ${test.name} exceeded performance budget (${
+          elapsed.toFixed(0)
+        } ms > ${test.budgetMs} ms)`,
+      );
+      failed = true;
+    }
+  }
+
   for (const test of tests) {
     // Warm up first: lets V8 optimize the hot path and pays the one-time
     // EXISTS snapshot drain before the timed loop, so measurements are stable.

--- a/bench/closures-data.json
+++ b/bench/closures-data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-14T21:26:48.918Z",
+  "generatedAt": "2026-08-15T19:23:39.656Z",
   "entries": [
     {
       "name": ".",
@@ -17,6 +17,7 @@
         "src\\parser\\mod.ts",
         "src\\parser\\parser.ts",
         "src\\parser\\sparql-parser.ts",
+        "src\\parser\\syntax-error.ts",
         "src\\parser\\turtle-generated.ts",
         "src\\parser\\turtle-parser.ts",
         "src\\quad-store.ts",
@@ -35,7 +36,7 @@
         "src\\term\\ordering.ts",
         "src\\wazoo-sparql-engine.ts"
       ],
-      "bytes": 589732
+      "bytes": 618162
     },
     {
       "name": "./term",
@@ -69,13 +70,31 @@
       "bytes": 54398
     },
     {
+      "name": "./sqlite",
+      "files": [
+        "src\\store\\memory-store.ts",
+        "src\\store\\sqlite-store.ts",
+        "src\\term\\canonical.ts",
+        "src\\term\\convert.ts",
+        "src\\term\\data-factory.ts",
+        "src\\term\\datetime.ts",
+        "src\\term\\hash.ts",
+        "src\\term\\identity.ts",
+        "src\\term\\mod.ts",
+        "src\\term\\numeric.ts",
+        "src\\term\\ordering.ts"
+      ],
+      "bytes": 65825
+    },
+    {
       "name": "./parser",
       "files": [
         "src\\parser\\mod.ts",
         "src\\parser\\parser.ts",
+        "src\\parser\\syntax-error.ts",
         "src\\term\\data-factory.ts"
       ],
-      "bytes": 218956
+      "bytes": 229542
     },
     {
       "name": "./serialize",

--- a/bench/measure-closures.ts
+++ b/bench/measure-closures.ts
@@ -21,6 +21,7 @@ const ENTRIES = [
   { name: ".", path: "./src/mod.ts" },
   { name: "./term", path: "./src/term/mod.ts" },
   { name: "./store", path: "./src/store/memory-store.ts" },
+  { name: "./sqlite", path: "./src/store/sqlite-store.ts" },
   { name: "./parser", path: "./src/parser/mod.ts" },
   { name: "./serialize", path: "./src/serialize/mod.ts" },
 ];

--- a/bench/measure-libs.ts
+++ b/bench/measure-libs.ts
@@ -190,7 +190,6 @@ function comunicaArtifact(): Sized {
 const ARTIFACT_EXCLUDED_SUFFIXES = [".test.ts", ".jison"];
 const ARTIFACT_EXCLUDED_FILES = [
   "parser/generate-parser.ts",
-  "store/sqlite-store.ts",
 ];
 
 function isExcluded(relPath: string): boolean {

--- a/bench/size-data.json
+++ b/bench/size-data.json
@@ -1,17 +1,17 @@
 {
-  "generatedAt": "2026-08-14T21:26:46.705Z",
+  "generatedAt": "2026-08-15T19:23:15.356Z",
   "engines": [
     {
       "name": "wazoo",
-      "bytes": 632215,
+      "bytes": 674085,
       "children": [
         {
           "name": "src/parser/parser.ts",
-          "bytes": 206696
+          "bytes": 211535
         },
         {
           "name": "src/evaluator/expression-evaluator.ts",
-          "bytes": 69041
+          "bytes": 72148
         },
         {
           "name": "src/parser/turtle-generated.ts",
@@ -19,11 +19,11 @@
         },
         {
           "name": "src/evaluator/join.ts",
-          "bytes": 48988
+          "bytes": 58944
         },
         {
           "name": "src/evaluator/bgp-evaluator.ts",
-          "bytes": 38988
+          "bytes": 42526
         },
         {
           "name": "src/evaluator/update-evaluator.ts",
@@ -31,11 +31,11 @@
         },
         {
           "name": "README.md",
-          "bytes": 21315
+          "bytes": 21746
         },
         {
           "name": "src/evaluator/sparql-evaluator.ts",
-          "bytes": 19032
+          "bytes": 19389
         },
         {
           "name": "src/term/hash.ts",
@@ -47,15 +47,19 @@
         },
         {
           "name": "src/parser/README.md",
-          "bytes": 10925
+          "bytes": 12567
+        },
+        {
+          "name": "src/store/sqlite-store.ts",
+          "bytes": 11427
+        },
+        {
+          "name": "src/evaluator/select-pipeline.ts",
+          "bytes": 10842
         },
         {
           "name": "src/evaluator/aggregate.ts",
           "bytes": 10690
-        },
-        {
-          "name": "src/evaluator/select-pipeline.ts",
-          "bytes": 10653
         },
         {
           "name": "src/quad-store.ts",
@@ -75,19 +79,23 @@
         },
         {
           "name": "src/parser/mod.ts",
-          "bytes": 4626
+          "bytes": 5198
+        },
+        {
+          "name": "src/parser/syntax-error.ts",
+          "bytes": 5175
         },
         {
           "name": "src/evaluator/reified.ts",
           "bytes": 4612
         },
         {
-          "name": "src/term/ordering.ts",
-          "bytes": 4130
+          "name": "src/wazoo-sparql-engine.ts",
+          "bytes": 4409
         },
         {
-          "name": "src/wazoo-sparql-engine.ts",
-          "bytes": 3867
+          "name": "src/term/ordering.ts",
+          "bytes": 4130
         },
         {
           "name": "src/term/numeric.ts",
@@ -110,12 +118,12 @@
           "bytes": 2435
         },
         {
-          "name": "src/sparql-engine-interface.ts",
-          "bytes": 2429
-        },
-        {
           "name": "src/term/identity.ts",
           "bytes": 2416
+        },
+        {
+          "name": "src/sparql-engine-interface.ts",
+          "bytes": 2369
         },
         {
           "name": "src/serialize/json-results.ts",
@@ -124,6 +132,10 @@
         {
           "name": "src/evaluator/expression-utils.ts",
           "bytes": 1706
+        },
+        {
+          "name": "src/mod.ts",
+          "bytes": 1140
         },
         {
           "name": "src/parser/LICENSE",
@@ -136,10 +148,6 @@
         {
           "name": "LICENSE",
           "bytes": 1075
-        },
-        {
-          "name": "src/mod.ts",
-          "bytes": 985
         },
         {
           "name": "src/term/mod.ts",
@@ -167,15 +175,15 @@
     },
     {
       "name": "comunica",
-      "bytes": 29693164,
+      "bytes": 29787521,
       "children": [
         {
           "name": "@comunica/actor-bindings-aggregator-factory-average",
-          "bytes": 14089783
+          "bytes": 14210804
         },
         {
           "name": "@comunica/actor-init-query",
-          "bytes": 8283471
+          "bytes": 8256807
         },
         {
           "name": "@comunica/actor-query-parse-sparql",
@@ -901,8 +909,8 @@
     }
   ],
   "wazoo": {
-    "artifactBytes": 632215,
-    "gzipBytes": 135178,
-    "files": 36
+    "artifactBytes": 674085,
+    "gzipBytes": 144539,
+    "files": 38
   }
 }

--- a/bench/sqlite_bench.ts
+++ b/bench/sqlite_bench.ts
@@ -1,0 +1,324 @@
+// SqliteStore vs MemoryStore benchmark (issue #56, workstream 2).
+//
+// Answers "when is the durable store worth the I/O" with measured numbers:
+// bulk load (autocommit vs one transaction), pattern match (full scan /
+// single-predicate / graph-scoped), countQuads, engine-level update
+// throughput (INSERT DATA / DELETE WHERE through WazooSparqlTransaction),
+// and the commit cost of synchronous=FULL vs NORMAL.
+//
+// Manual timing (not Deno.bench): each measured iteration runs on a freshly
+// seeded store, and only the operation is timed — seeding stays outside the
+// timer so the numbers are honest per-operation costs.
+//
+// Run: deno task bench:sqlite
+import type * as rdfjs from "@rdfjs/types";
+import { DataFactory } from "@/term/mod.ts";
+import { MemoryStore } from "@/store/memory-store.ts";
+import { SqliteStore } from "@/store/sqlite-store.ts";
+import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
+
+const { namedNode, literal, quad } = DataFactory;
+
+const QUAD_COUNT = 10_000;
+const ITERATIONS = 5;
+
+const ex = (suffix: string) => namedNode(`http://example.org/${suffix}`);
+const foafName = ex("name");
+const graphA = ex("g/a");
+
+/** buildQuads returns a people-shaped dataset of QUAD_COUNT quads. */
+function buildQuads(): rdfjs.Quad[] {
+  const quads: rdfjs.Quad[] = [];
+  for (let index = 0; index < QUAD_COUNT; index++) {
+    const person = ex(`person${index}`);
+    quads.push(quad(person, foafName, literal(`Name ${index}`)));
+    quads.push(quad(person, ex("age"), literal(`${index}`)));
+    if (index % 2 === 0) {
+      quads.push(
+        quad(person, ex("knows"), ex(`person${(index + 1) % QUAD_COUNT}`)),
+      );
+    }
+    if (index % 10 === 0) {
+      quads.push(quad(person, ex("graphProp"), ex("v"), graphA));
+    }
+  }
+  return quads;
+}
+
+/** sqliteTempPath returns a fresh temp db path for one bench case. */
+function sqliteTempPath(): string {
+  const dir = Deno.makeTempDirSync();
+  return `${dir}/bench.sqlite`;
+}
+
+/** seededMemory loads the dataset into a fresh MemoryStore. */
+function seededMemory(): MemoryStore {
+  const store = new MemoryStore();
+  for (const item of buildQuads()) {
+    store.addQuad(item);
+  }
+  return store;
+}
+
+/** seededSqlite loads the dataset into a fresh SqliteStore in one commit. */
+function seededSqlite(): SqliteStore {
+  const store = new SqliteStore({ path: sqliteTempPath() });
+  const transaction = store.createTransaction();
+  for (const item of buildQuads()) {
+    transaction.add(item);
+  }
+  transaction.commit();
+  return store;
+}
+
+/** sqliteEngine builds a WazooSparqlEngine over a seeded SqliteStore. */
+function sqliteEngine(): {
+  store: SqliteStore;
+  engine: WazooSparqlEngine;
+} {
+  const store = seededSqlite();
+  const engine = new WazooSparqlEngine({
+    store,
+    createTransaction: () => store.createTransaction(),
+  });
+  return { store, engine };
+}
+
+/**
+ * measureOp times only `op` over `iterations` fresh runs: each run builds a
+ * fresh target via `setup` (untimed), then times the operation. A warmup run
+ * primes V8 and SQLite caches.
+ */
+async function measureOp<T>(
+  setup: () => T,
+  op: (target: T) => void | Promise<void>,
+  iterations = ITERATIONS,
+): Promise<number> {
+  await op(setup()); // warmup
+  let total = 0;
+  for (let index = 0; index < iterations; index++) {
+    const target = setup();
+    const start = performance.now();
+    await op(target);
+    total += performance.now() - start;
+  }
+  return total / iterations;
+}
+
+/** row prints one comparison line. */
+function row(name: string, memoryMs: number, sqliteMs: number): void {
+  console.log(
+    `| ${name.padEnd(34)} | ${memoryMs.toFixed(1).padStart(8)} | ` +
+      `${sqliteMs.toFixed(1).padStart(9)} | ${
+        (sqliteMs / memoryMs).toFixed(1).padStart(6)
+      }x |`,
+  );
+}
+
+async function main(): Promise<void> {
+  console.log(
+    "SqliteStore vs MemoryStore (avg ms over 5 fresh runs; sqlite/memory ratio):",
+  );
+  console.log(
+    "| operation                              |   memory |    sqlite |  ratio |",
+  );
+  console.log(
+    "| -------------------------------------- | -------- | --------- | ------ |",
+  );
+
+  // Bulk load — memory vs sqlite autocommit vs one-transaction.
+  const memoryLoad = await measureOp(() => new MemoryStore(), (store) => {
+    for (const item of buildQuads()) {
+      store.addQuad(item);
+    }
+  });
+  const sqliteAutocommit = await measureOp(
+    () => new SqliteStore({ path: sqliteTempPath() }),
+    (store) => {
+      try {
+        for (const item of buildQuads()) {
+          store.addQuad(item);
+        }
+      } finally {
+        store.close();
+      }
+    },
+  );
+  const sqliteTransactional = await measureOp(
+    () => new SqliteStore({ path: sqliteTempPath() }),
+    (store) => {
+      try {
+        const transaction = store.createTransaction();
+        for (const item of buildQuads()) {
+          transaction.add(item);
+        }
+        transaction.commit();
+      } finally {
+        store.close();
+      }
+    },
+  );
+  console.log(
+    `| ${"bulk load 10k (addQuad)".padEnd(34)} | ${
+      memoryLoad.toFixed(1).padStart(8)
+    } | ` +
+      `${sqliteAutocommit.toFixed(1).padStart(9)} | ${
+        (sqliteAutocommit / memoryLoad).toFixed(1).padStart(6)
+      }x |`,
+  );
+  console.log(
+    `| ${"bulk load 10k (one transaction)".padEnd(34)} | ${
+      memoryLoad.toFixed(1).padStart(8)
+    } | ` +
+      `${sqliteTransactional.toFixed(1).padStart(9)} | ${
+        (sqliteTransactional / memoryLoad).toFixed(1).padStart(6)
+      }x |`,
+  );
+
+  row(
+    "match all 10k",
+    await measureOp(seededMemory, (s) => {
+      [...s.match()];
+    }),
+    await measureOp(seededSqlite, (s) => {
+      try {
+        [...s.match()];
+      } finally {
+        s.close();
+      }
+    }),
+  );
+  row(
+    "match single-predicate 10k",
+    await measureOp(seededMemory, (s) => {
+      [...s.match(null, foafName)];
+    }),
+    await measureOp(seededSqlite, (s) => {
+      try {
+        [...s.match(null, foafName)];
+      } finally {
+        s.close();
+      }
+    }),
+  );
+  row(
+    "match graph-scoped 10k",
+    await measureOp(seededMemory, (s) => {
+      [...s.match(null, null, null, graphA)];
+    }),
+    await measureOp(seededSqlite, (s) => {
+      try {
+        [...s.match(null, null, null, graphA)];
+      } finally {
+        s.close();
+      }
+    }),
+  );
+  row(
+    "countQuads 10k",
+    await measureOp(seededMemory, (s) => {
+      s.countQuads();
+    }),
+    await measureOp(seededSqlite, (s) => {
+      try {
+        s.countQuads();
+      } finally {
+        s.close();
+      }
+    }),
+  );
+
+  // Engine-level update throughput: 200 single-request INSERT DATA / 100
+  // DELETE WHERE, each request through one transaction on sqlite.
+  row(
+    "engine INSERT DATA x200",
+    await measureOp(seededMemory, async (store) => {
+      const engine = new WazooSparqlEngine({ store });
+      for (let index = 0; index < 200; index++) {
+        await engine.execute({
+          query: `INSERT DATA { <http://example.org/u${index}> ` +
+            `<http://example.org/p> "v${index}" }`,
+        });
+      }
+    }),
+    await measureOp(sqliteEngine, async ({ store, engine }) => {
+      try {
+        for (let index = 0; index < 200; index++) {
+          await engine.execute({
+            query: `INSERT DATA { <http://example.org/u${index}> ` +
+              `<http://example.org/p> "v${index}" }`,
+          });
+        }
+      } finally {
+        store.close();
+      }
+    }),
+  );
+  row(
+    "engine DELETE WHERE x100",
+    await measureOp(seededMemory, async (store) => {
+      const engine = new WazooSparqlEngine({ store });
+      for (let index = 0; index < 100; index++) {
+        await engine.execute({
+          query: `DELETE WHERE { <http://example.org/person${index}> ?p ?o }`,
+        });
+      }
+    }),
+    await measureOp(sqliteEngine, async ({ store, engine }) => {
+      try {
+        for (let index = 0; index < 100; index++) {
+          await engine.execute({
+            query: `DELETE WHERE { <http://example.org/person${index}> ?p ?o }`,
+          });
+        }
+      } finally {
+        store.close();
+      }
+    }),
+  );
+
+  // Commit cost under synchronous=FULL (default) vs NORMAL.
+  const commitMs = async (mode: "FULL" | "NORMAL"): Promise<number> =>
+    await measureOp(
+      () => new SqliteStore({ path: sqliteTempPath() }),
+      (store) => {
+        try {
+          store.db.exec(`PRAGMA synchronous = ${mode}`);
+          for (let round = 0; round < 10; round++) {
+            const transaction = store.createTransaction();
+            for (let index = 0; index < 100; index++) {
+              transaction.add(
+                quad(ex(`c${round}-${index}`), ex("p"), literal(`${index}`)),
+              );
+            }
+            transaction.commit();
+          }
+        } finally {
+          store.close();
+        }
+      },
+    );
+  const fullMs = await commitMs("FULL");
+  const normalMs = await commitMs("NORMAL");
+  console.log(
+    `| ${"commit 1k quads (10 x 100) FULL".padEnd(34)} | ${"".padStart(8)} | ${
+      fullMs.toFixed(1).padStart(9)
+    } | ${"".padStart(6)} |`,
+  );
+  console.log(
+    `| ${"commit 1k quads (10 x 100) NORMAL".padEnd(34)} | ${
+      "".padStart(8)
+    } | ${normalMs.toFixed(1).padStart(9)} | ${
+      (fullMs / normalMs).toFixed(1).padStart(6)
+    }x |`,
+  );
+
+  console.log(
+    "Read amplification note: sqlite match decodes a lossless JSON payload per " +
+      "row, so pattern scans are the durable store's dominant cost.",
+  );
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,8 @@
     "./term": "./src/term/mod.ts",
     "./store": "./src/store/memory-store.ts",
     "./parser": "./src/parser/mod.ts",
-    "./serialize": "./src/serialize/mod.ts"
+    "./serialize": "./src/serialize/mod.ts",
+    "./sqlite": "./src/store/sqlite-store.ts"
   },
   "publish": {
     "include": [
@@ -19,8 +20,7 @@
     "exclude": [
       "src/**/*.test.ts",
       "src/**/*.jison",
-      "src/parser/generate-parser.ts",
-      "src/store/sqlite-store.ts"
+      "src/parser/generate-parser.ts"
     ]
   },
   "imports": {
@@ -36,6 +36,7 @@
   "tasks": {
     "bench": "deno bench --allow-all",
     "bench:check": "deno run --allow-all bench/budget.ts",
+    "bench:sqlite": "deno run --allow-all bench/sqlite_bench.ts",
     "bench:size": "deno run --allow-read bench/measure-libs.ts > bench/size-data.json && deno run --allow-read --allow-write bench/treemap.ts && deno fmt docs/assets/chart-*.svg docs/assets/treemap-*.svg",
     "bench:size:closures": "deno run --allow-read --allow-write bench/measure-closures.ts && deno run --allow-read --allow-write bench/treemap.ts && deno fmt docs/assets/chart-*.svg docs/assets/treemap-*.svg",
     "bench:memory": "deno run --allow-all bench/collect-memory.ts && deno run --allow-read --allow-write bench/treemap.ts && deno fmt docs/assets/chart-*.svg docs/assets/treemap-*.svg",
@@ -52,6 +53,7 @@
         "lint",
         "check",
         "test",
+        "publish:check",
         "bench:check",
         "test:exists-ref",
         "test:sparql12:gap",
@@ -66,6 +68,7 @@
     "parser:generate": "deno run --allow-all src/parser/generate-parser.ts",
     "parser:check": "deno run --allow-all src/parser/generate-parser.ts --check",
     "publish:dry": "deno publish --dry-run --allow-dirty",
+    "publish:check": "deno run --allow-read --allow-run test/publish-graph-check.ts",
     "test": "deno test --allow-all",
     "test:exists-ref": "deno run --allow-all test/w3c/exists-ref.ts",
     "test:rdf11": "deno run --allow-all test/w3c/rdf-differential.ts",

--- a/docs/assets/chart-closures.svg
+++ b/docs/assets/chart-closures.svg
@@ -1,28 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 224"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 258"
   font-family="sans-serif">
-  <rect width="720" height="224" fill="#f8f9fa" />
+  <rect width="720" height="258" fill="#f8f9fa" />
   <text x="12" y="20" font-size="13" font-weight="bold"
     fill="#212529">Per-entrypoint consumer closure</text>
   <text x="12" y="34" font-size="9"
     fill="#868e96">Value-import graph of what each subpath loads from the published package (type-only imports erased)</text>
-  <rect x="16" y="46" width="5.8" height="18" fill="#1971c2" rx="2" />
+  <rect x="16" y="46" width="5.6" height="18" fill="#1971c2" rx="2" />
   <text x="470" y="58.0" text-anchor="end" font-family="sans-serif"
     font-size="10"
     fill="#212529">@wazoo/sparql-engine/serialize — 7 KiB (3 files)</text>
-  <rect x="16" y="80" width="31.8" height="18" fill="#1971c2" rx="2" />
+  <rect x="16" y="80" width="30.3" height="18" fill="#1971c2" rx="2" />
   <text x="470" y="92.0" text-anchor="end" font-family="sans-serif"
     font-size="10"
     fill="#212529">@wazoo/sparql-engine/term — 40 KiB (9 files)</text>
-  <rect x="16" y="114" width="41.9" height="18" fill="#1971c2" rx="2" />
+  <rect x="16" y="114" width="40.0" height="18" fill="#1971c2" rx="2" />
   <text x="470" y="126.0" text-anchor="end" font-family="sans-serif"
     font-size="10"
     fill="#212529">@wazoo/sparql-engine/store — 53 KiB (10 files)</text>
-  <rect x="16" y="148" width="168.6" height="18" fill="#1971c2" rx="2" />
+  <rect x="16" y="148" width="48.3" height="18" fill="#1971c2" rx="2" />
   <text x="470" y="160.0" text-anchor="end" font-family="sans-serif"
-    font-size="10"
-    fill="#212529">@wazoo/sparql-engine/parser — 214 KiB (3 files)</text>
-  <rect x="16" y="182" width="454.0" height="18" fill="#1971c2" rx="2" />
+    font-size="10" fill="#212529">./sqlite — 64 KiB (11 files)</text>
+  <rect x="16" y="182" width="168.6" height="18" fill="#1971c2" rx="2" />
   <text x="470" y="194.0" text-anchor="end" font-family="sans-serif"
     font-size="10"
-    fill="#212529">@wazoo/sparql-engine (full) — 576 KiB (30 files)</text>
+    fill="#212529">@wazoo/sparql-engine/parser — 224 KiB (4 files)</text>
+  <rect x="16" y="216" width="454.0" height="18" fill="#1971c2" rx="2" />
+  <text x="470" y="228.0" text-anchor="end" font-family="sans-serif"
+    font-size="10"
+    fill="#212529">@wazoo/sparql-engine (full) — 604 KiB (31 files)</text>
 </svg>

--- a/docs/assets/chart-library-size.svg
+++ b/docs/assets/chart-library-size.svg
@@ -5,13 +5,13 @@
     fill="#212529">Library size on disk</text>
   <text x="12" y="34" font-size="9"
     fill="#868e96">Engine package footprint, excluding the shared Deno runtime — bar length ∝ total installed size (binary MiB)</text>
-  <rect x="16" y="46" width="9.7" height="18" fill="#2f9e44" rx="2" />
+  <rect x="16" y="46" width="10.3" height="18" fill="#2f9e44" rx="2" />
   <text x="470" y="58.0" text-anchor="end" font-family="sans-serif"
-    font-size="10" fill="#212529">wazoo — 617 KiB (1.6% of total)</text>
-  <rect x="16" y="80" width="126.5" height="18" fill="#1971c2" rx="2" />
+    font-size="10" fill="#212529">wazoo — 658 KiB (1.7% of total)</text>
+  <rect x="16" y="80" width="126.1" height="18" fill="#1971c2" rx="2" />
   <text x="470" y="92.0" text-anchor="end" font-family="sans-serif"
     font-size="10" fill="#212529">oxigraph — 7.89 MiB (21.4% of total)</text>
   <rect x="16" y="114" width="454.0" height="18" fill="#f08c00" rx="2" />
   <text x="470" y="126.0" text-anchor="end" font-family="sans-serif"
-    font-size="10" fill="#212529">comunica — 28.32 MiB (76.9% of total)</text>
+    font-size="10" fill="#212529">comunica — 28.41 MiB (76.9% of total)</text>
 </svg>

--- a/docs/assets/treemap-submodules.svg
+++ b/docs/assets/treemap-submodules.svg
@@ -9,31 +9,31 @@
     stroke="#dee2e6" stroke-width="1" />
   <text x="18.0" y="60.0" font-family="sans-serif" font-size="10"
     font-weight="bold"
-    fill="#495057">@wazoo/sparql-engine (full) — 576 KiB</text>
-  <rect x="14.0" y="68.0" width="326.4" height="210.0" fill="#2f9e44"
+    fill="#495057">@wazoo/sparql-engine (full) — 604 KiB</text>
+  <rect x="14.0" y="68.0" width="329.5" height="210.0" fill="#2f9e44"
     stroke="#ffffff" stroke-width="1" />
-  <text x="177.2" y="176.0" text-anchor="middle" font-family="sans-serif"
+  <text x="178.7" y="176.0" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">parser · 5 files<tspan x="177.2" dy="12" font-size="8" fill="#ffffffcc">282 KiB</tspan></text>
-  <rect x="340.4" y="68.0" width="280.6" height="210.0" fill="#40c057"
+    fill="#fff">parser · 6 files<tspan x="178.7" dy="12" font-size="8" fill="#ffffffcc">287 KiB</tspan></text>
+  <rect x="343.5" y="68.0" width="278.2" height="210.0" fill="#40c057"
     stroke="#ffffff" stroke-width="1" />
-  <text x="480.7" y="176.0" text-anchor="middle" font-family="sans-serif"
+  <text x="482.6" y="176.0" text-anchor="middle" font-family="sans-serif"
     font-size="10"
-    fill="#fff">evaluator · 9 files<tspan x="480.7" dy="12" font-size="8" fill="#ffffffcc">243 KiB</tspan></text>
-  <rect x="621.0" y="68.0" width="85.0" height="115.1" fill="#69db7c"
+    fill="#fff">evaluator · 9 files<tspan x="482.6" dy="12" font-size="8" fill="#ffffffcc">243 KiB</tspan></text>
+  <rect x="621.7" y="68.0" width="84.3" height="115.1" fill="#69db7c"
     stroke="#ffffff" stroke-width="1" />
-  <text x="663.5" y="65.0" text-anchor="middle" font-family="sans-serif"
+  <text x="663.9" y="65.0" text-anchor="middle" font-family="sans-serif"
     font-size="8" fill="#495057">term · 9 files (40 KiB)</text>
-  <rect x="621.0" y="183.1" width="85.0" height="37.1" fill="#8ce99a"
+  <rect x="621.7" y="183.1" width="84.3" height="37.1" fill="#8ce99a"
     stroke="#ffffff" stroke-width="1" />
-  <text x="663.5" y="180.1" text-anchor="middle" font-family="sans-serif"
+  <text x="663.9" y="180.1" text-anchor="middle" font-family="sans-serif"
     font-size="8" fill="#495057">entrypoints · 3 files (13 KiB)</text>
-  <rect x="621.0" y="220.2" width="53.8" height="57.8" fill="#b2f2bb"
+  <rect x="621.7" y="220.2" width="53.4" height="57.8" fill="#b2f2bb"
     stroke="#ffffff" stroke-width="1" />
-  <text x="647.9" y="217.2" text-anchor="middle" font-family="sans-serif"
+  <text x="648.4" y="217.2" text-anchor="middle" font-family="sans-serif"
     font-size="8" fill="#495057">store · 1 file (13 KiB)</text>
-  <rect x="674.8" y="220.2" width="31.2" height="57.8" fill="#d3f9d8"
+  <rect x="675.1" y="220.2" width="30.9" height="57.8" fill="#d3f9d8"
     stroke="#ffffff" stroke-width="1" />
-  <text x="690.4" y="217.2" text-anchor="middle" font-family="sans-serif"
+  <text x="690.6" y="217.2" text-anchor="middle" font-family="sans-serif"
     font-size="8" fill="#495057">serialize · 3 files (7 KiB)</text>
 </svg>

--- a/docs/durable-transactions.md
+++ b/docs/durable-transactions.md
@@ -5,8 +5,9 @@ layout: default
 
 # Durable transaction backend for SPARQL updates
 
-Status: **prototype implemented** — `src/store/sqlite-store.ts` (with tests in
-`src/store/sqlite-store.test.ts`).
+Status: **released** — `SqliteStore` ships as the opt-in
+`@wazoo/sparql-engine/sqlite` subpath entrypoint, with a crash-recovery suite
+and measured benchmarks behind it (issue #56).
 
 ## Goal
 
@@ -32,22 +33,31 @@ interface WazooSparqlTransaction {
 `UpdateEvaluator.executeUpdate` creates **one** transaction per update request,
 routes every operation's writes through it, then commits once — so a
 multi-operation update (`INSERT DATA {…}; DELETE WHERE {…}`) is already
-all-or-nothing at the engine level. The missing piece is a _durable_
-implementation of that interface.
+all-or-nothing at the engine level. `SqliteStore` is the durable implementation
+of that interface.
 
-## Prototype: [`SqliteStore`](https://github.com/wazootech/sparql-engine/blob/main/src/store/sqlite-store.ts)
+## [`SqliteStore`](https://github.com/wazootech/sparql-engine/blob/main/src/store/sqlite-store.ts)
 
-[`SqliteStore`](https://github.com/wazootech/sparql-engine/blob/main/src/store/sqlite-store.ts)
-(`src/store/sqlite-store.ts`) is an RDF/JS Store + transaction factory backed by
-Deno/Node's built-in `node:sqlite` (`DatabaseSync`):
+`SqliteStore` (`src/store/sqlite-store.ts`) is an RDF/JS Store + transaction
+factory backed by Deno/Node's built-in `node:sqlite` (`DatabaseSync`), shipped
+behind the `./sqlite` subpath entrypoint — importing the package default pulls
+nothing new, and only opting in loads `node:sqlite`:
 
 ```ts
+import { SqliteStore } from "@wazoo/sparql-engine/sqlite";
+
 const store = new SqliteStore({ path: "data.sqlite" });
 const engine = new WazooSparqlEngine({
   store,
   createTransaction: () => store.createTransaction(),
 });
 ```
+
+**Runtime requirements:** Deno ≥ 2.1 or Node ≥ 22.5 (where `node:sqlite`
+exists). On unsupported runtimes the import itself fails with the runtime's
+module-not-found error. Browser/edge bundles never see it: a bundler that
+imports only `@wazoo/sparql-engine` (or any subpath except `./sqlite`) does not
+pull `node:sqlite`; in-memory workloads should keep using `MemoryStore`.
 
 ### Schema
 
@@ -74,6 +84,9 @@ quads(skey, pkey, okey, gkey, payload)
   lock up front, so two concurrent updates cannot interleave; a thrown error
   (from any insert/delete or the `beforeCommit` seam) triggers `ROLLBACK` and
   rethrows — the dataset is untouched.
+- `PRAGMA busy_timeout = 5000` lets a second concurrent writer wait for the lock
+  instead of failing with `SQLITE_BUSY` (verified by the concurrent-writer
+  recovery test).
 - Deletes apply before inserts; an `add`+`delete` of the same quad nets to the
   add, a `delete`+`add` nets to nothing. This matches the patch semantics the
   update evaluator already assumes for in-memory stores.
@@ -86,13 +99,20 @@ quads(skey, pkey, okey, gkey, payload)
 
 - `PRAGMA journal_mode = WAL`: writes survive process crashes; readers never
   block on a writer.
-- SQLite's default `synchronous=FULL` in WAL mode fsyncs each commit — a
-  committed update survives power loss. (A production deployment can trade some
-  durability for throughput with `synchronous=NORMAL`.)
-- A commit that completes survives `close()` and reopening the file with a
-  brand-new
-  [`SqliteStore`](https://github.com/wazootech/sparql-engine/blob/main/src/store/sqlite-store.ts)
-  — covered by the "data persists across store reopen" test.
+- `synchronous=FULL` (the default) fsyncs each commit — a committed update
+  survives power loss. A deployment can trade some durability for throughput
+  with `PRAGMA synchronous = NORMAL` (≈1.5× commit throughput in the benchmark
+  below).
+- A commit that completes survives `close()` **and** a hard process exit without
+  `close()` — proven by the crash-recovery suite, which kills real child
+  processes at the failure points:
+
+| Scenario                                   | Child behavior                          | On reopen                          |
+| ------------------------------------------ | --------------------------------------- | ---------------------------------- |
+| Committed update, hard exit (no `close()`) | commit, then `Deno.exit(0)`             | quad intact                        |
+| Buffered writes, exit before `commit()`    | transaction buffer, then `Deno.exit(1)` | dataset untouched                  |
+| Kill mid-`BEGIN IMMEDIATE`                 | raw WAL frames, never committed         | interrupted txn rolled back        |
+| Two concurrent writers (`busy_timeout`)    | interleaved commit batches              | both datasets complete, no partial |
 
 ## Verified behavior (tests)
 
@@ -106,22 +126,49 @@ quads(skey, pkey, okey, gkey, payload)
 - Failed commit: the `beforeCommit` test seam throws inside the transaction —
   every buffered write rolls back and the file stays empty.
 - Add/delete netting and `deleteGraph` scoping.
+- Crash recovery: `src/store/sqlite-store-recovery.test.ts` (child-process suite
+  above) + the 8 unit tests in `src/store/sqlite-store.test.ts`.
 
-## Packaging decision
+## Benchmark: SqliteStore vs MemoryStore
 
-`node:sqlite` is a Node/Deno built-in, so
-[`SqliteStore`](https://github.com/wazootech/sparql-engine/blob/main/src/store/sqlite-store.ts)
-is server-only and is **not exported from `src/mod.ts`** — the browser/edge
-export graph keeps zero runtime dependencies (`deno publish --dry-run` stays
-clean). It ships as a deep-import module today; before general release it should
-move to its own entrypoint (e.g. `./sqlite`) or a separate package.
+`deno task bench:sqlite` (`bench/sqlite_bench.ts`) times each operation on a
+freshly seeded store with only the operation inside the timer (10k-quad dataset,
+avg of 5 runs; dev machine, 2026-08-15 — see `bench/baseline.json`). Ratios are
+the durable-store cost story; CI runners are roughly 3× slower in absolute
+terms.
 
-## Type-resolution note
+| operation                       | memory  | sqlite    | ratio |
+| ------------------------------- | ------- | --------- | ----- |
+| bulk load 10k (addQuad)         | 40.9 ms | 16 204 ms | 396×  |
+| bulk load 10k (one transaction) | 40.9 ms | 732 ms    | 18×   |
+| match all 10k                   | 0.7 ms  | 106 ms    | 163×  |
+| match single-predicate 10k      | 0.6 ms  | 72 ms     | 115×  |
+| match graph-scoped 10k          | 0.1 ms  | 45 ms     | 402×  |
+| countQuads 10k                  | 0.1 ms  | 89 ms     | 617×  |
+| engine INSERT DATA ×200         | 11.6 ms | 177 ms    | 15×   |
+| engine DELETE WHERE ×100        | 65.0 ms | 3 287 ms  | 51×   |
+| commit 1k (10×100) FULL         | —       | 52.5 ms   | —     |
+| commit 1k (10×100) NORMAL       | —       | 34.1 ms   | 1.5×  |
 
-The repo's lockfile pinned `@types/node@18` transitively, which predates
-`node:sqlite` typings, so `deno.json` now maps `@types/node` to `^22.10.0`. That
-import is only referenced by the opt-in module and never reaches the published
-package.
+Read this as: **batch the writes**. Bulk loading through the engine's
+transaction hook is 22× faster than autocommit per-quad (one fsync per
+transaction vs one per row). The read paths pay payload-decode amplification —
+every `match` row is `JSON.parse`d and rebuilt into terms — which is why pattern
+scans are the durable store's dominant cost. WHERE-form updates (`DELETE WHERE`
+/ `DELETE/INSERT`) pay that amplification per scanned pattern; if you can
+express the workload as `INSERT DATA`/`DELETE DATA` (constant templates), you
+avoid it entirely.
+
+## Packaging
+
+`node:sqlite` is a Node/Deno builtin, so `SqliteStore` is server-only. It ships
+as the `./sqlite` subpath export; `src/mod.ts` (the default export) is unchanged
+and its graph stays free of `node:`/`npm:` imports. Two CI gates enforce the
+contract: `deno publish --dry-run` (every export resolves) and
+`deno task publish:check` (`test/publish-graph-check.ts` — the default graph has
+no `node:`/`npm:` runtime imports, and `./sqlite` pulls exactly `node:sqlite`).
+`deno task bench:check` carries two SqliteStore sanity budgets (transactional
+load + full match) as the CI regression gate.
 
 ## Alternatives considered
 
@@ -135,16 +182,12 @@ package.
 The engine-side contract
 ([`WazooSparqlTransaction`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlTransaction))
 is intentionally minimal (add/delete/commit/rollback), so any of these can slot
-in without engine changes — the SQLite prototype is the reference
-implementation.
+in without engine changes.
 
-## Next steps (not in this PR)
+## Next steps
 
-1. Export
-   [`SqliteStore`](https://github.com/wazootech/sparql-engine/blob/main/src/store/sqlite-store.ts)
-   from a dedicated `./sqlite` entrypoint.
-2. Decide fsync policy (`synchronous=NORMAL` vs `FULL`) and add a
-   `busy_timeout`/retry policy for concurrent writers.
-3. Benchmark update throughput vs the in-memory store.
-4. Consider `INSERT … ON CONFLICT` batching (single statement per commit) once
+1. `INSERT … ON CONFLICT` batching (single statement per commit) once
    transaction sizes grow.
+2. Optional `synchronous` mode on `SqliteStoreOptions` (default `FULL`), instead
+   of the store-level pragma the benchmark flips today.
+3. A `busy_timeout` option (currently a fixed 5000 ms default).

--- a/src/store/sqlite-store-recovery.test.ts
+++ b/src/store/sqlite-store-recovery.test.ts
@@ -1,0 +1,109 @@
+// Crash-recovery suite for SqliteStore (issue #56, workstream 3): the
+// durability claims are proven by actually killing processes at the failure
+// points, not by asserting behavior in-process:
+//
+//   1. committed → hard exit (no close()) → reopen → committed quad intact;
+//   2. buffered-but-uncommitted → exit → reopen → dataset untouched;
+//   3. kill mid-BEGIN IMMEDIATE (raw WAL frames, never committed) → reopen →
+//      interrupted transaction rolled back;
+//   4. two concurrent writers → both datasets land in full (busy_timeout
+//      serializes them; no interleaved partial commits).
+//
+// Each scenario runs in its own child Deno process via Deno.Command, so the
+// parent can never accidentally share in-memory state with the "crashing"
+// writer.
+import { assertEquals } from "@std/assert";
+import { dirname, fromFileUrl, join, resolve } from "@std/path";
+import { SqliteStore } from "@/store/sqlite-store.ts";
+
+const REPO_ROOT = resolve(dirname(fromFileUrl(import.meta.url)), "../..");
+const CHILD_SCRIPT = join(REPO_ROOT, "test", "sqlite-recovery-child.ts");
+
+/** runChild spawns the recovery child and resolves with its exit code. */
+async function runChild(...args: string[]): Promise<number> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["run", "--allow-all", CHILD_SCRIPT, ...args],
+    cwd: REPO_ROOT,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code } = await command.output();
+  return code;
+}
+
+/** tempDbPath returns a fresh temp db path for one scenario. */
+function tempDbPath(): string {
+  const dir = Deno.makeTempDirSync();
+  return `${dir}/recovery.sqlite`;
+}
+
+/** collectQuads reopens the file and returns its quads. */
+function collectQuads(path: string): unknown[] {
+  const store = new SqliteStore({ path });
+  try {
+    return store.getQuads(null, null, null, null);
+  } finally {
+    store.close();
+  }
+}
+
+Deno.test("SqliteStore recovery - committed update survives a hard process exit", async () => {
+  const path = tempDbPath();
+  // The child commits then dies without close().
+  const code = await runChild("commit-exit", path);
+  assertEquals(code, 0);
+  const quads = collectQuads(path);
+  assertEquals(quads.length, 1);
+  assertEquals(
+    (quads[0] as { subject: { value: string } }).subject.value,
+    "http://example.org/s",
+  );
+});
+
+Deno.test("SqliteStore recovery - uncommitted buffered writes roll back", async () => {
+  const path = tempDbPath();
+  // The child buffers writes in a transaction and exits before commit.
+  const code = await runChild("buffered-exit", path);
+  assertEquals(code, 1);
+  assertEquals(collectQuads(path).length, 0);
+});
+
+Deno.test("SqliteStore recovery - kill mid-BEGIN IMMEDIATE rolls back on reopen", async () => {
+  const path = tempDbPath();
+  // The child writes raw WAL frames inside an uncommitted transaction.
+  const code = await runChild("raw-mid-transaction", path);
+  assertEquals(code, 1);
+  assertEquals(collectQuads(path).length, 0);
+});
+
+Deno.test("SqliteStore recovery - concurrent writers never interleave partial commits", async () => {
+  const path = tempDbPath();
+  // Two writers race on the write lock; busy_timeout serializes them.
+  const [codeA, codeB] = await Promise.all([
+    runChild("concurrent-writer", path, "a"),
+    runChild("concurrent-writer", path, "b"),
+  ]);
+  assertEquals(codeA, 0);
+  assertEquals(codeB, 0);
+  const quads = collectQuads(path);
+  // Each writer committed 5 rounds x 20 quads = 100; both must be complete.
+  assertEquals(quads.length, 200);
+  const subjects = new Set(
+    quads.map((item) => (item as { subject: { value: string } }).subject.value),
+  );
+  assertEquals(subjects.size, 200);
+  for (let round = 0; round < 5; round++) {
+    for (let index = 0; index < 20; index++) {
+      assertEquals(
+        subjects.has(`http://example.org/a-${round}-${index}`),
+        true,
+        `missing writer a quad a-${round}-${index}`,
+      );
+      assertEquals(
+        subjects.has(`http://example.org/b-${round}-${index}`),
+        true,
+        `missing writer b quad b-${round}-${index}`,
+      );
+    }
+  }
+});

--- a/src/store/sqlite-store.ts
+++ b/src/store/sqlite-store.ts
@@ -12,11 +12,16 @@
  *
  * Design notes
  * ------------
- * - Uses Deno/Node's built-in `node:sqlite` (DatabaseSync). No npm or JSR
- *   dependency, so the engine's own runtime stays dependency-free; this
- *   module is intentionally NOT exported from src/mod.ts and is meant for
- *   server-side (Deno/Node) deployments. Browser bundles should keep using
- *   the in-memory MemoryStore.
+ * - Uses Deno/Node's built-in `node:sqlite` (DatabaseSync) — a builtin, not
+ *   a dependency — so the engine's default export graph stays
+ *   runtime-dependency-free. SqliteStore ships as the opt-in `./sqlite`
+ *   subpath entrypoint (`import { SqliteStore } from
+ *   "@wazoo/sparql-engine/sqlite";`); importing the package default pulls
+ *   nothing new, and only opting in loads `node:sqlite`. Server-side
+ *   (Deno >= 2.1 / Node >= 22.5) deployments only; browser bundles should
+ *   keep using the in-memory MemoryStore.
+ * - `PRAGMA busy_timeout` lets concurrent writers wait for the write lock
+ *   instead of failing with SQLITE_BUSY when a transaction is in flight.
  * - Rows are keyed by the engine's `termKey` per position (a sound RDF-term
  *   equality key), with a composite primary key over all four positions so
  *   quads that differ only by graph never collide.
@@ -201,6 +206,7 @@ export class SqliteStore implements rdfjs.Store<rdfjs.Quad> {
     this.db = new DatabaseSync(options.path);
     this.db.exec(
       "PRAGMA journal_mode = WAL;" +
+        "PRAGMA busy_timeout = 5000;" +
         "CREATE TABLE IF NOT EXISTS quads (" +
         "  skey TEXT NOT NULL," +
         "  pkey TEXT NOT NULL," +

--- a/test/publish-graph-check.ts
+++ b/test/publish-graph-check.ts
@@ -1,0 +1,97 @@
+// publish-graph-check asserts the entrypoint graphs stay runtime-dependency
+// free, per the packaging contract (issue #56):
+//
+//   - The default export (`src/mod.ts`) must not import `node:` builtins —
+//     the zero-runtime-dependency claim of the published package.
+//   - The `./sqlite` subpath (`src/store/sqlite-store.ts`) is the only
+//     opt-in entrypoint that loads a builtin, and exactly one: `node:sqlite`
+//     (a Node/Deno builtin, not a dependency).
+//   - No `npm:` value dependency may sneak into either graph. The single
+//     allowed npm: entry is the type-only `@rdfjs/types` (erased at compile
+//     time), which `deno info --json` still lists.
+//
+// Run: deno task publish:check (wired into `deno task ci` alongside
+// `publish:dry`, which asserts every export resolves).
+import { dirname, fromFileUrl, resolve } from "@std/path";
+
+const REPO_ROOT = resolve(dirname(fromFileUrl(import.meta.url)), "..");
+
+interface GraphModule {
+  specifier: string;
+}
+
+interface ModuleGraph {
+  modules: GraphModule[];
+}
+
+/**
+ * moduleSpecifiers returns every specifier in the value graph of entry
+ * (relative to the repo root). The path is passed relative to the cwd — an
+ * absolute path makes `deno info --json` omit node: builtins on Windows.
+ */
+async function moduleSpecifiers(entry: string): Promise<string[]> {
+  const command = new Deno.Command(Deno.execPath(), {
+    args: ["info", "--json", entry],
+    cwd: REPO_ROOT,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const { code, stdout, stderr } = await command.output();
+  if (code !== 0) {
+    throw new Error(
+      `deno info failed for ${entry}:\n${new TextDecoder().decode(stderr)}`,
+    );
+  }
+  const graph = JSON.parse(new TextDecoder().decode(stdout)) as ModuleGraph;
+  return graph.modules.map((module) => module.specifier);
+}
+
+/** assertPurity checks one entrypoint's graph against the contract. */
+function assertPurity(
+  entry: string,
+  specifiers: string[],
+  expectedNode: string[],
+): void {
+  const nodeImports = [
+    ...new Set(
+      specifiers.filter((specifier) => specifier.startsWith("node:")),
+    ),
+  ].sort();
+  const npmImports = [
+    ...new Set(
+      specifiers.filter((specifier) => specifier.startsWith("npm:")),
+    ),
+  ].sort();
+
+  const expected = [...expectedNode].sort();
+  if (JSON.stringify(nodeImports) !== JSON.stringify(expected)) {
+    throw new Error(
+      `${entry}: node: imports ${JSON.stringify(nodeImports)} do not match ` +
+        `expected ${JSON.stringify(expected)}`,
+    );
+  }
+  const foreignNpm = npmImports.filter(
+    (specifier) => !specifier.startsWith("npm:/@rdfjs/types@"),
+  );
+  if (foreignNpm.length > 0) {
+    throw new Error(
+      `${entry}: unexpected npm: dependencies ${JSON.stringify(foreignNpm)}` +
+        " (only type-only @rdfjs/types is allowed)",
+    );
+  }
+}
+
+// The default export must be pure: no node: builtins at all.
+const defaultGraph = await moduleSpecifiers("src/mod.ts");
+assertPurity("src/mod.ts (default export)", defaultGraph, []);
+
+// The sqlite subpath may load exactly node:sqlite and nothing else node:.
+const sqliteGraph = await moduleSpecifiers("src/store/sqlite-store.ts");
+assertPurity("src/store/sqlite-store.ts (./sqlite)", sqliteGraph, [
+  "node:sqlite",
+]);
+
+console.log(
+  "publish:check — default export graph has no node:/npm: runtime imports; " +
+    "./sqlite pulls only node:sqlite.",
+);

--- a/test/sqlite-recovery-child.ts
+++ b/test/sqlite-recovery-child.ts
@@ -1,0 +1,90 @@
+// Child-process helper for the SqliteStore crash-recovery suite
+// (src/store/sqlite-store-recovery.test.ts). Each mode simulates a different
+// failure point from inside a fresh Deno process; the parent test reopens the
+// database file and asserts what survived.
+//
+// Usage: deno run --allow-all test/sqlite-recovery-child.ts <mode> <dbPath> [tag]
+import { DatabaseSync } from "node:sqlite";
+import { SqliteStore } from "@/store/sqlite-store.ts";
+import { DataFactory } from "@/term/data-factory.ts";
+import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
+
+const { namedNode, literal, quad } = DataFactory;
+
+const [mode, path, tag] = Deno.args;
+
+switch (mode) {
+  case "commit-exit": {
+    // Commit one update, then hard-exit WITHOUT close(). The COMMIT is
+    // synchronous (WAL + synchronous=FULL), so the write is durable before
+    // the process dies — a reopen must see it.
+    const store = new SqliteStore({ path });
+    const engine = new WazooSparqlEngine({
+      store,
+      createTransaction: () => store.createTransaction(),
+    });
+    await engine.execute({
+      query:
+        `INSERT DATA { <http://example.org/s> <http://example.org/p> "v" }`,
+    });
+    Deno.exit(0);
+    break;
+  }
+  case "buffered-exit": {
+    // Buffer writes inside a transaction, then die before commit(). The
+    // SqliteTransaction keeps its patch in memory — nothing has touched the
+    // database — so a reopen must find the dataset untouched.
+    const store = new SqliteStore({ path });
+    const transaction = store.createTransaction();
+    transaction.add(
+      quad(
+        namedNode("http://example.org/s"),
+        namedNode("http://example.org/p"),
+        literal("v"),
+      ),
+    );
+    Deno.exit(1);
+    break;
+  }
+  case "raw-mid-transaction": {
+    // Crash with an uncommitted transaction at the SQLite level: rows are
+    // written into the WAL inside BEGIN IMMEDIATE but never committed. WAL
+    // recovery must roll the interrupted transaction back on reopen.
+    const store = new SqliteStore({ path });
+    store.close();
+    const db = new DatabaseSync(path);
+    db.exec(
+      "BEGIN IMMEDIATE;" +
+        "INSERT INTO quads (skey, pkey, okey, gkey, payload) " +
+        "VALUES ('k', 'k', 'k', 'k', '{}');",
+    );
+    Deno.exit(1);
+    break;
+  }
+  case "concurrent-writer": {
+    // Commit several small transactions with a yield between them so two
+    // writers genuinely overlap on the write lock. busy_timeout makes the
+    // second writer wait instead of failing with SQLITE_BUSY; the parent
+    // asserts both writers' data lands in full — no interleaved partials.
+    const store = new SqliteStore({ path });
+    for (let round = 0; round < 5; round++) {
+      const transaction = store.createTransaction();
+      for (let index = 0; index < 20; index++) {
+        transaction.add(
+          quad(
+            namedNode(`http://example.org/${tag}-${round}-${index}`),
+            namedNode("http://example.org/p"),
+            literal(`${index}`),
+          ),
+        );
+      }
+      transaction.commit();
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    store.close();
+    Deno.exit(0);
+    break;
+  }
+  default:
+    throw new Error(`unknown recovery child mode: ${mode}`);
+}


### PR DESCRIPTION
Closes #56 — SqliteStore graduation.

## What lands

**WS1 — subpath export + publish verification**
- `@wazoo/sparql-engine/sqlite` subpath entrypoint (`src/store/sqlite-store.ts`); removed from the publish exclude list so it ships.
- New `test/publish-graph-check.ts` (wired into `deno task ci` as `publish:check`): asserts the default export graph stays `node:`/`npm:`-free and that `./sqlite` pulls exactly one builtin (`node:sqlite`, the only allowed opt-in). `publish:dry` still gates that every export resolves.
- SqliteStore module doc rewritten for released status; `PRAGMA busy_timeout = 5000` so concurrent writers serialize instead of throwing `SQLITE_BUSY`.

**WS2 — benchmarks + budget**
- `bench/sqlite_bench.ts` (`deno task bench:sqlite`): MemoryStore-vs-SqliteStore on bulk load (autocommit vs one transaction), match (full / single-predicate / graph-scoped), countQuads, engine-level INSERT DATA / DELETE WHERE throughput, and synchronous=FULL vs NORMAL commit cost. Manual timing with seeding outside the timed region so numbers are honest per-op costs.
- `bench/budget.ts`: two SqliteStore sanity budgets (5k transactional load, 5k full match; ~4x headroom over local baselines) now run in `bench:check` — catches catastrophic regressions, not noise.
- `bench/baseline.json` records the measured numbers; closure/size measurements regenerated (artifact 0.64 MiB / 38 files; `./sqlite` closure 64.3 KiB).

**WS3 — crash-recovery subprocess suite**
- `test/sqlite-recovery-child.ts` + `src/store/sqlite-store-recovery.test.ts`: each durability claim is proven by killing an actual child process —
  1. committed update → hard exit (no `close()`) → survives reopen;
  2. buffered-but-uncommitted → exit → dataset untouched;
  3. kill mid-`BEGIN IMMEDIATE` (raw WAL frames) → rolled back on reopen;
  4. two concurrent writers → both datasets land complete, no interleaved partials.

## Verification
- `deno task ci` green (417 tests) incl. `publish:check`, `bench:check`
- `deno task publish:dry` passes with the new export
- `deno task test:w3c` 345/345; `docs:link-check` 0 broken