### PR TITLE
feat: statistics source for the join-cost estimator (piece 2 of #75, #129)

### DIFF
--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -201,14 +201,26 @@ engine's optimizer. It is a _dynamic_ greedy planner, not a static rewrite:
    [`scanEntry()`](https://github.com/wazootech/sparql-engine/blob/main/src/evaluator/join.ts)
    — so the planner uses the pattern's _true_ store cardinality
    (`entry.candidates.length`), never a heuristic estimate.
-3. A greedy loop repeatedly joins the remaining pattern with the lowest
+3. Before the loop, each pattern's statistics are resolved once from the
+   per-query `PatternStatistics` source (`src/planner/pattern-statistics.ts`,
+   issue #129) and cached by pattern signature: a store exposing
+   `estimateStats(pattern)` supplies its own numbers (the `countQuads`
+   capability pattern, decision #12), and otherwise the same shape is derived
+   from the pattern's already-scanned candidates — exact cardinality plus a
+   distinct-value pass capped at `DISTINCT_SAMPLE_CAP`, so large stores never
+   pay an unbounded counting pass. Named-graph scopes always use the scoped
+   candidate derivation (the hook cannot see the scope).
+4. A greedy loop repeatedly joins the remaining pattern with the lowest
    estimated cost against the current bindings. The estimate comes from an
    injectable `JoinCostEstimator` (`src/planner/join-cost-estimator.ts`; default
-   `BaselineJoinCostEstimator`, wired via `WazooSparqlEngineOptions.estimator`):
+   `BaselineJoinCostEstimator`, wired via `WazooSparqlEngineOptions.estimator`),
+   which receives each pattern's statistics:
    - no pattern variable bound → `bindings.length × candidates.length`;
    - a pattern variable bound in the incoming solutions → the positional index
      is probed, costing `bindings.length × average bucket size`
-     (`candidates.length ÷ distinct bound values`).
+     (`candidates.length ÷ distinct values` — the store's per-variable distinct
+     count when the statistics source supplies it, the bound values' distinct
+     count otherwise).
 
    The estimate affects only join order, never results (SPARQL §18.2.2 — joins
    commute), so an estimator swap is guarded by the W3C differential gate.

--- a/docs/03-api-contracts.md
+++ b/docs/03-api-contracts.md
@@ -303,25 +303,70 @@ pattern to join by estimated cost. That estimate comes from an injectable
 
 ```typescript
 export interface JoinCostEstimator {
-  estimateJoinCost(entry: ScanEntry, bindings: TermBinding[]): number;
+  estimateJoinCost(
+    entry: ScanEntry,
+    bindings: TermBinding[],
+    stats?: PatternStats,
+  ): number;
 }
 ```
 
 The default is `BaselineJoinCostEstimator` — the shipped greedy formula: no
 bound pattern variable costs `bindings.length × candidates.length`; a bound
 pattern variable costs `bindings.length × average bucket size`
-(`candidates.length ÷ distinct bound values`, bounded below by 1), using the
-bound variable with the fewest distinct values. Swap it via
+(`candidates.length ÷ distinct values`, bounded below by 1), using the bound
+variable with the fewest distinct values. Swap it via
 `WazooSparqlEngineOptions.estimator`.
 
 **Contract:** the estimator receives the pattern's `ScanEntry` (whose
 `candidates` array holds the pattern's true store cardinality from the up-front
-scan) and the current bindings, and nothing else — no store access, no
-statistics beyond the entry's candidates. It must be pure and deterministic.
-Crucially, the estimate affects **only join order, never results** (SPARQL 1.1
-§18.2.2: joins commute, so every order yields the same solution multiset); the
-W3C differential gate is the guard. Planner pieces 2–3 (statistics source,
-join-order search) plug in behind this seam.
+scan), the current bindings, and the pattern's optional `PatternStats` — and
+nothing else: no store access. It must be pure and deterministic. Crucially, the
+estimate affects **only join order, never results** (SPARQL 1.1 §18.2.2: joins
+commute, so every order yields the same solution multiset); the W3C differential
+gate is the guard. Planner piece 3 (join-order search) plugs in behind this
+seam.
+
+### 5a. Statistics source
+
+The greedy loop's bucket-size arithmetic is only as good as its distinct-value
+counts. `BaselineJoinCostEstimator` therefore takes per-pattern statistics
+(planner piece 2, issue #129) from `PatternStatistics`
+(`src/planner/pattern-statistics.ts`), the per-query statistics source:
+
+```typescript
+export interface PatternStats {
+  candidates: number;
+  distinctByVar: Partial<Record<string, number>>;
+}
+
+export class PatternStatistics {
+  constructor(store: rdfjs.Source<rdfjs.Quad>);
+  statsFor(storeView, entry: ScanEntry): Promise<PatternStats>;
+}
+```
+
+`PatternStatistics` is created once per query evaluation and threaded through
+every group, so statistics are computed once per query — keyed by pattern
+signature — never re-derived inside the greedy per-step loop. It resolves each
+pattern's stats in this order:
+
+1. **Store hook** — a store exposing `estimateStats(pattern)` (mirroring the
+   `countQuads` capability, decision #12) supplies its own numbers; the engine
+   uses them when present. `GraphScopedStore` forwards the hook like it forwards
+   `version`.
+2. **Scoped fallback** — named-graph scopes (GRAPH) always derive from the
+   pattern's own scoped candidate scan; the hook cannot see the scope, and the
+   scoped candidates are exact for that graph.
+3. **Bounded fallback** — otherwise the same shape is derived from the pattern's
+   already-scanned candidates: exact cardinality plus a distinct-value pass
+   capped at `DISTINCT_SAMPLE_CAP` candidates (exact below the cap, a
+   deterministic evenly-spaced sample above it), so large stores never pay an
+   unbounded counting pass. On identical data the fallback agrees exactly with a
+   hook answering the same numbers.
+
+Because stats only ever influence join **order** — never results — a store
+providing `estimateStats` (or not) is fully transparent to query output.
 
 ## Term utilities (exported from `src/mod.ts`)
 
@@ -352,12 +397,14 @@ Types:
 [`WazooSparqlEngineOptions`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngineOptions),
 [`WazooSparqlTransaction`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlTransaction),
 `IriFunction`, `IriFunctionMap` (link on JSR once published),
-`JoinCostEstimator` (link on JSR once published),
+`JoinCostEstimator` (link on JSR once published), `PatternStats`,
+`StoreStatisticsHook` (link on JSR once published),
 [`CanonicalTerm`](https://jsr.io/@wazoo/sparql-engine/doc/~/CanonicalTerm).
 
 Values/classes:
 [`WazooSparqlEngine`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngine),
-`BaselineJoinCostEstimator` (link on JSR once published),
+`BaselineJoinCostEstimator` (link on JSR once published), `PatternStatistics`,
+`DISTINCT_SAMPLE_CAP` (link on JSR once published),
 [`MemoryStore`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStore),
 [`MemoryStream`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStream),
 [`DataFactory`](https://jsr.io/@wazoo/sparql-engine/doc/~/DataFactory),

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -45,6 +45,7 @@ import {
   BaselineJoinCostEstimator,
   type JoinCostEstimator,
 } from "@/planner/join-cost-estimator.ts";
+import { PatternStatistics } from "@/planner/pattern-statistics.ts";
 import {
   expandReifiedTriples,
   isReifiesPattern,
@@ -94,10 +95,10 @@ export interface BgpEvaluatorOptions {
   /**
    * estimator supplies the join-cost estimator the greedy reorderer uses
    * to pick the next pattern to join (see JoinCostEstimator for the
-   * contract). Defaults to BaselineJoinCostEstimator. The estimate affects
-   * only join order — never results (SPARQL 1.1 §18.2.2). Planner pieces
-   * 2–3 (#129/#130) plug the statistics source and join-order search
-   * behind this same seam.
+   * contract). Defaults to BaselineJoinCostEstimator, which also consumes
+   * the per-pattern statistics from PatternStatistics (issue #129). The
+   * estimate affects only join order — never results (SPARQL 1.1 §18.2.2).
+   * Planner piece 3 (#130) plugs the join-order search behind this seam.
    */
   estimator?: JoinCostEstimator;
 }
@@ -172,11 +173,21 @@ export class BgpEvaluator {
     }
     // The top-level evaluation runs against the default graph (matching
     // Comunica, whose plain patterns never see named-graph quads); GRAPH
-    // patterns scope further inside.
+    // patterns scope further inside. One statistics source is created per
+    // query evaluation and threaded through every group, so pattern
+    // statistics are computed once per query (issue #129) — the greedy
+    // reorder loop and repeated BGP blocks never re-derive them.
     const defaultScope = this.store instanceof GraphScopedStore
       ? this.store
       : new GraphScopedStore(this.store, defaultGraph());
-    return await this.evaluateGroup(patterns, [{}], defaultScope, baseIri);
+    const stats = new PatternStatistics(this.store);
+    return await this.evaluateGroup(
+      patterns,
+      [{}],
+      defaultScope,
+      stats,
+      baseIri,
+    );
   }
 
   /**
@@ -772,6 +783,7 @@ export class BgpEvaluator {
     patterns: Pattern[],
     bindings: TermBinding[],
     store: rdfjs.Source<rdfjs.Quad>,
+    stats: PatternStatistics,
     baseIri?: string,
   ): Promise<TermBinding[]> {
     // Resolve the EXISTS snapshot once for this group and thread it down, so
@@ -796,6 +808,7 @@ export class BgpEvaluator {
         result,
         store,
         snapshot,
+        stats,
         baseIri,
       );
     }
@@ -805,6 +818,7 @@ export class BgpEvaluator {
         result,
         store,
         snapshot,
+        stats,
         baseIri,
       );
     }
@@ -823,11 +837,18 @@ export class BgpEvaluator {
     bindings: TermBinding[] | Iterable<TermBinding>,
     store: rdfjs.Source<rdfjs.Quad>,
     snapshot: ExistsSnapshot | null,
+    stats: PatternStatistics,
     baseIri?: string,
   ): Promise<Iterable<TermBinding>> {
     switch (pattern.type) {
       case "bgp":
-        return await this.joinBgp(pattern.triples, bindings, store, snapshot);
+        return await this.joinBgp(
+          pattern.triples,
+          bindings,
+          store,
+          snapshot,
+          stats,
+        );
       case "filter": {
         const context = expressionContainsExists(pattern.expression)
           ? this.scopedExistsContext(store, snapshot, baseIri)
@@ -860,6 +881,7 @@ export class BgpEvaluator {
           innerPatterns,
           [{}],
           store,
+          stats,
           baseIri,
         );
         const context = filters.some(expressionContainsExists)
@@ -878,6 +900,7 @@ export class BgpEvaluator {
           pattern.patterns,
           [{}],
           store,
+          stats,
           baseIri,
         );
         return minus(bindings, right);
@@ -889,7 +912,7 @@ export class BgpEvaluator {
         const branchResults: TermBinding[][] = [];
         for (const branch of pattern.patterns) {
           branchResults.push(
-            await this.evaluateGroup([branch], [{}], store, baseIri),
+            await this.evaluateGroup([branch], [{}], store, stats, baseIri),
           );
         }
         return innerJoin(bindings, branchResults.flat());
@@ -967,6 +990,7 @@ export class BgpEvaluator {
             innerPatterns,
             [{}],
             scopedStore,
+            stats,
             baseIri,
           );
           for (const binding of inner) {
@@ -988,6 +1012,7 @@ export class BgpEvaluator {
           pattern.patterns,
           [{}],
           store,
+          stats,
           baseIri,
         );
         return innerJoin(bindings, groupResult);
@@ -999,6 +1024,7 @@ export class BgpEvaluator {
             pattern.patterns,
             [{}],
             store,
+            stats,
             baseIri,
           );
           return innerJoin(bindings, inner);
@@ -1043,6 +1069,7 @@ export class BgpEvaluator {
     bindings: TermBinding[] | Iterable<TermBinding>,
     store: rdfjs.Source<rdfjs.Quad>,
     snapshot: ExistsSnapshot | null,
+    stats: PatternStatistics,
   ): Promise<Iterable<TermBinding>> {
     // Reified-triple patterns (`<< s p o >>`, annotation `{| ... |}`) expand
     // into plain `rdf:reifies` triples before any scanning or reordering.
@@ -1060,6 +1087,7 @@ export class BgpEvaluator {
         bindings,
         store,
         prebuiltIndex,
+        stats,
       );
     }
     // A single-pattern BGP has no chain to stream, so it takes the eager
@@ -1112,9 +1140,15 @@ export class BgpEvaluator {
     bindings: TermBinding[] | Iterable<TermBinding>,
     store: rdfjs.Source<rdfjs.Quad>,
     prebuiltIndex: QuadIndex | null,
+    stats: PatternStatistics,
   ): Promise<TermBinding[]> {
     const remaining = await Promise.all(
       triplePatterns.map((pattern) => scanEntry(store, pattern)),
+    );
+    // Resolve each pattern's statistics once for this BGP (cached by the
+    // per-query source by pattern signature), never inside the greedy loop.
+    const perEntryStats = await Promise.all(
+      remaining.map((entry) => stats.statsFor(store, entry)),
     );
 
     let result: TermBinding[] = Array.isArray(bindings)
@@ -1124,7 +1158,11 @@ export class BgpEvaluator {
       let bestIndex = 0;
       let bestCost = Number.POSITIVE_INFINITY;
       for (let index = 0; index < remaining.length; index++) {
-        const cost = this.estimator.estimateJoinCost(remaining[index], result);
+        const cost = this.estimator.estimateJoinCost(
+          remaining[index],
+          result,
+          perEntryStats[index],
+        );
         if (cost < bestCost) {
           bestCost = cost;
           bestIndex = index;

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -63,7 +63,8 @@ export interface SparqlEvaluatorOptions {
 
   /**
    * estimator supplies the BGP join-cost estimator (see
-   * JoinCostEstimator); defaults to the baseline greedy formula. Only
+   * JoinCostEstimator); defaults to the baseline greedy formula (which
+   * also consumes the per-pattern statistics source, issue #129). Only
    * affects join order, never results.
    */
   estimator?: JoinCostEstimator;

--- a/src/evaluator/update-evaluator.ts
+++ b/src/evaluator/update-evaluator.ts
@@ -61,7 +61,8 @@ export interface UpdateEvaluatorOptions {
 
   /**
    * estimator supplies the BGP join-cost estimator (see
-   * JoinCostEstimator); defaults to the baseline greedy formula. Only
+   * JoinCostEstimator); defaults to the baseline greedy formula (which
+   * also consumes the per-pattern statistics source, issue #129). Only
    * affects join order, never results.
    */
   estimator?: JoinCostEstimator;

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -20,6 +20,14 @@ export type {
 } from "@/evaluator/expression-evaluator.ts";
 export { BaselineJoinCostEstimator } from "@/planner/join-cost-estimator.ts";
 export type { JoinCostEstimator } from "@/planner/join-cost-estimator.ts";
+export {
+  DISTINCT_SAMPLE_CAP,
+  PatternStatistics,
+} from "@/planner/pattern-statistics.ts";
+export type {
+  PatternStats,
+  StoreStatisticsHook,
+} from "@/planner/pattern-statistics.ts";
 
 export { MemoryStore, MemoryStream } from "@/store/memory-store.ts";
 export { DataFactory, dataFactory } from "@/term/mod.ts";

--- a/src/planner/join-cost-estimator.test.ts
+++ b/src/planner/join-cost-estimator.test.ts
@@ -127,6 +127,55 @@ Deno.test(
 );
 
 Deno.test(
+  "BaselineJoinCostEstimator - stats candidates and distinct counts drive the cost",
+  () => {
+    // With stats, the bucket divisor is the store's distinct count for the
+    // bound variable (4), not the 1 distinct value the bindings happen to
+    // carry: cost = 2 bindings x (200 / 4) = 100. Without stats the same
+    // bindings cost 2 x (200 / 1) = 400 (the piece-1 binding-derived bound).
+    const bindings: TermBinding[] = [
+      { x: namedNode("http://example.org/v1") },
+      { x: namedNode("http://example.org/v1") },
+    ];
+    const entry = {
+      subject: patternVar,
+      predicate: constant,
+      object: otherVar,
+      candidates: candidateQuads(200),
+    };
+    const withStats = baseline.estimateJoinCost(entry, bindings, {
+      candidates: 200,
+      distinctByVar: { x: 4, y: 100 },
+    });
+    assertEquals(withStats, 100);
+    const withoutStats = baseline.estimateJoinCost(entry, bindings);
+    assertEquals(withoutStats, 400);
+  },
+);
+
+Deno.test(
+  "BaselineJoinCostEstimator - a variable's stats are ignored while it stays unbound",
+  () => {
+    // Only ?y is bound in the bindings; ?x's (very selective) store distinct
+    // count must not be used — the join cannot probe by an unbound variable.
+    const bindings: TermBinding[] = [{ y: namedNode("http://example.org/v1") }];
+    const entry = {
+      subject: patternVar,
+      predicate: constant,
+      object: otherVar,
+      candidates: candidateQuads(200),
+    };
+    const cost = baseline.estimateJoinCost(entry, bindings, {
+      candidates: 200,
+      distinctByVar: { x: 2, y: 100 },
+    });
+    // 1 binding x (200 / y's 100 distinct) = 2. Using ?x's 2 instead would
+    // have produced 100.
+    assertEquals(cost, 2);
+  },
+);
+
+Deno.test(
   "BaselineJoinCostEstimator - fully bound constants never count as variables",
   () => {
     // Every pattern position is a constant: no bound pattern variable to

--- a/src/planner/join-cost-estimator.ts
+++ b/src/planner/join-cost-estimator.ts
@@ -1,4 +1,5 @@
 import type { ScanEntry, TermBinding } from "@/evaluator/join.ts";
+import type { PatternStats } from "@/planner/pattern-statistics.ts";
 import { termKey } from "@/term/mod.ts";
 
 /**
@@ -11,31 +12,47 @@ import { termKey } from "@/term/mod.ts";
  *
  * Contract: an estimator receives the pattern's ScanEntry — whose
  * candidates array holds the pattern's true store cardinality from the
- * up-front scan in evaluateWithReordering — plus the current bindings. It
- * may assume nothing else: no store access, and no statistics beyond the
- * entry's candidates (planner piece 2 adds an optional store statistics
- * hook that feeds richer per-pattern stats behind this same seam). The
- * estimator must be pure and deterministic: the same entry and bindings
- * always produce the same cost, and calling it must have no side effects.
+ * up-front scan in evaluateWithReordering — plus the current bindings and
+ * the pattern's statistics (planner piece 2, issue #129). Stats are
+ * optional: they carry the store's per-variable distinct-value counts (see
+ * PatternStats), and the estimator must degrade gracefully when absent (or
+ * when a variable's distinct count is unknown). It may assume nothing else:
+ * no store access. The estimator must be pure and deterministic: the same
+ * entry, bindings, and stats always produce the same cost, and calling it
+ * must have no side effects.
  */
 export interface JoinCostEstimator {
   /**
    * estimateJoinCost returns the estimated number of quad iterations
    * joining the given pattern against the current bindings will perform.
    * Lower is cheaper. A cost of 0 (for example, no bindings left to join)
-   * is valid.
+   * is valid. stats, when supplied, carries the pattern's store statistics
+   * (candidates and per-variable distinct counts); pass undefined when the
+   * caller has none.
    */
-  estimateJoinCost(entry: ScanEntry, bindings: TermBinding[]): number;
+  estimateJoinCost(
+    entry: ScanEntry,
+    bindings: TermBinding[],
+    stats?: PatternStats,
+  ): number;
 }
 
 /**
  * BaselineJoinCostEstimator is the default JoinCostEstimator: the greedy
- * formula the engine shipped before the estimator seam existed, preserved
- * behavior-identical. Bindings that bind no pattern variable iterate every
- * candidate quad; bindings that bind a pattern variable probe the
- * positional index, costing roughly the average bucket size for the bound
- * variable with the fewest distinct bound values (candidate count divided
- * by that variable's distinct count) — a conservative per-binding bound.
+ * formula the engine shipped before the estimator seam existed, extended to
+ * use the piece-2 statistics when available. Bindings that bind no pattern
+ * variable iterate every candidate quad; bindings that bind a pattern
+ * variable probe the positional index, costing roughly the average bucket
+ * size for the bound variable with the fewest distinct bound values.
+ *
+ * The average bucket is candidate count divided by that variable's distinct
+ * count. The statistics source (PatternStatistics) supplies the store's
+ * distinct-value count for the pattern's variables, which is the true bucket
+ * average across the whole store; without stats (or for a variable the store
+ * has no count for), the estimator falls back to the distinct count of the
+ * values actually bound in the current bindings — the piece-1 behavior,
+ * which adapts to the join's current state but overestimates when few
+ * bindings remain. Either way the cost is a conservative per-binding bound.
  */
 export class BaselineJoinCostEstimator implements JoinCostEstimator {
   /**
@@ -45,37 +62,47 @@ export class BaselineJoinCostEstimator implements JoinCostEstimator {
   public estimateJoinCost(
     entry: ScanEntry,
     bindings: TermBinding[],
+    stats?: PatternStats,
   ): number {
     if (bindings.length === 0) {
       return 0;
     }
+    const candidates = stats?.candidates ?? entry.candidates.length;
     let mostSelectiveDistinct = Number.POSITIVE_INFINITY;
     for (const term of [entry.subject, entry.predicate, entry.object]) {
       if (term.termType !== "Variable") {
         continue;
       }
-      const distinct = new Set<string>();
+      const name = term.value;
+      // Only a variable bound in the current bindings can probe the index.
+      const boundDistinct = new Set<string>();
       for (const binding of bindings) {
-        const value = binding[term.value];
+        const value = binding[name];
         if (value !== undefined) {
-          distinct.add(termKey(value));
+          boundDistinct.add(termKey(value));
         }
       }
-      if (distinct.size === 0) {
+      if (boundDistinct.size === 0) {
         continue;
       }
-      if (distinct.size < mostSelectiveDistinct) {
-        mostSelectiveDistinct = distinct.size;
+      // Prefer the store's distinct-value count for the variable when the
+      // stats source supplies it: it reflects the true average bucket size
+      // across the whole store. Otherwise fall back to the distinct count of
+      // the values actually bound in the current bindings (the piece-1
+      // behavior, which adapts to the join's current state).
+      const storeDistinct = stats?.distinctByVar[name];
+      const distinct = storeDistinct !== undefined && storeDistinct > 0
+        ? storeDistinct
+        : boundDistinct.size;
+      if (distinct < mostSelectiveDistinct) {
+        mostSelectiveDistinct = distinct;
       }
     }
     if (mostSelectiveDistinct === Number.POSITIVE_INFINITY) {
       // No bound pattern variable: every binding iterates all candidates.
-      return bindings.length * entry.candidates.length;
+      return bindings.length * candidates;
     }
-    const averageBucket = Math.max(
-      1,
-      entry.candidates.length / mostSelectiveDistinct,
-    );
+    const averageBucket = Math.max(1, candidates / mostSelectiveDistinct);
     return bindings.length * averageBucket;
   }
 }

--- a/src/planner/pattern-statistics.test.ts
+++ b/src/planner/pattern-statistics.test.ts
@@ -1,0 +1,221 @@
+import { assertEquals } from "@std/assert";
+import type * as rdfjs from "@rdfjs/types";
+import { DataFactory } from "@/term/mod.ts";
+import type { ScanEntry } from "@/evaluator/join.ts";
+import { GraphScopedStore } from "@/quad-store.ts";
+import {
+  DISTINCT_SAMPLE_CAP,
+  fallbackStats,
+  patternSignature,
+  PatternStatistics,
+} from "@/planner/pattern-statistics.ts";
+import type { PatternStats } from "@/planner/pattern-statistics.ts";
+import { MemoryStore as Store } from "@/store/memory-store.ts";
+import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
+
+const { namedNode, literal, quad, variable, defaultGraph } = DataFactory;
+
+const patternVar = variable("x");
+const objectVar = variable("o");
+const constantP = namedNode("http://example.org/p");
+
+/** seedStore returns a store holding one quad per subject s0..s(n-1). */
+function seedStore(count: number, store = new Store()): Store {
+  for (let index = 0; index < count; index++) {
+    store.addQuad(
+      quad(
+        namedNode(`http://example.org/s${index}`),
+        constantP,
+        literal(`v${index}`),
+      ),
+    );
+  }
+  return store;
+}
+
+/** entry builds a ScanEntry over ?x <p> ?o with the given candidates. */
+function entry(candidates: rdfjs.Quad[]): ScanEntry {
+  return {
+    subject: patternVar,
+    predicate: constantP,
+    object: objectVar,
+    candidates,
+  };
+}
+
+/** statsStore wraps a MemoryStore with an estimateStats hook. */
+function statsStore(
+  store: Store,
+  estimateStats: () => PatternStats | undefined,
+): Store & { estimateStats: () => PatternStats | undefined } {
+  return Object.assign(store, { estimateStats });
+}
+
+/** candidatesFor returns every quad of the store as an array. */
+function candidatesFor(store: Store): rdfjs.Quad[] {
+  return store.getQuads(null, null, null);
+}
+
+/** collectMatch drains a store view's match stream into an array. */
+function collectMatch(store: rdfjs.Source<rdfjs.Quad>): rdfjs.Quad[] {
+  const quads: rdfjs.Quad[] = [];
+  store.match(null, null, null).on("data", (q: rdfjs.Quad) => quads.push(q));
+  return quads;
+}
+
+Deno.test("patternSignature - distinguishes patterns by terms and shape", () => {
+  const plain = entry([]);
+  const reifies: ScanEntry = { ...plain, reifies: true };
+  const tripleTerm: ScanEntry = { ...plain, tripleTermObject: true };
+  assertEquals(patternSignature(plain), "(?x|uri:http://example.org/p|?o)");
+  assertEquals(patternSignature(reifies), "R(?x|uri:http://example.org/p|?o)");
+  assertEquals(
+    patternSignature(tripleTerm),
+    "T(?x|uri:http://example.org/p|?o)",
+  );
+});
+
+Deno.test("PatternStatistics - hook supplies the stats and is cached", async () => {
+  const store = seedStore(10);
+  let calls = 0;
+  const hooked = statsStore(store, () => {
+    calls += 1;
+    return { candidates: 10, distinctByVar: { x: 10, o: 10 } };
+  });
+  const source = new PatternStatistics(hooked);
+  assertEquals(source.hasHook, true);
+
+  const first = await source.statsFor(hooked, entry(candidatesFor(hooked)));
+  assertEquals(first, { candidates: 10, distinctByVar: { x: 10, o: 10 } });
+  const second = await source.statsFor(hooked, entry(candidatesFor(hooked)));
+  assertEquals(second, first);
+  // The cache absorbs the second request: the hook ran exactly once.
+  assertEquals(calls, 1);
+});
+
+Deno.test("PatternStatistics - no hook falls back to the candidates scan", async () => {
+  const store = seedStore(10);
+  const source = new PatternStatistics(store);
+  assertEquals(source.hasHook, false);
+
+  const stats = await source.statsFor(store, entry(candidatesFor(store)));
+  // Exact distinct counts: 10 subjects, 1 predicate, 10 distinct objects.
+  assertEquals(stats, {
+    candidates: 10,
+    distinctByVar: { x: 10, o: 10 },
+  });
+});
+
+Deno.test(
+  "PatternStatistics - fallback agrees with the hook on identical data",
+  async () => {
+    const plain = seedStore(10);
+    const candidates = candidatesFor(plain);
+
+    // The hook answers with the exact numbers the fallback derives.
+    const hooked = statsStore(
+      seedStore(10),
+      () => fallbackStats(entry(candidates)),
+    );
+    const fromHook = await new PatternStatistics(hooked).statsFor(
+      hooked,
+      entry(candidates),
+    );
+    const fromFallback = await new PatternStatistics(plain).statsFor(
+      plain,
+      entry(candidates),
+    );
+    assertEquals(fromHook, fromFallback);
+  },
+);
+
+Deno.test(
+  "PatternStatistics - a hook returning undefined selects the fallback",
+  async () => {
+    const store = seedStore(10);
+    const hooked = statsStore(store, () => undefined);
+    const stats = await new PatternStatistics(hooked).statsFor(
+      hooked,
+      entry(candidatesFor(hooked)),
+    );
+    assertEquals(stats.candidates, 10);
+    assertEquals(stats.distinctByVar.o, 10);
+  },
+);
+
+Deno.test(
+  "PatternStatistics - named-graph scope never consults the hook",
+  async () => {
+    const store = seedStore(5);
+    const hooked = statsStore(store, () => {
+      throw new Error("hook must not be consulted in a named scope");
+    });
+    const source = new PatternStatistics(hooked);
+    const graph = namedNode("http://example.org/g");
+    const scoped = new GraphScopedStore(hooked, graph);
+    const stats = await source.statsFor(
+      scoped,
+      entry(collectMatch(scoped)),
+    );
+    // The scoped candidates are empty (all data is in the default graph),
+    // so the exact fallback reports zero candidates — never the hook.
+    assertEquals(stats, { candidates: 0, distinctByVar: {} });
+  },
+);
+
+Deno.test(
+  "PatternStatistics - default-graph scope sees through the GraphScopedStore view",
+  async () => {
+    const store = seedStore(5);
+    let calls = 0;
+    const hooked = statsStore(store, () => {
+      calls += 1;
+      return { candidates: 5, distinctByVar: { x: 5, o: 5 } };
+    });
+    const source = new PatternStatistics(hooked);
+    // The default-scope view wraps the raw store; the hook must be visible
+    // through it (mirroring version forwarding).
+    const scoped = new GraphScopedStore(hooked, defaultGraph());
+    const stats = await source.statsFor(
+      scoped,
+      entry(collectMatch(scoped)),
+    );
+    assertEquals(stats, { candidates: 5, distinctByVar: { x: 5, o: 5 } });
+    assertEquals(calls, 1);
+  },
+);
+
+Deno.test("fallbackStats - bounded sample stays deterministic for large scans", () => {
+  // 4x the cap: the stride samples every 4th candidate, so the distinct
+  // counts are exact for uniform data (subjects/objects all unique).
+  const count = DISTINCT_SAMPLE_CAP * 4;
+  const stats = fallbackStats(entry(candidatesFor(seedStore(count))));
+  assertEquals(stats.candidates, count);
+  assertEquals(stats.distinctByVar.x, count);
+  assertEquals(stats.distinctByVar.o, count);
+});
+
+Deno.test("fallbackStats - zero candidates reports empty stats", () => {
+  const stats = fallbackStats(entry([]));
+  assertEquals(stats, { candidates: 0, distinctByVar: {} });
+});
+
+Deno.test(
+  "WazooSparqlEngine - a stats-providing store feeds the estimator without changing results",
+  async () => {
+    const store = seedStore(10);
+    const hooked = statsStore(
+      store,
+      () => ({ candidates: 10, distinctByVar: { x: 10, o: 10 } }),
+    );
+    const engine = new WazooSparqlEngine({ store: hooked });
+    const query =
+      "SELECT ?x ?o WHERE { ?x <http://example.org/p> ?o . ?x ?p ?o }";
+    const withHook = await engine.execute({ query });
+    const withoutHook = await new WazooSparqlEngine({
+      store: seedStore(10),
+    }).execute({ query });
+    assertEquals(withHook, withoutHook);
+    assertEquals(withHook.kind, "select");
+  },
+);

--- a/src/planner/pattern-statistics.ts
+++ b/src/planner/pattern-statistics.ts
@@ -1,0 +1,216 @@
+import type * as rdfjs from "@rdfjs/types";
+import type { Term as SparqlTerm, Triple } from "@/parser/sparql-parser.ts";
+import type { ScanEntry } from "@/evaluator/join.ts";
+import { GraphScopedStore } from "@/quad-store.ts";
+import { sparqlTermToRdfTerm, termKey } from "@/term/mod.ts";
+
+/**
+ * PatternStats are the per-pattern statistics that feed the join-cost
+ * estimator (planner piece 2, issue #129):
+ *
+ *   - candidates — how many quads the pattern matches in the store (the
+ *     pattern's cardinality). For the default-graph scope this agrees with
+ *     ScanEntry.candidates, which the join actually materializes;
+ *   - distinctByVar — for each variable position of the pattern, how many
+ *     distinct values that variable takes across the matched quads. This is
+ *     the per-variable value-frequency that lets the estimator see true
+ *     index bucket sizes, so two medium-selectivity patterns that share a
+ *     variable are recognized as cheaper than unrelated patterns.
+ *
+ * Stats only ever influence join order — never results (SPARQL 1.1 §18.2.2).
+ */
+export interface PatternStats {
+  candidates: number;
+  distinctByVar: Partial<Record<string, number>>;
+}
+
+/**
+ * StoreStatisticsHook is the optional store capability that feeds the
+ * statistics source (mirroring the countQuads precedent, decision #12): a
+ * store that can answer pattern-cardinality questions efficiently exposes
+ * estimateStats, and the engine uses it when present, falling back to a
+ * bounded derivation from the pattern's own candidate scan otherwise.
+ *
+ * The hook returns the statistics for the given triple pattern over the same
+ * universe the store's match() exposes. A store whose data lives in the
+ * default graph (the typical case) thus returns numbers that agree exactly
+ * with the engine's fallback on identical data; a store with named-graph
+ * data should scope its own answer accordingly. Returning undefined (or not
+ * implementing the hook at all) selects the fallback for that pattern.
+ */
+export type StoreStatisticsHook = {
+  estimateStats?(
+    pattern: Triple,
+  ): PatternStats | undefined | Promise<PatternStats | undefined>;
+};
+
+/** DISTINCT_SAMPLE_CAP bounds the fallback distinct-value pass. */
+export const DISTINCT_SAMPLE_CAP = 1024;
+
+/**
+ * patternSignature renders a stable cache key for a pattern: variables by
+ * name, constants by term key, with markers for the reifies / triple-term
+ * object join shapes (which scan differently than plain positional matches).
+ */
+export function patternSignature(entry: ScanEntry): string {
+  const term = (t: SparqlTerm): string => {
+    if (t.termType === "Variable" || t.termType === "BlankNode") {
+      return `?${t.value}`;
+    }
+    if (t.termType === "Quad") {
+      return `<<${term(t.subject)}|${term(t.predicate)}|${term(t.object)}>>`;
+    }
+    return termKey(sparqlTermToRdfTerm(t));
+  };
+  const shape = entry.reifies ? "R" : entry.tripleTermObject ? "T" : "";
+  return `${shape}(${term(entry.subject)}|${term(entry.predicate)}|${
+    term(entry.object)
+  })`;
+}
+
+/**
+ * PatternStatistics is the statistics source for one query evaluation. It
+ * resolves PatternStats for a BGP pattern once per query, keyed by pattern
+ * signature, so the greedy join-order loop in evaluateWithReordering never
+ * re-derives them per step.
+ *
+ * Resolution order:
+ *   1. A store exposing estimateStats supplies its own numbers (cached).
+ *   2. Named-graph scopes (GRAPH) always derive from the pattern's scoped
+ *      candidate scan — the store hook cannot see the scope, and the scoped
+ *      candidates are exact for that graph.
+ *   3. Otherwise the bounded fallback derives the same shape from the
+ *      pattern's already-scanned candidates: the exact cardinality plus a
+ *      distinct-value pass capped at DISTINCT_SAMPLE_CAP candidates (exact
+ *      below the cap, a deterministic evenly-spaced sample above it), so
+ *      large stores never pay an unbounded counting pass.
+ */
+export class PatternStatistics {
+  private readonly cache = new Map<string, PatternStats>();
+
+  private readonly hook: StoreStatisticsHook["estimateStats"];
+
+  public constructor(store: rdfjs.Source<rdfjs.Quad>) {
+    const candidate = (store as StoreStatisticsHook).estimateStats;
+    this.hook = typeof candidate === "function"
+      ? candidate.bind(store)
+      : undefined;
+  }
+
+  /** hasHook reports whether the store exposes estimateStats. */
+  public get hasHook(): boolean {
+    return this.hook !== undefined;
+  }
+
+  /**
+   * statsFor resolves the statistics for one scanned pattern within the
+   * given store scope (see class doc for the resolution order). The scope is
+   * the store view the pattern was scanned against; the result is cached by
+   * pattern signature per scope kind.
+   */
+  public async statsFor(
+    storeView: rdfjs.Source<rdfjs.Quad>,
+    entry: ScanEntry,
+  ): Promise<PatternStats> {
+    const namedScope = storeView instanceof GraphScopedStore &&
+      storeView.graph.termType !== "DefaultGraph";
+    const key = `${namedScope ? "s" : "d"}::${patternSignature(entry)}`;
+    const cached = this.cache.get(key);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const stats = await this.resolve(entry, namedScope);
+    this.cache.set(key, stats);
+    return stats;
+  }
+
+  private async resolve(
+    entry: ScanEntry,
+    namedScope: boolean,
+  ): Promise<PatternStats> {
+    if (
+      !namedScope && this.hook !== undefined && !entry.reifies &&
+      !entry.tripleTermObject
+    ) {
+      const fromHook = await this.hook({
+        subject: entry.subject,
+        predicate: entry.predicate,
+        object: entry.object,
+      });
+      if (fromHook !== undefined) {
+        return fromHook;
+      }
+    }
+    return fallbackStats(entry);
+  }
+}
+
+/**
+ * fallbackStats derives PatternStats from the pattern's own candidate scan —
+ * the candidates array evaluateWithReordering already materializes — so the
+ * fallback needs no extra store access. The distinct-value pass is bounded:
+ * candidates up to DISTINCT_SAMPLE_CAP count exactly; larger scans sample an
+ * evenly spaced stride of at most the cap and scale the distinct count by
+ * the sampling ratio, keeping large-store overhead constant.
+ */
+export function fallbackStats(entry: ScanEntry): PatternStats {
+  const quads = entry.candidates;
+  // Track each variable position by its query variable name (the same
+  // name the join binds and the estimator reads), so distinctByVar is keyed
+  // like the hook's contract. Blank-node pattern positions act as query
+  // variables named `_:label` (matching getQueryVarName in join.ts).
+  const positions: { name: string; index: 0 | 1 | 2 }[] = [];
+  for (
+    const [term, index] of [
+      [entry.subject, 0],
+      [entry.predicate, 1],
+      [entry.object, 2],
+    ] as const
+  ) {
+    if (term.termType === "Variable" || term.termType === "BlankNode") {
+      positions.push({
+        name: term.termType === "BlankNode" ? `_:${term.value}` : term.value,
+        index,
+      });
+    }
+  }
+  const distinctByVar: Partial<Record<string, number>> = {};
+  const n = quads.length;
+  if (n === 0) {
+    return { candidates: 0, distinctByVar };
+  }
+  const quadTerm = (quad: rdfjs.Quad, index: 0 | 1 | 2): rdfjs.Term =>
+    index === 0 ? quad.subject : index === 1 ? quad.predicate : quad.object;
+  if (n <= DISTINCT_SAMPLE_CAP) {
+    const sets = positions.map(() => new Set<string>());
+    for (const quad of quads) {
+      for (let index = 0; index < positions.length; index++) {
+        sets[index].add(termKey(quadTerm(quad, positions[index].index)));
+      }
+    }
+    for (let index = 0; index < positions.length; index++) {
+      distinctByVar[positions[index].name] = sets[index].size;
+    }
+    return { candidates: n, distinctByVar };
+  }
+  // Bounded sample: stride = n / cap, so exactly ~cap candidates are
+  // examined, evenly spaced (deterministic — no randomness).
+  const stride = Math.ceil(n / DISTINCT_SAMPLE_CAP);
+  const sets = positions.map(() => new Set<string>());
+  let sampled = 0;
+  for (let index = 0; index < n; index += stride) {
+    const quad = quads[index];
+    for (let p = 0; p < positions.length; p++) {
+      sets[p].add(termKey(quadTerm(quad, positions[p].index)));
+    }
+    sampled++;
+  }
+  const scale = n / sampled;
+  for (let index = 0; index < positions.length; index++) {
+    distinctByVar[positions[index].name] = Math.min(
+      n,
+      Math.round(sets[index].size * scale),
+    );
+  }
+  return { candidates: n, distinctByVar };
+}

--- a/src/quad-store.ts
+++ b/src/quad-store.ts
@@ -1,5 +1,9 @@
 import type * as rdfjs from "@rdfjs/types";
-import type { Term as SparqlTerm } from "@/parser/sparql-parser.ts";
+import type { Term as SparqlTerm, Triple } from "@/parser/sparql-parser.ts";
+import type {
+  PatternStats,
+  StoreStatisticsHook,
+} from "@/planner/pattern-statistics.ts";
 import { MemoryStore } from "@/store/memory-store.ts";
 import { DataFactory, sameRdfTerm, termKey } from "@/term/mod.ts";
 
@@ -155,6 +159,22 @@ export class GraphScopedStore implements rdfjs.Source<rdfjs.Quad> {
    * the view (the view itself never mutates the data). */
   public get version(): number | null {
     return storeVersion(this.store);
+  }
+
+  /**
+   * estimateStats delegates to the wrapped store's statistics hook (issue
+   * #129), mirroring version. The PatternStatistics source consults it only
+   * at the default-graph scope — a named scope derives exact stats from its
+   * scoped candidates instead, since the hook cannot see the scope.
+   */
+  public estimateStats?(
+    pattern: Triple,
+  ): PatternStats | Promise<PatternStats | undefined> | undefined {
+    const hook = (this.store as StoreStatisticsHook).estimateStats;
+    if (typeof hook !== "function") {
+      return undefined;
+    }
+    return hook.call(this.store, pattern);
   }
 
   public match(

--- a/src/wazoo-sparql-engine.ts
+++ b/src/wazoo-sparql-engine.ts
@@ -69,10 +69,10 @@ export interface WazooSparqlEngineOptions {
 
   /**
    * estimator supplies the BGP join-cost estimator (see JoinCostEstimator);
-   * defaults to the baseline greedy formula. The estimate affects only
-   * join order — never results (SPARQL 1.1 §18.2.2). Planner pieces 2–3
-   * (#129/#130) plug the statistics source and join-order search behind
-   * this seam.
+   * defaults to the baseline greedy formula (which also consumes the
+   * per-pattern statistics source, issue #129). The estimate affects only
+   * join order — never results (SPARQL 1.1 §18.2.2). Planner piece 3
+   * (#130) plugs the join-order search behind this seam.
    */
   estimator?: JoinCostEstimator;
 }


### PR DESCRIPTION
Closes #129 — planner piece 2 of 3 (splits #75). Stacked on #131 (piece 1, estimator surface); retargets to main automatically when #131 merges.

## What lands

**The statistics source** (`src/planner/pattern-statistics.ts`): `PatternStats` (`{ candidates, distinctByVar }`) resolved once per query by `PatternStatistics` — created in `evaluateBgp`, threaded through every group, cached by pattern signature, so the greedy reorder loop never re-derives them per step.

Resolution order per pattern:
1. **Store hook** — a store exposing `estimateStats(pattern)` supplies its own numbers (the `countQuads` capability pattern, decision #12). `GraphScopedStore` forwards it like `version`.
2. **Scoped fallback** — named-graph scopes (GRAPH) derive from the pattern's own scoped candidate scan; the hook cannot see the scope, and the scoped candidates are exact for that graph.
3. **Bounded fallback** — same shape from the already-scanned candidates: exact cardinality plus a distinct-value pass capped at `DISTINCT_SAMPLE_CAP` (exact below, deterministic evenly-spaced sample above), so large stores never pay an unbounded counting pass.

**Estimator upgrade**: `JoinCostEstimator.estimateJoinCost` gains an optional `stats` argument; `BaselineJoinCostEstimator` uses the store's per-variable distinct count as the bucket divisor when available, falling back to the bound values' distinct count (piece-1 behavior). Stats only ever influence join order — never results (SPARQL 1.1 §18.2.2).

## Verification
- `deno task ci` green (433 tests; 12 new: hook/fallback/cache/agreement/bounded-sample/scope tests + 2 estimator stats tests)
- `deno task test:w3c` 345/345 — no result change
- `deno task bench:check` all budgets pass; `docs:link-check` 0 broken