### PR TITLE
feat: DP join-order search for small BGPs, greedy fallback (piece 3 of #75, #130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,33 +231,31 @@ per-group baseline). Each cell is the per-iteration average; every query is
 cross-verified to return identical results on all three engines before timing.
 Timings are machine-specific — run `deno task bench` for your own numbers.
 
-Core joins, 400-person graph (~2,200 quads):
-
-| query                        | wazoo   | comunica | oxigraph |
-| ---------------------------- | ------- | -------- | -------- |
-| full scan                    | 0.96 ms | 5.5 ms   | 12.2 ms  |
-| join (knows × name)          | 0.66 ms | 3.1 ms   | 3.4 ms   |
-| asymmetric join              | 1.2 ms  | 19.2 ms  | 19.3 ms  |
-| reorder chain, written order | 97.4 ms | 96.8 ms  | 4.2 ms   |
-| reorder chain, planner on    | 1.2 ms  | —        | —        |
+Core joins, 400-person graph (~2,200 quads):| query | wazoo | comunica |
+oxigraph | | ---------------------------- | -------- | -------- | -------- | |
+full scan | 1.1 ms | 6.0 ms | 8.8 ms | | join (knows × name) | 0.91 ms | 3.4 ms
+| 1.6 ms | | asymmetric join | 1.7 ms | 23.0 ms | 11.5 ms | | reorder chain,
+written order | 105.5 ms | 107.8 ms | 2.2 ms | | reorder chain, planner on | 1.5
+ms | — | — | | dp-join, DP plan | 62.2 ms | 190.4 ms | 1120 ms | | dp-join,
+greedy plan | 125.2 ms | — | — |
 
 EXISTS surface, 400-person graph:
 
-| query               | wazoo  | comunica | oxigraph |
-| ------------------- | ------ | -------- | -------- |
-| `FILTER EXISTS`     | 1.0 ms | 19.3 ms  | 1.6 ms   |
-| `FILTER NOT EXISTS` | 0.9 ms | 20.1 ms  | 1.4 ms   |
-| nested `EXISTS`     | 1.2 ms | 74.8 ms  | 1.7 ms   |
-| nested `NOT EXISTS` | 1.2 ms | 75.2 ms  | 1.8 ms   |
+| query               | wazoo   | comunica | oxigraph |
+| ------------------- | ------- | -------- | -------- |
+| `FILTER EXISTS`     | 0.70 ms | 21.5 ms  | 0.77 ms  |
+| `FILTER NOT EXISTS` | 0.64 ms | 23.4 ms  | 0.85 ms  |
+| nested `EXISTS`     | 0.87 ms | 88.8 ms  | 0.93 ms  |
+| nested `NOT EXISTS` | 0.86 ms | 127.7 ms | 0.93 ms  |
 
 EXISTS surface, 10,000-person graph (~55,000 quads):
 
 | query               | wazoo   | comunica | oxigraph |
 | ------------------- | ------- | -------- | -------- |
-| `FILTER EXISTS`     | 33.0 ms | 466.1 ms | 34.0 ms  |
-| `FILTER NOT EXISTS` | 33.2 ms | 466.2 ms | 32.9 ms  |
-| nested `EXISTS`     | 40.9 ms | 1.9 s    | 39.4 ms  |
-| nested `NOT EXISTS` | 43.0 ms | 1.8 s    | 40.6 ms  |
+| `FILTER EXISTS`     | 20.1 ms | 499.0 ms | 22.2 ms  |
+| `FILTER NOT EXISTS` | 19.3 ms | 484.7 ms | 21.4 ms  |
+| nested `EXISTS`     | 25.9 ms | 3.1 s    | 26.4 ms  |
+| nested `NOT EXISTS` | 26.8 ms | 2.2 s    | 31.5 ms  |
 
 Scaling the data 25x (400 → 10,000 people) grows wazoo's EXISTS cost ~35x while
 nesting stays within ~1.2x of the simple case at both scales: the snapshot is

--- a/bench/engine_bench.ts
+++ b/bench/engine_bench.ts
@@ -11,6 +11,7 @@ import {
   Store as OxigraphStore,
 } from "oxigraph";
 import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
+import { BaselineJoinCostEstimator } from "@/planner/join-cost-estimator.ts";
 import {
   canonicalizeComunicaTerm,
   getComunicaEngine,
@@ -196,6 +197,23 @@ const wazooEngineNoReorder = new WazooSparqlEngine({
   store: memoryStore,
   reorderPatterns: false,
 });
+// The greedy surrogate engine disables the DP join-order search (issue
+// #130) while keeping the exact baseline cost formula: the DP path activates
+// only for BaselineJoinCostEstimator instances, so an estimator object
+// delegating to the baseline formula runs the piece-1/2 greedy stepwise
+// planner. The dp-join group compares the two planners on the same query.
+const wazooGreedyEngine = new WazooSparqlEngine({
+  store: memoryStore,
+  estimator: {
+    estimateJoinCost(scan, bindings, stats) {
+      return new BaselineJoinCostEstimator().estimateJoinCost(
+        scan,
+        bindings,
+        stats,
+      );
+    },
+  },
+});
 const comunicaEngine = getComunicaEngine();
 
 // 10k-subject scaling group: the same person-ring shape at 25x the main
@@ -236,6 +254,17 @@ const chainQuery =
   "SELECT ?s ?grand ?n WHERE { ?s <http://xmlns.com/foaf/0.1/knows> ?friend . " +
   "?grand <http://xmlns.com/foaf/0.1/name> ?n . " +
   "?friend <http://xmlns.com/foaf/0.1/knows> ?grand }";
+// DP-vs-greedy shape (issue #130): two patterns sharing both variables (400
+// candidates each, buckets of 1) plus a smaller unrelated pattern (200
+// spouse edges). The greedy stepwise planner joins the unrelated pattern
+// first — it is the cheapest single join — then pays the full cross product
+// twice; the DP join-order search joins the shared pair first and pays it
+// once. Written order is irrelevant: both planners reorder. Result: 400 x
+// 200 = 80,000 rows on the shared benchmark graph.
+const dpJoinQuery =
+  "SELECT ?s ?o ?n ?z ?w WHERE { ?s <http://xmlns.com/foaf/0.1/knows> ?o . " +
+  "?s <http://xmlns.com/foaf/0.1/name> ?n . " +
+  "?z <http://example.org/spouse> ?w }";
 // Mutating update: moves every name quad to a new predicate. Used for the
 // cross-engine verification, which runs on fresh throwaway stores so a
 // broken engine that silently ignores updates is caught (its store would
@@ -894,6 +923,7 @@ await verifyConstructEquality(constructQuery, "construct");
 await verifyUpdateEquality(moveUpdateQuery, "update-move");
 await verifyUpdateEquality(rewriteUpdateQuery, "update-rewrite");
 await verifySelectEquality(chainQuery, "reorder-chain");
+await verifySelectEquality(dpJoinQuery, "dp-join");
 await verifySelectEquality(optionalQuery, "optional");
 await verifySelectEquality(minusQuery, "minus");
 await verifySelectEquality(unionQuery, "union");
@@ -1107,6 +1137,64 @@ Deno.bench({ name: "oxigraph - chain", group: "reorder-chain" }, () => {
   ) as unknown as OxigraphBinding[];
   if (result.length === 0) {
     throw new Error("oxigraph chain returned no bindings");
+  }
+});
+
+// dp-join: the DP join-order search (issue #130) vs the greedy stepwise
+// planner on the two-shared-variable shape. Both wazoo rows must return the
+// full 80,000-row result; the greedy surrogate runs the identical baseline
+// cost formula with the DP path disabled, isolating the ordering win.
+Deno.bench(
+  {
+    name: "wazoo - dp-join (DP plan)",
+    group: "dp-join",
+    baseline: true,
+  },
+  async () => {
+    const result = await wazooEngine.execute({ query: dpJoinQuery });
+    if (
+      result.kind !== "select" ||
+      result.data.results.bindings.length !== 80_000
+    ) {
+      throw new Error("wazoo dp-join (DP plan) returned the wrong row count");
+    }
+  },
+);
+
+Deno.bench(
+  {
+    name: "wazoo - dp-join (greedy surrogate)",
+    group: "dp-join",
+  },
+  async () => {
+    const result = await wazooGreedyEngine.execute({ query: dpJoinQuery });
+    if (
+      result.kind !== "select" ||
+      result.data.results.bindings.length !== 80_000
+    ) {
+      throw new Error(
+        "wazoo dp-join (greedy surrogate) returned the wrong row count",
+      );
+    }
+  },
+);
+
+Deno.bench({ name: "comunica - dp-join", group: "dp-join" }, async () => {
+  const stream = await comunicaEngine.queryBindings(dpJoinQuery, {
+    sources: [memoryStore],
+  });
+  const bindings = await stream.toArray();
+  if (bindings.length === 0) {
+    throw new Error("comunica dp-join returned no bindings");
+  }
+});
+
+Deno.bench({ name: "oxigraph - dp-join", group: "dp-join" }, () => {
+  const result = oxigraphStore.query(
+    dpJoinQuery,
+  ) as unknown as OxigraphBinding[];
+  if (result.length === 0) {
+    throw new Error("oxigraph dp-join returned no bindings");
   }
 });
 

--- a/bench/latency-chart.ts
+++ b/bench/latency-chart.ts
@@ -41,9 +41,11 @@ const ENGINE_COLORS: Record<string, string> = {
 };
 
 /** Headline query classes, mirroring docs/07-benchmarking.md "Known results".
- * The asym/chain rows split by engine because the planner is wazoo-only:
- * comunica/oxigraph benches are named "- asym"/"- chain" (written order),
- * while wazoo registers "(reorder on)" and "(reorder off)" variants. */
+ * The asym/chain/dp-join rows split by engine because the planner is
+ * wazoo-only: comunica/oxigraph benches are named "- asym"/"- chain"/
+ * "- dp-join" (their own planners), while wazoo registers the reorder and
+ * planner variants (the dp-join "greedy surrogate" row disables the DP
+ * search, issue #130). */
 interface Row {
   group: string;
   /** bench-name label per engine (after "<engine> - "). */
@@ -94,6 +96,24 @@ const SECTIONS: Section[] = [
         group: "reorder-chain",
         labels: { wazoo: "chain (reorder on)", comunica: SAME, oxigraph: SAME },
         title: "3-pattern chain, planner on",
+      },
+      {
+        group: "dp-join",
+        labels: {
+          wazoo: "dp-join (DP plan)",
+          comunica: "dp-join",
+          oxigraph: "dp-join",
+        },
+        title: "shared-variable pair, DP plan",
+      },
+      {
+        group: "dp-join",
+        labels: {
+          wazoo: "dp-join (greedy surrogate)",
+          comunica: SAME,
+          oxigraph: SAME,
+        },
+        title: "shared-variable pair, greedy plan",
       },
       {
         group: "ask",

--- a/bench/latency-data.json
+++ b/bench/latency-data.json
@@ -4,87 +4,43 @@
   "cpu": "unknown",
   "benches": [
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "ask",
-      "name": "comunica - ask",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 1733,
-            "min": 157500.0,
-            "max": 2250000.0,
-            "avg": 291350.0,
-            "p75": 306700.0,
-            "p99": 1209000.0,
-            "p995": 1366900.0,
-            "p999": 1754700.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "ask",
-      "name": "oxigraph - ask",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 10122,
-            "min": 26000.0,
-            "max": 36586800.0,
-            "avg": 49432.0,
-            "p75": 40100.0,
-            "p99": 156200.0,
-            "p995": 336800.0,
-            "p999": 2408300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "ask",
-      "name": "wazoo - ask",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "scan",
+      "name": "wazoo - scan",
       "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 28,
-            "min": 2346.02,
-            "max": 4199.86,
-            "avg": 2856.984285714286,
-            "p75": 2949.19,
-            "p99": 4199.86,
-            "p995": 4199.86,
-            "p999": 4199.86,
-            "highPrecision": false,
+            "n": 475,
+            "min": 616100.0,
+            "max": 3612000.0,
+            "avg": 1078064.0,
+            "p75": 1203400.0,
+            "p99": 2484900.0,
+            "p995": 2848000.0,
+            "p999": 3612000.0,
+            "highPrecision": true,
             "usedExplicitTimers": false
           }
         }
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "asym-join",
-      "name": "comunica - asym",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "scan",
+      "name": "comunica - scan",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 37,
-            "min": 16649800.0,
-            "max": 23325700.0,
-            "avg": 19204230.0,
-            "p75": 20030600.0,
-            "p99": 23325700.0,
-            "p995": 23325700.0,
-            "p999": 23325700.0,
+            "n": 94,
+            "min": 4018600.0,
+            "max": 12583300.0,
+            "avg": 6031780.0,
+            "p75": 6534500.0,
+            "p99": 12583300.0,
+            "p995": 12583300.0,
+            "p999": 12583300.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -92,21 +48,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "asym-join",
-      "name": "oxigraph - asym",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "scan",
+      "name": "oxigraph - scan",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 35,
-            "min": 10856100.0,
-            "max": 53425400.0,
-            "avg": 19263729.0,
-            "p75": 17985900.0,
-            "p99": 53425400.0,
-            "p995": 53425400.0,
-            "p999": 53425400.0,
+            "n": 71,
+            "min": 5524400.0,
+            "max": 28879000.0,
+            "avg": 8802054.0,
+            "p75": 9204700.0,
+            "p99": 28879000.0,
+            "p995": 28879000.0,
+            "p999": 28879000.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -114,1363 +70,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "asym-join",
-      "name": "wazoo - asym (reorder off)",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 380,
-            "min": 847400.0,
-            "max": 2820300.0,
-            "avg": 1357056.0,
-            "p75": 1508900.0,
-            "p99": 2472300.0,
-            "p995": 2819100.0,
-            "p999": 2820300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "asym-join",
-      "name": "wazoo - asym (reorder on)",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 432,
-            "min": 734000.0,
-            "max": 9809500.0,
-            "avg": 1184545.0,
-            "p75": 1268800.0,
-            "p99": 2850100.0,
-            "p995": 3781000.0,
-            "p999": 9809500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "cast",
-      "name": "comunica - cast-boolean",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 188,
-            "min": 2068300.0,
-            "max": 7649100.0,
-            "avg": 2812390.0,
-            "p75": 3118500.0,
-            "p99": 5471300.0,
-            "p995": 7649100.0,
-            "p999": 7649100.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "cast",
-      "name": "comunica - cast-dateTime",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 140,
-            "min": 2837900.0,
-            "max": 7538600.0,
-            "avg": 3871835.0,
-            "p75": 4185600.0,
-            "p99": 6680100.0,
-            "p995": 7538600.0,
-            "p999": 7538600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "cast",
-      "name": "comunica - cast-numeric",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 74,
-            "min": 6052700.0,
-            "max": 11137800.0,
-            "avg": 7820036.0,
-            "p75": 8594100.0,
-            "p99": 11137800.0,
-            "p995": 11137800.0,
-            "p999": 11137800.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "cast",
-      "name": "oxigraph - cast-boolean",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 218,
-            "min": 1680800.0,
-            "max": 42129900.0,
-            "avg": 2534943.0,
-            "p75": 2190800.0,
-            "p99": 7919300.0,
-            "p995": 41789100.0,
-            "p999": 42129900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "cast",
-      "name": "oxigraph - cast-dateTime",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 147,
-            "min": 2584300.0,
-            "max": 38604500.0,
-            "avg": 3608415.0,
-            "p75": 3550400.0,
-            "p99": 7534200.0,
-            "p995": 38604500.0,
-            "p999": 38604500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "cast",
-      "name": "oxigraph - cast-numeric",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 91,
-            "min": 3815800.0,
-            "max": 42793300.0,
-            "avg": 6255376.0,
-            "p75": 5993200.0,
-            "p99": 42793300.0,
-            "p995": 42793300.0,
-            "p999": 42793300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "cast",
-      "name": "wazoo - cast-boolean",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 1752,
-            "min": 224900.0,
-            "max": 2195000.0,
-            "avg": 286896.0,
-            "p75": 279700.0,
-            "p99": 864700.0,
-            "p995": 1045600.0,
-            "p999": 1358200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "cast",
-      "name": "wazoo - cast-dateTime",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 1107,
-            "min": 316900.0,
-            "max": 5372800.0,
-            "avg": 454977.0,
-            "p75": 409500.0,
-            "p99": 1917300.0,
-            "p995": 3183000.0,
-            "p999": 4856700.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "cast",
-      "name": "wazoo - cast-numeric",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 567,
-            "min": 602300.0,
-            "max": 9001100.0,
-            "avg": 909376.0,
-            "p75": 851800.0,
-            "p99": 3896100.0,
-            "p995": 5390200.0,
-            "p999": 9001100.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "construct",
-      "name": "comunica - construct",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 235,
-            "min": 1644900.0,
-            "max": 3928400.0,
-            "avg": 2234012.0,
-            "p75": 2502400.0,
-            "p99": 3848300.0,
-            "p995": 3878100.0,
-            "p999": 3928400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "construct",
-      "name": "comunica - construct-list",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 185,
-            "min": 2075600.0,
-            "max": 8127700.0,
-            "avg": 2851139.0,
-            "p75": 3155700.0,
-            "p99": 6013300.0,
-            "p995": 8127700.0,
-            "p999": 8127700.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "construct",
-      "name": "oxigraph - construct",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 391,
-            "min": 593500.0,
-            "max": 5184900.0,
-            "avg": 1360667.0,
-            "p75": 1726900.0,
-            "p99": 4497400.0,
-            "p995": 4928200.0,
-            "p999": 5184900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "construct",
-      "name": "oxigraph - construct-list",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 93,
-            "min": 1926600.0,
-            "max": 74583500.0,
-            "avg": 5983385.0,
-            "p75": 6161600.0,
-            "p99": 74583500.0,
-            "p995": 74583500.0,
-            "p999": 74583500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "construct",
-      "name": "wazoo - construct",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 2350,
-            "min": 134300.0,
-            "max": 1352400.0,
-            "avg": 213535.0,
-            "p75": 203700.0,
-            "p99": 738400.0,
-            "p995": 858400.0,
-            "p999": 1179300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "construct",
-      "name": "wazoo - construct-list",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 686,
-            "min": 445100.0,
-            "max": 17541400.0,
-            "avg": 742750.0,
-            "p75": 684500.0,
-            "p99": 1935100.0,
-            "p995": 2260100.0,
-            "p999": 17541400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "distinct",
-      "name": "comunica - distinct",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 388,
-            "min": 995400.0,
-            "max": 4559400.0,
-            "avg": 1321144.0,
-            "p75": 1369800.0,
-            "p99": 3342700.0,
-            "p995": 3816900.0,
-            "p999": 4559400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "distinct",
-      "name": "oxigraph - distinct",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 2293,
-            "min": 128300.0,
-            "max": 2862400.0,
-            "avg": 220571.0,
-            "p75": 262900.0,
-            "p99": 744800.0,
-            "p995": 1396200.0,
-            "p999": 2348000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "distinct",
-      "name": "wazoo - distinct",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 1695,
-            "min": 210400.0,
-            "max": 1863600.0,
-            "avg": 296574.0,
-            "p75": 293700.0,
-            "p99": 917900.0,
-            "p995": 1129300.0,
-            "p999": 1690600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "comunica - exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 36,
-            "min": 16752200.0,
-            "max": 22937800.0,
-            "avg": 19340945.0,
-            "p75": 20135400.0,
-            "p99": 22937800.0,
-            "p995": 22937800.0,
-            "p999": 22937800.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "comunica - nested-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 17,
-            "min": 66992600.0,
-            "max": 93518600.0,
-            "avg": 74844683.0,
-            "p75": 76921000.0,
-            "p99": 93518600.0,
-            "p995": 93518600.0,
-            "p999": 93518600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "comunica - nested-not-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 17,
-            "min": 65806400.0,
-            "max": 107788500.0,
-            "avg": 75186295.0,
-            "p75": 76080200.0,
-            "p99": 107788500.0,
-            "p995": 107788500.0,
-            "p999": 107788500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "comunica - not-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 35,
-            "min": 16388800.0,
-            "max": 25007400.0,
-            "avg": 20115300.0,
-            "p75": 21721700.0,
-            "p99": 25007400.0,
-            "p995": 25007400.0,
-            "p999": 25007400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "oxigraph - exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 329,
-            "min": 971600.0,
-            "max": 24644200.0,
-            "avg": 1636930.0,
-            "p75": 1456300.0,
-            "p99": 5152400.0,
-            "p995": 6223400.0,
-            "p999": 24644200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "oxigraph - nested-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 306,
-            "min": 1081700.0,
-            "max": 47481000.0,
-            "avg": 1680352.0,
-            "p75": 1612100.0,
-            "p99": 3011000.0,
-            "p995": 5178100.0,
-            "p999": 47481000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "oxigraph - nested-not-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 294,
-            "min": 1182800.0,
-            "max": 24128600.0,
-            "avg": 1755672.0,
-            "p75": 1717200.0,
-            "p99": 5656800.0,
-            "p995": 7010200.0,
-            "p999": 24128600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "oxigraph - not-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 370,
-            "min": 921900.0,
-            "max": 23857500.0,
-            "avg": 1383136.0,
-            "p75": 1394700.0,
-            "p99": 3962200.0,
-            "p995": 5031900.0,
-            "p999": 23857500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "wazoo - exists",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 515,
-            "min": 616700.0,
-            "max": 6669900.0,
-            "avg": 997412.0,
-            "p75": 939000.0,
-            "p99": 4471600.0,
-            "p995": 4710700.0,
-            "p999": 6669900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "wazoo - nested-exists",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 439,
-            "min": 886800.0,
-            "max": 3145800.0,
-            "avg": 1166739.0,
-            "p75": 1183100.0,
-            "p99": 2284200.0,
-            "p995": 2410300.0,
-            "p999": 3145800.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "wazoo - nested-not-exists",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 420,
-            "min": 943900.0,
-            "max": 6775900.0,
-            "avg": 1217873.0,
-            "p75": 1150400.0,
-            "p99": 3924700.0,
-            "p995": 4682300.0,
-            "p999": 6775900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists",
-      "name": "wazoo - not-exists",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 576,
-            "min": 614900.0,
-            "max": 5281200.0,
-            "avg": 896498.0,
-            "p75": 878400.0,
-            "p99": 3427400.0,
-            "p995": 4074100.0,
-            "p999": 5281200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "comunica - exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 12,
-            "min": 424753900.0,
-            "max": 498571900.0,
-            "avg": 466057059.0,
-            "p75": 482254500.0,
-            "p99": 498571900.0,
-            "p995": 498571900.0,
-            "p999": 498571900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "comunica - nested-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 11,
-            "min": 1817166800.0,
-            "max": 1947642500.0,
-            "avg": 1878378446.0,
-            "p75": 1907352300.0,
-            "p99": 1947642500.0,
-            "p995": 1947642500.0,
-            "p999": 1947642500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "comunica - nested-not-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 11,
-            "min": 1718467900.0,
-            "max": 1986483000.0,
-            "avg": 1836040064.0,
-            "p75": 1864418700.0,
-            "p99": 1986483000.0,
-            "p995": 1986483000.0,
-            "p999": 1986483000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "comunica - not-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 12,
-            "min": 436520000.0,
-            "max": 507319600.0,
-            "avg": 466215975.0,
-            "p75": 473474300.0,
-            "p99": 507319600.0,
-            "p995": 507319600.0,
-            "p999": 507319600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "oxigraph - exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 25,
-            "min": 21120200.0,
-            "max": 63025900.0,
-            "avg": 33991424.0,
-            "p75": 36486400.0,
-            "p99": 63025900.0,
-            "p995": 63025900.0,
-            "p999": 63025900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "oxigraph - nested-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 23,
-            "min": 29248600.0,
-            "max": 70035500.0,
-            "avg": 39412531.0,
-            "p75": 46646000.0,
-            "p99": 70035500.0,
-            "p995": 70035500.0,
-            "p999": 70035500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "oxigraph - nested-not-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 23,
-            "min": 33082400.0,
-            "max": 69546800.0,
-            "avg": 40554027.0,
-            "p75": 39644200.0,
-            "p99": 69546800.0,
-            "p995": 69546800.0,
-            "p999": 69546800.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "oxigraph - not-exists",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 27,
-            "min": 25423800.0,
-            "max": 49211000.0,
-            "avg": 32881175.0,
-            "p75": 37499100.0,
-            "p99": 49211000.0,
-            "p995": 49211000.0,
-            "p999": 49211000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "wazoo - exists",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 25,
-            "min": 28364400.0,
-            "max": 48972500.0,
-            "avg": 33019284.0,
-            "p75": 33237100.0,
-            "p99": 48972500.0,
-            "p995": 48972500.0,
-            "p999": 48972500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "wazoo - nested-exists",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 24,
-            "min": 35522900.0,
-            "max": 84792600.0,
-            "avg": 40933288.0,
-            "p75": 40274100.0,
-            "p99": 84792600.0,
-            "p995": 84792600.0,
-            "p999": 84792600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "wazoo - nested-not-exists",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 23,
-            "min": 36741600.0,
-            "max": 67666500.0,
-            "avg": 43036566.0,
-            "p75": 43814200.0,
-            "p99": 67666500.0,
-            "p995": 67666500.0,
-            "p999": 67666500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "exists-large",
-      "name": "wazoo - not-exists",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 25,
-            "min": 26783400.0,
-            "max": 50259600.0,
-            "avg": 33185856.0,
-            "p75": 33945600.0,
-            "p99": 50259600.0,
-            "p995": 50259600.0,
-            "p999": 50259600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "filter-expr",
-      "name": "comunica - filter-expr",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 88,
-            "min": 4961000.0,
-            "max": 10551100.0,
-            "avg": 6576245.0,
-            "p75": 7265900.0,
-            "p99": 10551100.0,
-            "p995": 10551100.0,
-            "p999": 10551100.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "filter-expr",
-      "name": "oxigraph - filter-expr",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 436,
-            "min": 715100.0,
-            "max": 6651200.0,
-            "avg": 1177828.0,
-            "p75": 1234300.0,
-            "p99": 3258400.0,
-            "p995": 3619100.0,
-            "p999": 6651200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "filter-expr",
-      "name": "wazoo - filter-expr",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 285,
-            "min": 1102300.0,
-            "max": 19272700.0,
-            "avg": 1859738.0,
-            "p75": 1981600.0,
-            "p99": 6418300.0,
-            "p995": 6907700.0,
-            "p999": 19272700.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "from",
-      "name": "comunica - from",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 643,
-            "min": 535900.0,
-            "max": 9077500.0,
-            "avg": 791981.0,
-            "p75": 771100.0,
-            "p99": 2260300.0,
-            "p995": 3250400.0,
-            "p999": 9077500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "from",
-      "name": "oxigraph - from",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 561,
-            "min": 450400.0,
-            "max": 35140500.0,
-            "avg": 906407.0,
-            "p75": 821800.0,
-            "p99": 3452700.0,
-            "p995": 3842300.0,
-            "p999": 35140500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "from",
-      "name": "wazoo - from",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 705,
-            "min": 482000.0,
-            "max": 4715000.0,
-            "avg": 719942.0,
-            "p75": 730700.0,
-            "p99": 2449900.0,
-            "p995": 2570000.0,
-            "p999": 4715000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "graph",
-      "name": "comunica - graph",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 684,
-            "min": 511400.0,
-            "max": 2165500.0,
-            "avg": 740936.0,
-            "p75": 740500.0,
-            "p99": 1852400.0,
-            "p995": 1946900.0,
-            "p999": 2165500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "graph",
-      "name": "oxigraph - graph",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 555,
-            "min": 465800.0,
-            "max": 57096400.0,
-            "avg": 911899.0,
-            "p75": 892400.0,
-            "p99": 2666600.0,
-            "p995": 4730800.0,
-            "p999": 57096400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "graph",
-      "name": "wazoo - graph",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 3412,
-            "min": 92400.0,
-            "max": 3623700.0,
-            "avg": 146999.0,
-            "p75": 132400.0,
-            "p99": 763100.0,
-            "p995": 1101500.0,
-            "p999": 2537500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "group-aggregate",
-      "name": "comunica - group-aggregate",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 80,
-            "min": 5031400.0,
-            "max": 13197900.0,
-            "avg": 6995683.0,
-            "p75": 7662400.0,
-            "p99": 13197900.0,
-            "p995": 13197900.0,
-            "p999": 13197900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "group-aggregate",
-      "name": "comunica - having",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 213,
-            "min": 1861700.0,
-            "max": 5119200.0,
-            "avg": 2474268.0,
-            "p75": 2875100.0,
-            "p99": 4097700.0,
-            "p995": 4127000.0,
-            "p999": 5119200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "group-aggregate",
-      "name": "oxigraph - group-aggregate",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 418,
-            "min": 707400.0,
-            "max": 5667700.0,
-            "avg": 1218089.0,
-            "p75": 1294300.0,
-            "p99": 3168400.0,
-            "p995": 3919500.0,
-            "p999": 5667700.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "group-aggregate",
-      "name": "oxigraph - having",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 1775,
-            "min": 153400.0,
-            "max": 3361500.0,
-            "avg": 284244.0,
-            "p75": 278800.0,
-            "p99": 1145600.0,
-            "p995": 1983300.0,
-            "p999": 3274600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "group-aggregate",
-      "name": "wazoo - group-aggregate",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 270,
-            "min": 1178900.0,
-            "max": 8888900.0,
-            "avg": 1916328.0,
-            "p75": 1952800.0,
-            "p99": 6004200.0,
-            "p995": 6275900.0,
-            "p999": 8888900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "group-aggregate",
-      "name": "wazoo - having",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 800,
-            "min": 416200.0,
-            "max": 4019700.0,
-            "avg": 644469.0,
-            "p75": 610000.0,
-            "p99": 2659100.0,
-            "p995": 3029200.0,
-            "p999": 4019700.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join",
-      "name": "comunica - join",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 173,
-            "min": 1938700.0,
-            "max": 17783300.0,
-            "avg": 3072106.0,
-            "p75": 3383100.0,
-            "p99": 10198000.0,
-            "p995": 17783300.0,
-            "p999": 17783300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join",
-      "name": "oxigraph - join",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 155,
-            "min": 1766200.0,
-            "max": 35868300.0,
-            "avg": 3420502.0,
-            "p75": 3261600.0,
-            "p99": 11334300.0,
-            "p995": 35868300.0,
-            "p999": 35868300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
       "group": "join",
       "name": "wazoo - join",
       "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 769,
-            "min": 374600.0,
-            "max": 2982500.0,
-            "avg": 656844.0,
-            "p75": 670100.0,
-            "p99": 1957000.0,
-            "p995": 2493100.0,
-            "p999": 2982500.0,
+            "n": 560,
+            "min": 477000.0,
+            "max": 9276400.0,
+            "avg": 908534.0,
+            "p75": 966300.0,
+            "p99": 2972700.0,
+            "p995": 3121100.0,
+            "p999": 9276400.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -1478,21 +92,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join-large",
-      "name": "comunica - minus",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join",
+      "name": "comunica - join",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 26,
-            "min": 28056200.0,
-            "max": 35640000.0,
-            "avg": 31717493.0,
-            "p75": 32706300.0,
-            "p99": 35640000.0,
-            "p995": 35640000.0,
-            "p999": 35640000.0,
+            "n": 159,
+            "min": 1895700.0,
+            "max": 8053400.0,
+            "avg": 3374919.0,
+            "p75": 3977200.0,
+            "p99": 6944400.0,
+            "p995": 8053400.0,
+            "p999": 8053400.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -1500,21 +114,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join-large",
-      "name": "comunica - optional",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join",
+      "name": "oxigraph - join",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 12,
-            "min": 420767800.0,
-            "max": 483262600.0,
-            "avg": 444388834.0,
-            "p75": 455721400.0,
-            "p99": 483262600.0,
-            "p995": 483262600.0,
-            "p999": 483262600.0,
+            "n": 320,
+            "min": 872100.0,
+            "max": 16934500.0,
+            "avg": 1603211.0,
+            "p75": 1605300.0,
+            "p99": 5317700.0,
+            "p995": 15324300.0,
+            "p999": 16934500.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -1522,109 +136,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join-large",
-      "name": "comunica - union",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 16,
-            "min": 77791500.0,
-            "max": 118408900.0,
-            "avg": 87062613.0,
-            "p75": 87647400.0,
-            "p99": 118408900.0,
-            "p995": 118408900.0,
-            "p999": 118408900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join-large",
-      "name": "oxigraph - minus",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 39,
-            "min": 13821100.0,
-            "max": 33511300.0,
-            "avg": 17144313.0,
-            "p75": 16148500.0,
-            "p99": 33511300.0,
-            "p995": 33511300.0,
-            "p999": 33511300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join-large",
-      "name": "oxigraph - optional",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 21,
-            "min": 37136100.0,
-            "max": 58303200.0,
-            "avg": 46006943.0,
-            "p75": 53227300.0,
-            "p99": 58303200.0,
-            "p995": 58303200.0,
-            "p999": 58303200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join-large",
-      "name": "oxigraph - union",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 16,
-            "min": 77737800.0,
-            "max": 124294300.0,
-            "avg": 98151425.0,
-            "p75": 104830100.0,
-            "p99": 124294300.0,
-            "p995": 124294300.0,
-            "p999": 124294300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join-large",
-      "name": "wazoo - minus",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "asym-join",
+      "name": "wazoo - asym (reorder on)",
       "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 49,
-            "min": 11198200.0,
-            "max": 17147600.0,
-            "avg": 13269180.0,
-            "p75": 14140100.0,
-            "p99": 17147600.0,
-            "p995": 17147600.0,
-            "p999": 17147600.0,
+            "n": 303,
+            "min": 937700.0,
+            "max": 10873900.0,
+            "avg": 1714475.0,
+            "p75": 1817200.0,
+            "p99": 5386900.0,
+            "p995": 7459500.0,
+            "p999": 10873900.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -1632,65 +158,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join-large",
-      "name": "wazoo - optional",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 43,
-            "min": 13214000.0,
-            "max": 18959000.0,
-            "avg": 15401870.0,
-            "p75": 15818500.0,
-            "p99": 18959000.0,
-            "p995": 18959000.0,
-            "p999": 18959000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "join-large",
-      "name": "wazoo - union",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 24,
-            "min": 34088400.0,
-            "max": 43888000.0,
-            "avg": 37902542.0,
-            "p75": 39448400.0,
-            "p99": 43888000.0,
-            "p995": 43888000.0,
-            "p999": 43888000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "minus",
-      "name": "comunica - minus",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "asym-join",
+      "name": "wazoo - asym (reorder off)",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 270,
-            "min": 1421600.0,
-            "max": 4791700.0,
-            "avg": 1934249.0,
-            "p75": 2161100.0,
-            "p99": 4010500.0,
-            "p995": 4457200.0,
-            "p999": 4791700.0,
+            "n": 344,
+            "min": 863600.0,
+            "max": 7602900.0,
+            "avg": 1503303.0,
+            "p75": 1679600.0,
+            "p99": 3779500.0,
+            "p995": 4361500.0,
+            "p999": 7602900.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -1698,21 +180,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "minus",
-      "name": "oxigraph - minus",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "asym-join",
+      "name": "comunica - asym",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 468,
-            "min": 597300.0,
-            "max": 35454000.0,
-            "avg": 1116118.0,
-            "p75": 1120500.0,
-            "p99": 3222900.0,
-            "p995": 4076500.0,
-            "p999": 35454000.0,
+            "n": 32,
+            "min": 17898400.0,
+            "max": 29001000.0,
+            "avg": 22965104.0,
+            "p75": 25113600.0,
+            "p99": 29001000.0,
+            "p995": 29001000.0,
+            "p999": 29001000.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -1720,43 +202,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "minus",
-      "name": "wazoo - minus",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 728,
-            "min": 482000.0,
-            "max": 3453300.0,
-            "avg": 697401.0,
-            "p75": 695100.0,
-            "p99": 1984400.0,
-            "p995": 2476100.0,
-            "p999": 3453300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "optional",
-      "name": "comunica - optional",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "asym-join",
+      "name": "oxigraph - asym",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 31,
-            "min": 20571500.0,
-            "max": 32435200.0,
-            "avg": 24200075.0,
-            "p75": 25267800.0,
-            "p99": 32435200.0,
-            "p995": 32435200.0,
-            "p999": 32435200.0,
+            "n": 54,
+            "min": 7766000.0,
+            "max": 31273500.0,
+            "avg": 11493026.0,
+            "p75": 11981500.0,
+            "p99": 31273500.0,
+            "p995": 31273500.0,
+            "p999": 31273500.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -1764,329 +224,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "optional",
-      "name": "oxigraph - optional",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 195,
-            "min": 1605700.0,
-            "max": 36283500.0,
-            "avg": 2697967.0,
-            "p75": 2407600.0,
-            "p99": 26712900.0,
-            "p995": 36283500.0,
-            "p999": 36283500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "optional",
-      "name": "wazoo - optional",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 522,
-            "min": 563200.0,
-            "max": 4778700.0,
-            "avg": 978820.0,
-            "p75": 1020200.0,
-            "p99": 3698800.0,
-            "p995": 4493600.0,
-            "p999": 4778700.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "order-limit",
-      "name": "comunica - order-limit",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 81,
-            "min": 5756500.0,
-            "max": 10535200.0,
-            "avg": 7046421.0,
-            "p75": 7532700.0,
-            "p99": 10535200.0,
-            "p995": 10535200.0,
-            "p999": 10535200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "order-limit",
-      "name": "oxigraph - order-limit",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 288,
-            "min": 1265700.0,
-            "max": 7725500.0,
-            "avg": 1876683.0,
-            "p75": 2026200.0,
-            "p99": 5582300.0,
-            "p995": 6290900.0,
-            "p999": 7725500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "order-limit",
-      "name": "wazoo - order-limit",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 329,
-            "min": 866200.0,
-            "max": 9158200.0,
-            "avg": 1562209.0,
-            "p75": 1741300.0,
-            "p99": 5343100.0,
-            "p995": 5611900.0,
-            "p999": 9158200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "path",
-      "name": "comunica - path-plus",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 28,
-            "min": 23722700.0,
-            "max": 38312900.0,
-            "avg": 27696090.0,
-            "p75": 28691000.0,
-            "p99": 38312900.0,
-            "p995": 38312900.0,
-            "p999": 38312900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "path",
-      "name": "comunica - path-seq",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 180,
-            "min": 2066700.0,
-            "max": 5015800.0,
-            "avg": 2940747.0,
-            "p75": 3498200.0,
-            "p99": 4921000.0,
-            "p995": 5015800.0,
-            "p999": 5015800.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "path",
-      "name": "oxigraph - path-plus",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 354,
-            "min": 822000.0,
-            "max": 22555400.0,
-            "avg": 1447047.0,
-            "p75": 1301600.0,
-            "p99": 6705900.0,
-            "p995": 21313600.0,
-            "p999": 22555400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "path",
-      "name": "oxigraph - path-seq",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 192,
-            "min": 1771500.0,
-            "max": 35475200.0,
-            "avg": 2732361.0,
-            "p75": 2817300.0,
-            "p99": 6396700.0,
-            "p995": 35475200.0,
-            "p999": 35475200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "path",
-      "name": "wazoo - path-plus",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 281,
-            "min": 1229500.0,
-            "max": 10300300.0,
-            "avg": 1834192.0,
-            "p75": 1830000.0,
-            "p99": 6586600.0,
-            "p995": 6697600.0,
-            "p999": 10300300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "path",
-      "name": "wazoo - path-seq",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 80,
-            "min": 3967500.0,
-            "max": 18851900.0,
-            "avg": 7101822.0,
-            "p75": 8272700.0,
-            "p99": 18851900.0,
-            "p995": 18851900.0,
-            "p999": 18851900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "reduced",
-      "name": "comunica - reduced",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 423,
-            "min": 865400.0,
-            "max": 4252700.0,
-            "avg": 1213481.0,
-            "p75": 1281500.0,
-            "p99": 2356000.0,
-            "p995": 2518800.0,
-            "p999": 4252700.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "reduced",
-      "name": "oxigraph - reduced",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 2424,
-            "min": 106400.0,
-            "max": 1954600.0,
-            "avg": 207174.0,
-            "p75": 226700.0,
-            "p99": 764600.0,
-            "p995": 858700.0,
-            "p999": 1462200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "reduced",
-      "name": "wazoo - reduced",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 1755,
-            "min": 198900.0,
-            "max": 2862400.0,
-            "avg": 287160.0,
-            "p75": 270700.0,
-            "p99": 1177900.0,
-            "p995": 1836400.0,
-            "p999": 2810400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
       "group": "reorder-chain",
-      "name": "comunica - chain",
-      "baseline": false,
+      "name": "wazoo - chain (reorder on)",
+      "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 15,
-            "min": 87061800.0,
-            "max": 110806600.0,
-            "avg": 96805994.0,
-            "p75": 100454900.0,
-            "p99": 110806600.0,
-            "p995": 110806600.0,
-            "p999": 110806600.0,
+            "n": 346,
+            "min": 824700.0,
+            "max": 6991000.0,
+            "avg": 1499664.0,
+            "p75": 1706400.0,
+            "p99": 4026900.0,
+            "p995": 5207400.0,
+            "p999": 6991000.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2094,29 +246,7 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "reorder-chain",
-      "name": "oxigraph - chain",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 137,
-            "min": 2552900.0,
-            "max": 33967200.0,
-            "avg": 4207030.0,
-            "p75": 4171600.0,
-            "p99": 12937300.0,
-            "p995": 33967200.0,
-            "p999": 33967200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
       "group": "reorder-chain",
       "name": "wazoo - chain (reorder off)",
       "baseline": false,
@@ -2124,13 +254,13 @@
         {
           "ok": {
             "n": 15,
-            "min": 86811300.0,
-            "max": 119248000.0,
-            "avg": 97376600.0,
-            "p75": 101894000.0,
-            "p99": 119248000.0,
-            "p995": 119248000.0,
-            "p999": 119248000.0,
+            "min": 94561100.0,
+            "max": 121699300.0,
+            "avg": 105502987.0,
+            "p75": 110448300.0,
+            "p99": 121699300.0,
+            "p995": 121699300.0,
+            "p999": 121699300.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2138,21 +268,65 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
       "group": "reorder-chain",
-      "name": "wazoo - chain (reorder on)",
+      "name": "comunica - chain",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 15,
+            "min": 91759100.0,
+            "max": 148705300.0,
+            "avg": 107793194.0,
+            "p75": 111950900.0,
+            "p99": 148705300.0,
+            "p995": 148705300.0,
+            "p999": 148705300.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "reorder-chain",
+      "name": "oxigraph - chain",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 240,
+            "min": 1326700.0,
+            "max": 18651400.0,
+            "avg": 2160226.0,
+            "p75": 2055700.0,
+            "p99": 10046500.0,
+            "p995": 16875400.0,
+            "p999": 18651400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "dp-join",
+      "name": "wazoo - dp-join (DP plan)",
       "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 432,
-            "min": 696900.0,
-            "max": 3867500.0,
-            "avg": 1189854.0,
-            "p75": 1255000.0,
-            "p99": 2385800.0,
-            "p995": 2556700.0,
-            "p999": 3867500.0,
+            "n": 19,
+            "min": 54303200.0,
+            "max": 93219200.0,
+            "avg": 62202132.0,
+            "p75": 65878100.0,
+            "p99": 93219200.0,
+            "p995": 93219200.0,
+            "p999": 93219200.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2160,21 +334,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "scan",
-      "name": "comunica - scan",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "dp-join",
+      "name": "wazoo - dp-join (greedy surrogate)",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 100,
-            "min": 3832300.0,
-            "max": 9194900.0,
-            "avg": 5533452.0,
-            "p75": 6085700.0,
-            "p99": 9058400.0,
-            "p995": 9194900.0,
-            "p999": 9194900.0,
+            "n": 14,
+            "min": 107898900.0,
+            "max": 162450100.0,
+            "avg": 125171200.0,
+            "p75": 130224900.0,
+            "p99": 162450100.0,
+            "p995": 162450100.0,
+            "p999": 162450100.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2182,21 +356,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "scan",
-      "name": "oxigraph - scan",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "dp-join",
+      "name": "comunica - dp-join",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 51,
-            "min": 7065200.0,
-            "max": 54913300.0,
-            "avg": 12211473.0,
-            "p75": 11551500.0,
-            "p99": 54913300.0,
-            "p995": 54913300.0,
-            "p999": 54913300.0,
+            "n": 13,
+            "min": 170067400.0,
+            "max": 214473500.0,
+            "avg": 190434070.0,
+            "p75": 193808100.0,
+            "p99": 214473500.0,
+            "p995": 214473500.0,
+            "p999": 214473500.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2204,21 +378,43 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "scan",
-      "name": "wazoo - scan",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "dp-join",
+      "name": "oxigraph - dp-join",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 12,
+            "min": 497949200.0,
+            "max": 2600680800.0,
+            "avg": 1119920884.0,
+            "p75": 1285678900.0,
+            "p99": 2600680800.0,
+            "p995": 2600680800.0,
+            "p999": 2600680800.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "ask",
+      "name": "wazoo - ask",
       "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 527,
-            "min": 555800.0,
-            "max": 14735800.0,
-            "avg": 963957.0,
-            "p75": 997700.0,
-            "p99": 2552900.0,
-            "p995": 6232400.0,
-            "p999": 14735800.0,
+            "n": 137294,
+            "min": 1500.0,
+            "max": 9579200.0,
+            "avg": 3643.0,
+            "p75": 3500.0,
+            "p99": 12500.0,
+            "p995": 19000.0,
+            "p999": 84100.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2226,21 +422,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "comunica - string-before-after",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "ask",
+      "name": "comunica - ask",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 110,
-            "min": 3840700.0,
-            "max": 7503400.0,
-            "avg": 4993168.0,
-            "p75": 5437800.0,
-            "p99": 6740400.0,
-            "p995": 7503400.0,
-            "p999": 7503400.0,
+            "n": 1593,
+            "min": 146300.0,
+            "max": 3101900.0,
+            "avg": 315767.0,
+            "p75": 319700.0,
+            "p99": 1441600.0,
+            "p995": 1595500.0,
+            "p999": 2544000.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2248,21 +444,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "comunica - string-concat",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "ask",
+      "name": "oxigraph - ask",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 143,
-            "min": 2747600.0,
-            "max": 10172200.0,
-            "avg": 3745076.0,
-            "p75": 4088100.0,
-            "p99": 7197700.0,
-            "p995": 10172200.0,
-            "p999": 10172200.0,
+            "n": 16123,
+            "min": 17500.0,
+            "max": 553000.0,
+            "avg": 31030.0,
+            "p75": 32100.0,
+            "p99": 106100.0,
+            "p995": 141100.0,
+            "p999": 277000.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2270,285 +466,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "comunica - string-datatype",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 182,
-            "min": 2086500.0,
-            "max": 5399500.0,
-            "avg": 2898278.0,
-            "p75": 3241500.0,
-            "p99": 5307400.0,
-            "p995": 5399500.0,
-            "p999": 5399500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "comunica - string-encode-uri",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 173,
-            "min": 2246900.0,
-            "max": 6998000.0,
-            "avg": 3090277.0,
-            "p75": 3540100.0,
-            "p99": 6180300.0,
-            "p995": 6998000.0,
-            "p999": 6998000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "comunica - string-iri",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 115,
-            "min": 3555200.0,
-            "max": 8775200.0,
-            "avg": 4726282.0,
-            "p75": 5052000.0,
-            "p99": 7872600.0,
-            "p995": 8775200.0,
-            "p999": 8775200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "comunica - string-lang",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 106,
-            "min": 3936800.0,
-            "max": 8758400.0,
-            "avg": 5211197.0,
-            "p75": 5829200.0,
-            "p99": 8699200.0,
-            "p995": 8758400.0,
-            "p999": 8758400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "comunica - string-replace",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 146,
-            "min": 2824800.0,
-            "max": 5483600.0,
-            "avg": 3689771.0,
-            "p75": 4043500.0,
-            "p99": 5460200.0,
-            "p995": 5483600.0,
-            "p999": 5483600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "oxigraph - string-before-after",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 149,
-            "min": 2246600.0,
-            "max": 48562500.0,
-            "avg": 3580207.0,
-            "p75": 3173100.0,
-            "p99": 39203700.0,
-            "p995": 48562500.0,
-            "p999": 48562500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "oxigraph - string-concat",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 208,
-            "min": 1635600.0,
-            "max": 35810500.0,
-            "avg": 2577580.0,
-            "p75": 2351800.0,
-            "p99": 9166800.0,
-            "p995": 34170800.0,
-            "p999": 35810500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "oxigraph - string-datatype",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 229,
-            "min": 1349600.0,
-            "max": 44066000.0,
-            "avg": 2278775.0,
-            "p75": 1993200.0,
-            "p99": 6402700.0,
-            "p995": 32533700.0,
-            "p999": 44066000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "oxigraph - string-encode-uri",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 215,
-            "min": 1342600.0,
-            "max": 38062300.0,
-            "avg": 2414882.0,
-            "p75": 2230300.0,
-            "p99": 6879300.0,
-            "p995": 29486600.0,
-            "p999": 38062300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "oxigraph - string-iri",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 170,
-            "min": 1829500.0,
-            "max": 31276400.0,
-            "avg": 3059771.0,
-            "p75": 2717400.0,
-            "p99": 30821200.0,
-            "p995": 31276400.0,
-            "p999": 31276400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "oxigraph - string-lang",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 150,
-            "min": 1848900.0,
-            "max": 40236900.0,
-            "avg": 3483446.0,
-            "p75": 3040200.0,
-            "p99": 33276200.0,
-            "p995": 40236900.0,
-            "p999": 40236900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "oxigraph - string-replace",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 146,
-            "min": 1627600.0,
-            "max": 145300300.0,
-            "avg": 3585852.0,
-            "p75": 2363100.0,
-            "p99": 38114100.0,
-            "p995": 145300300.0,
-            "p999": 145300300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "wazoo - string-before-after",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "construct",
+      "name": "wazoo - construct",
       "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 1035,
-            "min": 359800.0,
-            "max": 3197800.0,
-            "avg": 488166.0,
-            "p75": 436600.0,
-            "p99": 2384700.0,
-            "p995": 2741400.0,
-            "p999": 3165800.0,
+            "n": 1931,
+            "min": 124900.0,
+            "max": 1469400.0,
+            "avg": 259908.0,
+            "p75": 284200.0,
+            "p99": 892200.0,
+            "p995": 1029100.0,
+            "p999": 1456200.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2556,153 +488,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "wazoo - string-concat",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 1514,
-            "min": 237800.0,
-            "max": 5180600.0,
-            "avg": 335797.0,
-            "p75": 297600.0,
-            "p99": 1722700.0,
-            "p995": 2588000.0,
-            "p999": 4059400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "wazoo - string-datatype",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 1642,
-            "min": 232900.0,
-            "max": 2743600.0,
-            "avg": 306396.0,
-            "p75": 296300.0,
-            "p99": 916600.0,
-            "p995": 1112100.0,
-            "p999": 2329500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "wazoo - string-encode-uri",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 1180,
-            "min": 286800.0,
-            "max": 16477200.0,
-            "avg": 426791.0,
-            "p75": 368000.0,
-            "p99": 1922000.0,
-            "p995": 2700400.0,
-            "p999": 4347100.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "wazoo - string-iri",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 1095,
-            "min": 325100.0,
-            "max": 3532400.0,
-            "avg": 461029.0,
-            "p75": 409100.0,
-            "p99": 2168500.0,
-            "p995": 2624500.0,
-            "p999": 3481900.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "wazoo - string-lang",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 977,
-            "min": 372600.0,
-            "max": 4440200.0,
-            "avg": 516895.0,
-            "p75": 477000.0,
-            "p99": 1987800.0,
-            "p995": 3120100.0,
-            "p999": 4440200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "string-fn",
-      "name": "wazoo - string-replace",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 1122,
-            "min": 298900.0,
-            "max": 3435600.0,
-            "avg": 449223.0,
-            "p75": 398100.0,
-            "p99": 2049300.0,
-            "p995": 2952000.0,
-            "p999": 3396400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "subquery",
-      "name": "comunica - subquery",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "construct",
+      "name": "comunica - construct",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 183,
-            "min": 2046500.0,
-            "max": 5888100.0,
-            "avg": 2899921.0,
-            "p75": 3398300.0,
-            "p99": 5821700.0,
-            "p995": 5888100.0,
-            "p999": 5888100.0,
+            "n": 190,
+            "min": 1660100.0,
+            "max": 7418400.0,
+            "avg": 2804616.0,
+            "p75": 3233400.0,
+            "p99": 6942400.0,
+            "p995": 7418400.0,
+            "p999": 7418400.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2710,21 +510,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "subquery",
-      "name": "comunica - subquery-agg",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "construct",
+      "name": "oxigraph - construct",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 178,
-            "min": 2076800.0,
-            "max": 9073000.0,
-            "avg": 2955049.0,
-            "p75": 3258500.0,
-            "p99": 6614100.0,
-            "p995": 9073000.0,
-            "p999": 9073000.0,
+            "n": 808,
+            "min": 255400.0,
+            "max": 40641400.0,
+            "avg": 625064.0,
+            "p75": 607200.0,
+            "p99": 1992100.0,
+            "p995": 2715400.0,
+            "p999": 40641400.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2732,109 +532,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "subquery",
-      "name": "comunica - subquery-nested",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 187,
-            "min": 2097800.0,
-            "max": 6681300.0,
-            "avg": 2847449.0,
-            "p75": 3256300.0,
-            "p99": 6602100.0,
-            "p995": 6681300.0,
-            "p999": 6681300.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "subquery",
-      "name": "oxigraph - subquery",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 217,
-            "min": 1472600.0,
-            "max": 53263400.0,
-            "avg": 2439359.0,
-            "p75": 2182900.0,
-            "p99": 7017900.0,
-            "p995": 30629700.0,
-            "p999": 53263400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "subquery",
-      "name": "oxigraph - subquery-agg",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 1416,
-            "min": 169100.0,
-            "max": 3723600.0,
-            "avg": 355608.0,
-            "p75": 375200.0,
-            "p99": 1171700.0,
-            "p995": 1959700.0,
-            "p999": 3367800.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "subquery",
-      "name": "oxigraph - subquery-nested",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 259,
-            "min": 1566900.0,
-            "max": 24061500.0,
-            "avg": 2008323.0,
-            "p75": 2030800.0,
-            "p99": 3311400.0,
-            "p995": 4041100.0,
-            "p999": 24061500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "subquery",
-      "name": "wazoo - subquery",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "construct",
+      "name": "wazoo - construct-list",
       "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 336,
-            "min": 950200.0,
-            "max": 7390600.0,
-            "avg": 1527192.0,
-            "p75": 1551500.0,
-            "p99": 5624000.0,
-            "p995": 6518600.0,
-            "p999": 7390600.0,
+            "n": 504,
+            "min": 504200.0,
+            "max": 20139300.0,
+            "avg": 1007743.0,
+            "p75": 1063600.0,
+            "p99": 2535700.0,
+            "p995": 11146800.0,
+            "p999": 20139300.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2842,65 +554,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "subquery",
-      "name": "wazoo - subquery-agg",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 1467,
-            "min": 203100.0,
-            "max": 3989400.0,
-            "avg": 343161.0,
-            "p75": 316400.0,
-            "p99": 1550600.0,
-            "p995": 2396000.0,
-            "p999": 3770500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "subquery",
-      "name": "wazoo - subquery-nested",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 363,
-            "min": 842900.0,
-            "max": 11073600.0,
-            "avg": 1429447.0,
-            "p75": 1424800.0,
-            "p99": 4145700.0,
-            "p995": 7394000.0,
-            "p999": 11073600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "union",
-      "name": "comunica - union",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "construct",
+      "name": "comunica - construct-list",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 193,
-            "min": 1984300.0,
-            "max": 12549400.0,
-            "avg": 2830639.0,
-            "p75": 3136300.0,
-            "p99": 8242400.0,
-            "p995": 12549400.0,
-            "p999": 12549400.0,
+            "n": 134,
+            "min": 2426100.0,
+            "max": 8458800.0,
+            "avg": 4081698.0,
+            "p75": 4518700.0,
+            "p99": 7136100.0,
+            "p995": 8458800.0,
+            "p999": 8458800.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2908,21 +576,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "union",
-      "name": "oxigraph - union",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "construct",
+      "name": "oxigraph - construct-list",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 224,
-            "min": 1433500.0,
-            "max": 27674300.0,
-            "avg": 2358505.0,
-            "p75": 2302500.0,
-            "p99": 6380100.0,
-            "p995": 26988900.0,
-            "p999": 27674300.0,
+            "n": 401,
+            "min": 533700.0,
+            "max": 42416400.0,
+            "avg": 1329588.0,
+            "p75": 1123200.0,
+            "p99": 4186300.0,
+            "p995": 26644300.0,
+            "p999": 42416400.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2930,21 +598,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "union",
-      "name": "wazoo - union",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update",
+      "name": "wazoo - update",
       "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 1005,
-            "min": 322500.0,
-            "max": 3648300.0,
-            "avg": 501749.0,
-            "p75": 475500.0,
-            "p99": 2289500.0,
-            "p995": 2525400.0,
-            "p999": 3616200.0,
+            "n": 14,
+            "min": 128113200.0,
+            "max": 164989900.0,
+            "avg": 148971236.0,
+            "p75": 151991000.0,
+            "p99": 164989900.0,
+            "p995": 164989900.0,
+            "p999": 164989900.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2952,7 +620,7 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
       "group": "update",
       "name": "comunica - update",
       "baseline": false,
@@ -2960,13 +628,13 @@
         {
           "ok": {
             "n": 14,
-            "min": 116157800.0,
-            "max": 142332100.0,
-            "avg": 123537515.0,
-            "p75": 126901600.0,
-            "p99": 142332100.0,
-            "p995": 142332100.0,
-            "p999": 142332100.0,
+            "min": 135210700.0,
+            "max": 155941200.0,
+            "avg": 143444329.0,
+            "p75": 147147400.0,
+            "p99": 155941200.0,
+            "p995": 155941200.0,
+            "p999": 155941200.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2974,21 +642,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
       "group": "update",
       "name": "oxigraph - update",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 1096,
-            "min": 316800.0,
-            "max": 1892500.0,
-            "avg": 460766.0,
-            "p75": 454500.0,
-            "p99": 1219900.0,
-            "p995": 1341100.0,
-            "p999": 1703100.0,
+            "n": 865,
+            "min": 309600.0,
+            "max": 5357400.0,
+            "avg": 585382.0,
+            "p75": 632800.0,
+            "p99": 1499200.0,
+            "p995": 1909200.0,
+            "p999": 5357400.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -2996,21 +664,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update",
-      "name": "wazoo - update",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "optional",
+      "name": "wazoo - optional",
       "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 15,
-            "min": 113396200.0,
-            "max": 125544000.0,
-            "avg": 120540367.0,
-            "p75": 123476700.0,
-            "p99": 125544000.0,
-            "p995": 125544000.0,
-            "p999": 125544000.0,
+            "n": 873,
+            "min": 285500.0,
+            "max": 2891100.0,
+            "avg": 578446.0,
+            "p75": 636600.0,
+            "p99": 1832500.0,
+            "p995": 2163500.0,
+            "p999": 2891100.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3018,21 +686,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "comunica - add-graph",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "optional",
+      "name": "comunica - optional",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 257,
-            "min": 1325600.0,
-            "max": 26278700.0,
-            "avg": 2032266.0,
-            "p75": 2143100.0,
-            "p99": 4954500.0,
-            "p995": 4994000.0,
-            "p999": 26278700.0,
+            "n": 33,
+            "min": 19421200.0,
+            "max": 25937200.0,
+            "avg": 22140740.0,
+            "p75": 23417000.0,
+            "p99": 25937200.0,
+            "p995": 25937200.0,
+            "p999": 25937200.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3040,21 +708,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "comunica - add-graph-silent",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "optional",
+      "name": "oxigraph - optional",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 264,
-            "min": 1324100.0,
-            "max": 11577900.0,
-            "avg": 1968474.0,
-            "p75": 2129100.0,
-            "p99": 5518300.0,
-            "p995": 6147200.0,
-            "p999": 11577900.0,
+            "n": 329,
+            "min": 874800.0,
+            "max": 32904300.0,
+            "avg": 1560283.0,
+            "p75": 1348200.0,
+            "p99": 5538000.0,
+            "p995": 30896700.0,
+            "p999": 32904300.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3062,21 +730,43 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "comunica - clear-graph",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "minus",
+      "name": "wazoo - minus",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1070,
+            "min": 231300.0,
+            "max": 10454000.0,
+            "avg": 471474.0,
+            "p75": 500500.0,
+            "p99": 1399600.0,
+            "p995": 1522800.0,
+            "p999": 4633100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "minus",
+      "name": "comunica - minus",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 560,
-            "min": 638600.0,
-            "max": 3476000.0,
-            "avg": 909032.0,
-            "p75": 918200.0,
-            "p99": 2194500.0,
-            "p995": 2581800.0,
-            "p999": 3476000.0,
+            "n": 217,
+            "min": 1282000.0,
+            "max": 5834800.0,
+            "avg": 2433353.0,
+            "p75": 2892000.0,
+            "p99": 5111200.0,
+            "p995": 5575100.0,
+            "p999": 5834800.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3084,21 +774,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "comunica - clear-graph-silent",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "minus",
+      "name": "oxigraph - minus",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 576,
-            "min": 586600.0,
-            "max": 2975000.0,
-            "avg": 881293.0,
-            "p75": 882000.0,
-            "p99": 2070000.0,
-            "p995": 2421600.0,
-            "p999": 2975000.0,
+            "n": 751,
+            "min": 346400.0,
+            "max": 25091700.0,
+            "avg": 673640.0,
+            "p75": 653800.0,
+            "p99": 1825000.0,
+            "p995": 2547000.0,
+            "p999": 25091700.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3106,21 +796,43 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "comunica - copy-graph",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "union",
+      "name": "wazoo - union",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1151,
+            "min": 220400.0,
+            "max": 5045300.0,
+            "avg": 438738.0,
+            "p75": 472500.0,
+            "p99": 1364200.0,
+            "p995": 1522400.0,
+            "p999": 2240800.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "union",
+      "name": "comunica - union",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 138,
-            "min": 2899300.0,
-            "max": 6519700.0,
-            "avg": 3925937.0,
-            "p75": 4358600.0,
-            "p99": 6312300.0,
-            "p995": 6519700.0,
-            "p999": 6519700.0,
+            "n": 182,
+            "min": 1885300.0,
+            "max": 7914400.0,
+            "avg": 2908854.0,
+            "p75": 3206600.0,
+            "p99": 6593600.0,
+            "p995": 7914400.0,
+            "p999": 7914400.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3128,21 +840,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "comunica - copy-graph-silent",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "union",
+      "name": "oxigraph - union",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 138,
-            "min": 2907700.0,
-            "max": 6105900.0,
-            "avg": 3914129.0,
-            "p75": 4281200.0,
-            "p99": 6014200.0,
-            "p995": 6105900.0,
-            "p999": 6105900.0,
+            "n": 300,
+            "min": 835400.0,
+            "max": 28309700.0,
+            "avg": 1720676.0,
+            "p75": 1608800.0,
+            "p99": 4693400.0,
+            "p995": 27634000.0,
+            "p999": 28309700.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3150,21 +862,43 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "comunica - drop-graph",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "path",
+      "name": "wazoo - path-seq",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 134,
+            "min": 2393000.0,
+            "max": 10101500.0,
+            "avg": 4110028.0,
+            "p75": 4565700.0,
+            "p99": 9059200.0,
+            "p995": 10101500.0,
+            "p999": 10101500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "path",
+      "name": "comunica - path-seq",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 569,
-            "min": 610000.0,
-            "max": 2824600.0,
-            "avg": 894156.0,
-            "p75": 922900.0,
-            "p99": 2303200.0,
-            "p995": 2524000.0,
-            "p999": 2824600.0,
+            "n": 161,
+            "min": 2126600.0,
+            "max": 7215800.0,
+            "avg": 3358102.0,
+            "p75": 4163200.0,
+            "p99": 6245300.0,
+            "p995": 7215800.0,
+            "p999": 7215800.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3172,21 +906,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "comunica - drop-graph-silent",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "path",
+      "name": "oxigraph - path-seq",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 580,
-            "min": 603000.0,
-            "max": 3633100.0,
-            "avg": 876407.0,
-            "p75": 871500.0,
-            "p99": 2386900.0,
-            "p995": 3031900.0,
-            "p999": 3633100.0,
+            "n": 247,
+            "min": 969800.0,
+            "max": 51549800.0,
+            "avg": 2083405.0,
+            "p75": 1922000.0,
+            "p99": 22862100.0,
+            "p995": 30666300.0,
+            "p999": 51549800.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3194,21 +928,43 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "comunica - move-graph",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "path",
+      "name": "wazoo - path-plus",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 582,
+            "min": 463300.0,
+            "max": 4399700.0,
+            "avg": 875125.0,
+            "p75": 918800.0,
+            "p99": 2451900.0,
+            "p995": 2849500.0,
+            "p999": 4399700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "path",
+      "name": "comunica - path-plus",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 120,
-            "min": 3381100.0,
-            "max": 8552100.0,
-            "avg": 4631380.0,
-            "p75": 4960200.0,
-            "p99": 8177800.0,
-            "p995": 8552100.0,
-            "p999": 8552100.0,
+            "n": 28,
+            "min": 21404800.0,
+            "max": 35421500.0,
+            "avg": 27483358.0,
+            "p75": 28882100.0,
+            "p99": 35421500.0,
+            "p995": 35421500.0,
+            "p999": 35421500.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3216,21 +972,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "comunica - move-graph-silent",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "path",
+      "name": "oxigraph - path-plus",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 126,
-            "min": 3419600.0,
-            "max": 6328600.0,
-            "avg": 4320153.0,
-            "p75": 4709800.0,
-            "p99": 5778100.0,
-            "p995": 6328600.0,
-            "p999": 6328600.0,
+            "n": 464,
+            "min": 518600.0,
+            "max": 31839500.0,
+            "avg": 1102046.0,
+            "p75": 1110300.0,
+            "p99": 3193700.0,
+            "p995": 20777300.0,
+            "p999": 31839500.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3238,21 +994,43 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "oxigraph - add-graph",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "group-aggregate",
+      "name": "wazoo - group-aggregate",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 396,
+            "min": 659400.0,
+            "max": 7507500.0,
+            "avg": 1292430.0,
+            "p75": 1366500.0,
+            "p99": 4611600.0,
+            "p995": 5582600.0,
+            "p999": 7507500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "group-aggregate",
+      "name": "comunica - group-aggregate",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 68,
-            "min": 5735900.0,
-            "max": 15250300.0,
-            "avg": 8744836.0,
-            "p75": 9416400.0,
-            "p99": 15250300.0,
-            "p995": 15250300.0,
-            "p999": 15250300.0,
+            "n": 66,
+            "min": 5681500.0,
+            "max": 14040500.0,
+            "avg": 8840635.0,
+            "p75": 9845200.0,
+            "p99": 14040500.0,
+            "p995": 14040500.0,
+            "p999": 14040500.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3260,21 +1038,197 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "oxigraph - add-graph-silent",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "group-aggregate",
+      "name": "oxigraph - group-aggregate",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 743,
+            "min": 330000.0,
+            "max": 3977500.0,
+            "avg": 686002.0,
+            "p75": 793700.0,
+            "p99": 1797100.0,
+            "p995": 2071000.0,
+            "p999": 3977500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "group-aggregate",
+      "name": "wazoo - having",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 954,
+            "min": 217100.0,
+            "max": 3723800.0,
+            "avg": 531046.0,
+            "p75": 631600.0,
+            "p99": 1753200.0,
+            "p995": 2149400.0,
+            "p999": 3723800.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "group-aggregate",
+      "name": "comunica - having",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 156,
+            "min": 1888400.0,
+            "max": 6379600.0,
+            "avg": 3447954.0,
+            "p75": 4140700.0,
+            "p99": 6376700.0,
+            "p995": 6379600.0,
+            "p999": 6379600.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "group-aggregate",
+      "name": "oxigraph - having",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 1845,
+            "min": 119500.0,
+            "max": 2291200.0,
+            "avg": 273232.0,
+            "p75": 317600.0,
+            "p99": 958700.0,
+            "p995": 1136100.0,
+            "p999": 2220200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "filter-expr",
+      "name": "wazoo - filter-expr",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 246,
+            "min": 811400.0,
+            "max": 12817700.0,
+            "avg": 2106230.0,
+            "p75": 2334500.0,
+            "p99": 9986800.0,
+            "p995": 10643500.0,
+            "p999": 12817700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "filter-expr",
+      "name": "comunica - filter-expr",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 71,
+            "min": 5198900.0,
+            "max": 16589800.0,
+            "avg": 8383141.0,
+            "p75": 10031300.0,
+            "p99": 16589800.0,
+            "p995": 16589800.0,
+            "p999": 16589800.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "filter-expr",
+      "name": "oxigraph - filter-expr",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 686,
+            "min": 454600.0,
+            "max": 2797400.0,
+            "avg": 739823.0,
+            "p75": 824800.0,
+            "p99": 1625100.0,
+            "p995": 1889000.0,
+            "p999": 2797400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "order-limit",
+      "name": "wazoo - order-limit",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 520,
+            "min": 680600.0,
+            "max": 5167100.0,
+            "avg": 983547.0,
+            "p75": 986300.0,
+            "p99": 3062800.0,
+            "p995": 3560800.0,
+            "p999": 5167100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "order-limit",
+      "name": "comunica - order-limit",
       "baseline": false,
       "results": [
         {
           "ok": {
             "n": 73,
-            "min": 5854200.0,
-            "max": 14496000.0,
-            "avg": 7983259.0,
-            "p75": 8263700.0,
-            "p99": 14496000.0,
-            "p995": 14496000.0,
-            "p999": 14496000.0,
+            "min": 5387100.0,
+            "max": 13543600.0,
+            "avg": 7961166.0,
+            "p75": 8576700.0,
+            "p99": 13543600.0,
+            "p995": 13543600.0,
+            "p999": 13543600.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3282,21 +1236,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "oxigraph - clear-graph",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "order-limit",
+      "name": "oxigraph - order-limit",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 72,
-            "min": 5967600.0,
-            "max": 16889700.0,
-            "avg": 8014302.0,
-            "p75": 8472100.0,
-            "p99": 16889700.0,
-            "p995": 16889700.0,
-            "p999": 16889700.0,
+            "n": 364,
+            "min": 932300.0,
+            "max": 8967400.0,
+            "avg": 1424934.0,
+            "p75": 1463400.0,
+            "p99": 4631700.0,
+            "p995": 7975300.0,
+            "p999": 8967400.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3304,21 +1258,43 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "oxigraph - clear-graph-silent",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "distinct",
+      "name": "wazoo - distinct",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 2320,
+            "min": 120500.0,
+            "max": 2744100.0,
+            "avg": 216709.0,
+            "p75": 210100.0,
+            "p99": 1185100.0,
+            "p995": 1340500.0,
+            "p999": 1820200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "distinct",
+      "name": "comunica - distinct",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 73,
-            "min": 5154700.0,
-            "max": 15529300.0,
-            "avg": 7830847.0,
-            "p75": 8743100.0,
-            "p99": 15529300.0,
-            "p995": 15529300.0,
-            "p999": 15529300.0,
+            "n": 321,
+            "min": 977600.0,
+            "max": 4466300.0,
+            "avg": 1609572.0,
+            "p75": 1783400.0,
+            "p99": 3416100.0,
+            "p995": 4442900.0,
+            "p999": 4466300.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3326,21 +1302,21 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "oxigraph - copy-graph",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "distinct",
+      "name": "oxigraph - distinct",
       "baseline": false,
       "results": [
         {
           "ok": {
-            "n": 69,
-            "min": 6096800.0,
-            "max": 16923300.0,
-            "avg": 8617429.0,
-            "p75": 9477200.0,
-            "p99": 16923300.0,
-            "p995": 16923300.0,
-            "p999": 16923300.0,
+            "n": 2565,
+            "min": 105200.0,
+            "max": 1578000.0,
+            "avg": 195552.0,
+            "p75": 211400.0,
+            "p99": 599700.0,
+            "p995": 712000.0,
+            "p999": 1155700.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }
@@ -3348,395 +1324,2507 @@
       ]
     },
     {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "oxigraph - copy-graph-silent",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 65,
-            "min": 5975300.0,
-            "max": 23939200.0,
-            "avg": 10011739.0,
-            "p75": 11163400.0,
-            "p99": 23939200.0,
-            "p995": 23939200.0,
-            "p999": 23939200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "oxigraph - drop-graph",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 76,
-            "min": 5407500.0,
-            "max": 16407500.0,
-            "avg": 7678462.0,
-            "p75": 7779100.0,
-            "p99": 16407500.0,
-            "p995": 16407500.0,
-            "p999": 16407500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "oxigraph - drop-graph-silent",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 73,
-            "min": 5506400.0,
-            "max": 19045700.0,
-            "avg": 8400585.0,
-            "p75": 9624800.0,
-            "p99": 19045700.0,
-            "p995": 19045700.0,
-            "p999": 19045700.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "oxigraph - move-graph",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 51,
-            "min": 6219300.0,
-            "max": 23204600.0,
-            "avg": 11720620.0,
-            "p75": 13054100.0,
-            "p99": 23204600.0,
-            "p995": 23204600.0,
-            "p999": 23204600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "oxigraph - move-graph-silent",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 67,
-            "min": 5711000.0,
-            "max": 17124600.0,
-            "avg": 8726195.0,
-            "p75": 9444600.0,
-            "p99": 17124600.0,
-            "p995": 17124600.0,
-            "p999": 17124600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "wazoo - add-graph",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 548,
-            "min": 614200.0,
-            "max": 5338100.0,
-            "avg": 927429.0,
-            "p75": 869800.0,
-            "p99": 3883700.0,
-            "p995": 4712800.0,
-            "p999": 5338100.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "wazoo - add-graph-silent",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 533,
-            "min": 587600.0,
-            "max": 5900600.0,
-            "avg": 953559.0,
-            "p75": 868400.0,
-            "p99": 3779000.0,
-            "p995": 4681900.0,
-            "p999": 5900600.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "wazoo - clear-graph",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 360,
-            "min": 1030200.0,
-            "max": 5883100.0,
-            "avg": 1455264.0,
-            "p75": 1539800.0,
-            "p99": 5161200.0,
-            "p995": 5869500.0,
-            "p999": 5883100.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "wazoo - clear-graph-silent",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 359,
-            "min": 995300.0,
-            "max": 6257400.0,
-            "avg": 1431979.0,
-            "p75": 1413700.0,
-            "p99": 4434600.0,
-            "p995": 5681200.0,
-            "p999": 6257400.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "wazoo - copy-graph",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 146,
-            "min": 2857100.0,
-            "max": 17166000.0,
-            "avg": 3728603.0,
-            "p75": 3672500.0,
-            "p99": 13569800.0,
-            "p995": 17166000.0,
-            "p999": 17166000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "wazoo - copy-graph-silent",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 146,
-            "min": 2913600.0,
-            "max": 9946800.0,
-            "avg": 3844209.0,
-            "p75": 3995900.0,
-            "p99": 9377000.0,
-            "p995": 9946800.0,
-            "p999": 9946800.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "wazoo - drop-graph",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 390,
-            "min": 1002700.0,
-            "max": 4797700.0,
-            "avg": 1328457.0,
-            "p75": 1295700.0,
-            "p99": 3397900.0,
-            "p995": 3845800.0,
-            "p999": 4797700.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "wazoo - drop-graph-silent",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 365,
-            "min": 1016600.0,
-            "max": 6739200.0,
-            "avg": 1407200.0,
-            "p75": 1432700.0,
-            "p99": 3845600.0,
-            "p995": 4174600.0,
-            "p999": 6739200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "wazoo - move-graph",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 128,
-            "min": 3469600.0,
-            "max": 8573000.0,
-            "avg": 4264267.0,
-            "p75": 4523700.0,
-            "p99": 8038900.0,
-            "p995": 8573000.0,
-            "p999": 8573000.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "update-ops",
-      "name": "wazoo - move-graph-silent",
-      "baseline": true,
-      "results": [
-        {
-          "ok": {
-            "n": 126,
-            "min": 3269200.0,
-            "max": 13376800.0,
-            "avg": 4318525.0,
-            "p75": 4524300.0,
-            "p99": 11344400.0,
-            "p995": 13376800.0,
-            "p999": 13376800.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "values-bind",
-      "name": "comunica - values-bind",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 463,
-            "min": 802700.0,
-            "max": 3331500.0,
-            "avg": 1110479.0,
-            "p75": 1089500.0,
-            "p99": 2637600.0,
-            "p995": 2886500.0,
-            "p999": 3331500.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
-      "group": "values-bind",
-      "name": "oxigraph - values-bind",
-      "baseline": false,
-      "results": [
-        {
-          "ok": {
-            "n": 4934,
-            "min": 57700.0,
-            "max": 19753600.0,
-            "avg": 103740.0,
-            "p75": 97600.0,
-            "p99": 401700.0,
-            "p995": 541800.0,
-            "p999": 1665200.0,
-            "highPrecision": true,
-            "usedExplicitTimers": false
-          }
-        }
-      ]
-    },
-    {
-      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/repos/sparql-engine/bench/engine_bench.ts",
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
       "group": "values-bind",
       "name": "wazoo - values-bind",
       "baseline": true,
       "results": [
         {
           "ok": {
-            "n": 1047,
-            "min": 269000.0,
-            "max": 4906300.0,
-            "avg": 481509.0,
-            "p75": 452500.0,
-            "p99": 2640300.0,
-            "p995": 3446000.0,
-            "p999": 4850900.0,
+            "n": 1885,
+            "min": 127200.0,
+            "max": 5761400.0,
+            "avg": 267206.0,
+            "p75": 272100.0,
+            "p99": 1139800.0,
+            "p995": 1368000.0,
+            "p999": 3834100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "values-bind",
+      "name": "comunica - values-bind",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 343,
+            "min": 758300.0,
+            "max": 4163000.0,
+            "avg": 1494498.0,
+            "p75": 1676400.0,
+            "p99": 3720400.0,
+            "p995": 3971500.0,
+            "p999": 4163000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "values-bind",
+      "name": "oxigraph - values-bind",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 6135,
+            "min": 38200.0,
+            "max": 1147100.0,
+            "avg": 81654.0,
+            "p75": 83000.0,
+            "p99": 381100.0,
+            "p995": 441300.0,
+            "p999": 698700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "graph",
+      "name": "wazoo - graph",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 3902,
+            "min": 64300.0,
+            "max": 5193400.0,
+            "avg": 128573.0,
+            "p75": 129100.0,
+            "p99": 436600.0,
+            "p995": 1122200.0,
+            "p999": 1546000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "graph",
+      "name": "comunica - graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 490,
+            "min": 510000.0,
+            "max": 3912200.0,
+            "avg": 1039294.0,
+            "p75": 1216200.0,
+            "p99": 3154900.0,
+            "p995": 3266300.0,
+            "p999": 3912200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "graph",
+      "name": "oxigraph - graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 709,
+            "min": 393100.0,
+            "max": 34799500.0,
+            "avg": 715567.0,
+            "p75": 577600.0,
+            "p99": 2041000.0,
+            "p995": 10080400.0,
+            "p999": 34799500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "from",
+      "name": "wazoo - from",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1323,
+            "min": 231500.0,
+            "max": 7754600.0,
+            "avg": 380824.0,
+            "p75": 340700.0,
+            "p99": 2161200.0,
+            "p995": 2368100.0,
+            "p999": 3025100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "from",
+      "name": "comunica - from",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 544,
+            "min": 548900.0,
+            "max": 3476200.0,
+            "avg": 938153.0,
+            "p75": 972700.0,
+            "p99": 2716100.0,
+            "p995": 2868600.0,
+            "p999": 3476200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "from",
+      "name": "oxigraph - from",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 805,
+            "min": 369900.0,
+            "max": 27760800.0,
+            "avg": 628110.0,
+            "p75": 538600.0,
+            "p99": 1304100.0,
+            "p995": 1430500.0,
+            "p999": 27760800.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "subquery",
+      "name": "wazoo - subquery",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 592,
+            "min": 480000.0,
+            "max": 4433200.0,
+            "avg": 857626.0,
+            "p75": 869700.0,
+            "p99": 2800800.0,
+            "p995": 3090600.0,
+            "p999": 4433200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "subquery",
+      "name": "comunica - subquery",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 162,
+            "min": 1973400.0,
+            "max": 9115900.0,
+            "avg": 3316834.0,
+            "p75": 4014500.0,
+            "p99": 7250400.0,
+            "p995": 9115900.0,
+            "p999": 9115900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "subquery",
+      "name": "oxigraph - subquery",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 289,
+            "min": 990500.0,
+            "max": 32217500.0,
+            "avg": 1779272.0,
+            "p75": 1638100.0,
+            "p99": 25143000.0,
+            "p995": 30693400.0,
+            "p999": 32217500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "subquery",
+      "name": "wazoo - subquery-agg",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 2197,
+            "min": 116800.0,
+            "max": 5075200.0,
+            "avg": 228493.0,
+            "p75": 215400.0,
+            "p99": 1260000.0,
+            "p995": 1495500.0,
+            "p999": 2407200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "subquery",
+      "name": "comunica - subquery-agg",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 144,
+            "min": 2301400.0,
+            "max": 9118400.0,
+            "avg": 3770407.0,
+            "p75": 4286300.0,
+            "p99": 8962100.0,
+            "p995": 9118400.0,
+            "p999": 9118400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "subquery",
+      "name": "oxigraph - subquery-agg",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 2276,
+            "min": 116300.0,
+            "max": 5967400.0,
+            "avg": 220745.0,
+            "p75": 235300.0,
+            "p99": 716700.0,
+            "p995": 802900.0,
+            "p999": 1671700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "subquery",
+      "name": "wazoo - subquery-nested",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 563,
+            "min": 444900.0,
+            "max": 3917100.0,
+            "avg": 905474.0,
+            "p75": 947600.0,
+            "p99": 2916500.0,
+            "p995": 3464400.0,
+            "p999": 3917100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "subquery",
+      "name": "comunica - subquery-nested",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 140,
+            "min": 2381100.0,
+            "max": 7740600.0,
+            "avg": 3949824.0,
+            "p75": 4838700.0,
+            "p99": 7421200.0,
+            "p995": 7740600.0,
+            "p999": 7740600.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "subquery",
+      "name": "oxigraph - subquery-nested",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 250,
+            "min": 809900.0,
+            "max": 31954400.0,
+            "avg": 2073554.0,
+            "p75": 2160000.0,
+            "p99": 4995800.0,
+            "p995": 5599200.0,
+            "p999": 31954400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "wazoo - exists",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 723,
+            "min": 350800.0,
+            "max": 5520300.0,
+            "avg": 698842.0,
+            "p75": 725900.0,
+            "p99": 2413300.0,
+            "p995": 2915800.0,
+            "p999": 5520300.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "comunica - exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 33,
+            "min": 17115200.0,
+            "max": 28977900.0,
+            "avg": 21527328.0,
+            "p75": 24657100.0,
+            "p99": 28977900.0,
+            "p995": 28977900.0,
+            "p999": 28977900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "oxigraph - exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 664,
+            "min": 443900.0,
+            "max": 25184600.0,
+            "avg": 767468.0,
+            "p75": 779500.0,
+            "p99": 1926600.0,
+            "p995": 2258100.0,
+            "p999": 25184600.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "wazoo - not-exists",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 789,
+            "min": 334800.0,
+            "max": 4521200.0,
+            "avg": 642015.0,
+            "p75": 681600.0,
+            "p99": 2180800.0,
+            "p995": 3110600.0,
+            "p999": 4521200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "comunica - not-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 32,
+            "min": 17142400.0,
+            "max": 30617500.0,
+            "avg": 23415900.0,
+            "p75": 25288400.0,
+            "p99": 30617500.0,
+            "p995": 30617500.0,
+            "p999": 30617500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "oxigraph - not-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 598,
+            "min": 495800.0,
+            "max": 23279900.0,
+            "avg": 849786.0,
+            "p75": 885500.0,
+            "p99": 1990400.0,
+            "p995": 2930000.0,
+            "p999": 23279900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "wazoo - nested-exists",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 583,
+            "min": 536900.0,
+            "max": 7057500.0,
+            "avg": 872468.0,
+            "p75": 868800.0,
+            "p99": 2729600.0,
+            "p995": 3719900.0,
+            "p999": 7057500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "comunica - nested-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 16,
+            "min": 74452000.0,
+            "max": 118608200.0,
+            "avg": 88781350.0,
+            "p75": 91522600.0,
+            "p99": 118608200.0,
+            "p995": 118608200.0,
+            "p999": 118608200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "oxigraph - nested-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 546,
+            "min": 611900.0,
+            "max": 18310000.0,
+            "avg": 932885.0,
+            "p75": 906400.0,
+            "p99": 2273100.0,
+            "p995": 3331600.0,
+            "p999": 18310000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "wazoo - nested-not-exists",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 590,
+            "min": 498500.0,
+            "max": 4614800.0,
+            "avg": 860462.0,
+            "p75": 868900.0,
+            "p99": 2664000.0,
+            "p995": 3006900.0,
+            "p999": 4614800.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "comunica - nested-not-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 12,
+            "min": 80978200.0,
+            "max": 578671900.0,
+            "avg": 127691167.0,
+            "p75": 90320900.0,
+            "p99": 578671900.0,
+            "p995": 578671900.0,
+            "p999": 578671900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists",
+      "name": "oxigraph - nested-not-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 546,
+            "min": 547200.0,
+            "max": 10181700.0,
+            "avg": 929424.0,
+            "p75": 989700.0,
+            "p99": 2666100.0,
+            "p995": 3341800.0,
+            "p999": 10181700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "wazoo - exists",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 35,
+            "min": 16427000.0,
+            "max": 28420500.0,
+            "avg": 20107240.0,
+            "p75": 20946800.0,
+            "p99": 28420500.0,
+            "p995": 28420500.0,
+            "p999": 28420500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "comunica - exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 11,
+            "min": 452086200.0,
+            "max": 550907000.0,
+            "avg": 499000364.0,
+            "p75": 540382400.0,
+            "p99": 550907000.0,
+            "p995": 550907000.0,
+            "p999": 550907000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "oxigraph - exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 34,
+            "min": 17885300.0,
+            "max": 34237300.0,
+            "avg": 22158421.0,
+            "p75": 23808800.0,
+            "p99": 34237300.0,
+            "p995": 34237300.0,
+            "p999": 34237300.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "wazoo - not-exists",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 36,
+            "min": 15279700.0,
+            "max": 24075500.0,
+            "avg": 19328942.0,
+            "p75": 20427100.0,
+            "p99": 24075500.0,
+            "p995": 24075500.0,
+            "p999": 24075500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "comunica - not-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 12,
+            "min": 429787100.0,
+            "max": 576898300.0,
+            "avg": 484712200.0,
+            "p75": 490062400.0,
+            "p99": 576898300.0,
+            "p995": 576898300.0,
+            "p999": 576898300.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "oxigraph - not-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 35,
+            "min": 17650400.0,
+            "max": 34609500.0,
+            "avg": 21428272.0,
+            "p75": 22386200.0,
+            "p99": 34609500.0,
+            "p995": 34609500.0,
+            "p999": 34609500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "wazoo - nested-exists",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 30,
+            "min": 22294400.0,
+            "max": 42199400.0,
+            "avg": 25932364.0,
+            "p75": 26047700.0,
+            "p99": 42199400.0,
+            "p995": 42199400.0,
+            "p999": 42199400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "comunica - nested-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 11,
+            "min": 1976170000.0,
+            "max": 5246008500.0,
+            "avg": 3055230564.0,
+            "p75": 4407667600.0,
+            "p99": 5246008500.0,
+            "p995": 5246008500.0,
+            "p999": 5246008500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "oxigraph - nested-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 29,
+            "min": 22750900.0,
+            "max": 39332100.0,
+            "avg": 26399314.0,
+            "p75": 26995000.0,
+            "p99": 39332100.0,
+            "p995": 39332100.0,
+            "p999": 39332100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "wazoo - nested-not-exists",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 30,
+            "min": 21765200.0,
+            "max": 41758500.0,
+            "avg": 26817977.0,
+            "p75": 28426800.0,
+            "p99": 41758500.0,
+            "p995": 41758500.0,
+            "p999": 41758500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "comunica - nested-not-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 11,
+            "min": 2008533000.0,
+            "max": 2631992000.0,
+            "avg": 2217423455.0,
+            "p75": 2373573600.0,
+            "p99": 2631992000.0,
+            "p995": 2631992000.0,
+            "p999": 2631992000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "exists-large",
+      "name": "oxigraph - nested-not-exists",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 26,
+            "min": 24733200.0,
+            "max": 48856200.0,
+            "avg": 31539343.0,
+            "p75": 33835900.0,
+            "p99": 48856200.0,
+            "p995": 48856200.0,
+            "p999": 48856200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join-large",
+      "name": "wazoo - union",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 21,
+            "min": 43758000.0,
+            "max": 55393100.0,
+            "avg": 47962620.0,
+            "p75": 49707600.0,
+            "p99": 55393100.0,
+            "p995": 55393100.0,
+            "p999": 55393100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join-large",
+      "name": "comunica - union",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 15,
+            "min": 95666800.0,
+            "max": 142745000.0,
+            "avg": 111121094.0,
+            "p75": 116603100.0,
+            "p99": 142745000.0,
+            "p995": 142745000.0,
+            "p999": 142745000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join-large",
+      "name": "oxigraph - union",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 15,
+            "min": 77571700.0,
+            "max": 156660000.0,
+            "avg": 108190827.0,
+            "p75": 120019300.0,
+            "p99": 156660000.0,
+            "p995": 156660000.0,
+            "p999": 156660000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join-large",
+      "name": "wazoo - optional",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 35,
+            "min": 16235800.0,
+            "max": 27056100.0,
+            "avg": 20780926.0,
+            "p75": 22429900.0,
+            "p99": 27056100.0,
+            "p995": 27056100.0,
+            "p999": 27056100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join-large",
+      "name": "comunica - optional",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 11,
+            "min": 518197200.0,
+            "max": 728055000.0,
+            "avg": 576726673.0,
+            "p75": 612183400.0,
+            "p99": 728055000.0,
+            "p995": 728055000.0,
+            "p999": 728055000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join-large",
+      "name": "oxigraph - optional",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 20,
+            "min": 43736500.0,
+            "max": 75133100.0,
+            "avg": 54960050.0,
+            "p75": 60964700.0,
+            "p99": 75133100.0,
+            "p995": 75133100.0,
+            "p999": 75133100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join-large",
+      "name": "wazoo - minus",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 41,
+            "min": 14032100.0,
+            "max": 23722100.0,
+            "avg": 16865540.0,
+            "p75": 18021900.0,
+            "p99": 23722100.0,
+            "p995": 23722100.0,
+            "p999": 23722100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join-large",
+      "name": "comunica - minus",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 22,
+            "min": 37813100.0,
+            "max": 85903500.0,
+            "avg": 47261928.0,
+            "p75": 46772300.0,
+            "p99": 85903500.0,
+            "p995": 85903500.0,
+            "p999": 85903500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "join-large",
+      "name": "oxigraph - minus",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 34,
+            "min": 17067200.0,
+            "max": 42814400.0,
+            "avg": 21590942.0,
+            "p75": 20882500.0,
+            "p99": 42814400.0,
+            "p995": 42814400.0,
+            "p999": 42814400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "cast",
+      "name": "wazoo - cast-numeric",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 759,
+            "min": 486500.0,
+            "max": 8062700.0,
+            "avg": 665736.0,
+            "p75": 697300.0,
+            "p99": 1648800.0,
+            "p995": 1897000.0,
+            "p999": 8062700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "cast",
+      "name": "comunica - cast-numeric",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 64,
+            "min": 7098400.0,
+            "max": 11610200.0,
+            "avg": 9212646.0,
+            "p75": 9869700.0,
+            "p99": 11610200.0,
+            "p995": 11610200.0,
+            "p999": 11610200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "cast",
+      "name": "oxigraph - cast-numeric",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 161,
+            "min": 2078400.0,
+            "max": 20556900.0,
+            "avg": 3315342.0,
+            "p75": 3367400.0,
+            "p99": 19672900.0,
+            "p995": 20556900.0,
+            "p999": 20556900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "cast",
+      "name": "wazoo - cast-boolean",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1894,
+            "min": 167900.0,
+            "max": 11995900.0,
+            "avg": 264998.0,
+            "p75": 271500.0,
+            "p99": 873400.0,
+            "p995": 1079200.0,
+            "p999": 7589000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "cast",
+      "name": "comunica - cast-boolean",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 148,
+            "min": 2477500.0,
+            "max": 9050500.0,
+            "avg": 3600888.0,
+            "p75": 4009300.0,
+            "p99": 7412100.0,
+            "p995": 9050500.0,
+            "p999": 9050500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "cast",
+      "name": "oxigraph - cast-boolean",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 391,
+            "min": 798900.0,
+            "max": 20691100.0,
+            "avg": 1310744.0,
+            "p75": 1288300.0,
+            "p99": 5076500.0,
+            "p995": 19779300.0,
+            "p999": 20691100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "cast",
+      "name": "wazoo - cast-dateTime",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1392,
+            "min": 265300.0,
+            "max": 10646800.0,
+            "avg": 362466.0,
+            "p75": 371900.0,
+            "p99": 1000900.0,
+            "p995": 1200200.0,
+            "p999": 1897500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "cast",
+      "name": "comunica - cast-dateTime",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 94,
+            "min": 3851400.0,
+            "max": 11865400.0,
+            "avg": 5885955.0,
+            "p75": 6764700.0,
+            "p99": 11865400.0,
+            "p995": 11865400.0,
+            "p999": 11865400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "cast",
+      "name": "oxigraph - cast-dateTime",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 240,
+            "min": 1485700.0,
+            "max": 19879300.0,
+            "avg": 2170881.0,
+            "p75": 2286900.0,
+            "p99": 4514000.0,
+            "p995": 18614800.0,
+            "p999": 19879300.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "wazoo - string-concat",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1699,
+            "min": 205400.0,
+            "max": 12367500.0,
+            "avg": 296191.0,
+            "p75": 264400.0,
+            "p99": 1355800.0,
+            "p995": 1626700.0,
+            "p999": 11239800.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "comunica - string-concat",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 101,
+            "min": 3625300.0,
+            "max": 9710300.0,
+            "avg": 5416845.0,
+            "p75": 6314500.0,
+            "p99": 9591400.0,
+            "p995": 9710300.0,
+            "p999": 9710300.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "oxigraph - string-concat",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 422,
+            "min": 758200.0,
+            "max": 20074700.0,
+            "avg": 1212441.0,
+            "p75": 1106600.0,
+            "p99": 4543600.0,
+            "p995": 17075500.0,
+            "p999": 20074700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "wazoo - string-before-after",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1280,
+            "min": 248400.0,
+            "max": 8549700.0,
+            "avg": 394059.0,
+            "p75": 379200.0,
+            "p99": 1925600.0,
+            "p995": 2335000.0,
+            "p999": 2793000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "comunica - string-before-after",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 96,
+            "min": 4017800.0,
+            "max": 11453100.0,
+            "avg": 5839572.0,
+            "p75": 6348400.0,
+            "p99": 11453100.0,
+            "p995": 11453100.0,
+            "p999": 11453100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "oxigraph - string-before-after",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 262,
+            "min": 1113200.0,
+            "max": 21602100.0,
+            "avg": 2003918.0,
+            "p75": 1979700.0,
+            "p99": 17579600.0,
+            "p995": 19998200.0,
+            "p999": 21602100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "wazoo - string-replace",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1479,
+            "min": 217800.0,
+            "max": 4810600.0,
+            "avg": 340081.0,
+            "p75": 352900.0,
+            "p99": 1262000.0,
+            "p995": 1497000.0,
+            "p999": 2112800.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "comunica - string-replace",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 117,
+            "min": 3114800.0,
+            "max": 9639600.0,
+            "avg": 4675034.0,
+            "p75": 5155200.0,
+            "p99": 7925700.0,
+            "p995": 9639600.0,
+            "p999": 9639600.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "oxigraph - string-replace",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 355,
+            "min": 852500.0,
+            "max": 19047500.0,
+            "avg": 1443711.0,
+            "p75": 1407400.0,
+            "p99": 5609900.0,
+            "p995": 18523100.0,
+            "p999": 19047500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "wazoo - string-encode-uri",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1621,
+            "min": 222500.0,
+            "max": 3066400.0,
+            "avg": 310588.0,
+            "p75": 316600.0,
+            "p99": 1304300.0,
+            "p995": 1415800.0,
+            "p999": 2522900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "comunica - string-encode-uri",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 128,
+            "min": 2730500.0,
+            "max": 16000500.0,
+            "avg": 4214932.0,
+            "p75": 4627300.0,
+            "p99": 10570800.0,
+            "p995": 16000500.0,
+            "p999": 16000500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "oxigraph - string-encode-uri",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 348,
+            "min": 882700.0,
+            "max": 27234300.0,
+            "avg": 1470193.0,
+            "p75": 1494800.0,
+            "p99": 7011000.0,
+            "p995": 22415200.0,
+            "p999": 27234300.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "wazoo - string-datatype",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1939,
+            "min": 194700.0,
+            "max": 2325700.0,
+            "avg": 259342.0,
+            "p75": 261900.0,
+            "p99": 781100.0,
+            "p995": 969900.0,
+            "p999": 1210700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "comunica - string-datatype",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 137,
+            "min": 2737300.0,
+            "max": 6993100.0,
+            "avg": 3919070.0,
+            "p75": 4485200.0,
+            "p99": 6969100.0,
+            "p995": 6993100.0,
+            "p999": 6993100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "oxigraph - string-datatype",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 381,
+            "min": 838500.0,
+            "max": 18087600.0,
+            "avg": 1341949.0,
+            "p75": 1288800.0,
+            "p99": 11887000.0,
+            "p995": 18033000.0,
+            "p999": 18087600.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "wazoo - string-lang",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1278,
+            "min": 275300.0,
+            "max": 3865400.0,
+            "avg": 393841.0,
+            "p75": 409900.0,
+            "p99": 1090500.0,
+            "p995": 1108900.0,
+            "p999": 1812100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "comunica - string-lang",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 91,
+            "min": 4360900.0,
+            "max": 12928500.0,
+            "avg": 6157008.0,
+            "p75": 6504800.0,
+            "p99": 12928500.0,
+            "p995": 12928500.0,
+            "p999": 12928500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "oxigraph - string-lang",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 292,
+            "min": 981400.0,
+            "max": 25907100.0,
+            "avg": 1765189.0,
+            "p75": 1628900.0,
+            "p99": 16687700.0,
+            "p995": 19619000.0,
+            "p999": 25907100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "wazoo - string-iri",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 1401,
+            "min": 207000.0,
+            "max": 9056300.0,
+            "avg": 359463.0,
+            "p75": 355700.0,
+            "p99": 1359900.0,
+            "p995": 1446000.0,
+            "p999": 2207100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "comunica - string-iri",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 90,
+            "min": 4068200.0,
+            "max": 16480100.0,
+            "avg": 6282369.0,
+            "p75": 6802400.0,
+            "p99": 16480100.0,
+            "p995": 16480100.0,
+            "p999": 16480100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "string-fn",
+      "name": "oxigraph - string-iri",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 297,
+            "min": 994300.0,
+            "max": 22748100.0,
+            "avg": 1743815.0,
+            "p75": 1769100.0,
+            "p99": 4446600.0,
+            "p995": 17169500.0,
+            "p999": 22748100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "reduced",
+      "name": "wazoo - reduced",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 2248,
+            "min": 122700.0,
+            "max": 1889700.0,
+            "avg": 223557.0,
+            "p75": 239100.0,
+            "p99": 724900.0,
+            "p995": 820000.0,
+            "p999": 1340200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "reduced",
+      "name": "comunica - reduced",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 339,
+            "min": 878000.0,
+            "max": 5322000.0,
+            "avg": 1520906.0,
+            "p75": 1733200.0,
+            "p99": 4025100.0,
+            "p995": 4637500.0,
+            "p999": 5322000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "reduced",
+      "name": "oxigraph - reduced",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 2479,
+            "min": 102800.0,
+            "max": 3079800.0,
+            "avg": 202483.0,
+            "p75": 212300.0,
+            "p99": 715500.0,
+            "p995": 888700.0,
+            "p999": 1129000.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "wazoo - clear-graph",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 539,
+            "min": 511000.0,
+            "max": 3327200.0,
+            "avg": 945603.0,
+            "p75": 1016000.0,
+            "p99": 2641900.0,
+            "p995": 3045200.0,
+            "p999": 3327200.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "comunica - clear-graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 454,
+            "min": 621400.0,
+            "max": 3381400.0,
+            "avg": 1134008.0,
+            "p75": 1309100.0,
+            "p99": 2758800.0,
+            "p995": 3308700.0,
+            "p999": 3381400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "oxigraph - clear-graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 71,
+            "min": 5616100.0,
+            "max": 17254400.0,
+            "avg": 8298985.0,
+            "p75": 8813600.0,
+            "p99": 17254400.0,
+            "p995": 17254400.0,
+            "p999": 17254400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "wazoo - clear-graph-silent",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 494,
+            "min": 508800.0,
+            "max": 3719900.0,
+            "avg": 1030980.0,
+            "p75": 1192800.0,
+            "p99": 2917900.0,
+            "p995": 3232500.0,
+            "p999": 3719900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "comunica - clear-graph-silent",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 432,
+            "min": 586100.0,
+            "max": 4972500.0,
+            "avg": 1179887.0,
+            "p75": 1308100.0,
+            "p99": 4102500.0,
+            "p995": 4587000.0,
+            "p999": 4972500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "oxigraph - clear-graph-silent",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 70,
+            "min": 5984500.0,
+            "max": 14968600.0,
+            "avg": 8448616.0,
+            "p75": 9464500.0,
+            "p99": 14968600.0,
+            "p995": 14968600.0,
+            "p999": 14968600.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "wazoo - drop-graph",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 453,
+            "min": 490800.0,
+            "max": 6524400.0,
+            "avg": 1124162.0,
+            "p75": 1390200.0,
+            "p99": 2832600.0,
+            "p995": 3454500.0,
+            "p999": 6524400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "comunica - drop-graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 452,
+            "min": 589800.0,
+            "max": 3097300.0,
+            "avg": 1129506.0,
+            "p75": 1275300.0,
+            "p99": 2705800.0,
+            "p995": 2926200.0,
+            "p999": 3097300.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "oxigraph - drop-graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 68,
+            "min": 5726900.0,
+            "max": 18847700.0,
+            "avg": 8679231.0,
+            "p75": 9018900.0,
+            "p99": 18847700.0,
+            "p995": 18847700.0,
+            "p999": 18847700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "wazoo - drop-graph-silent",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 493,
+            "min": 513900.0,
+            "max": 5027500.0,
+            "avg": 1034617.0,
+            "p75": 1135300.0,
+            "p99": 3488400.0,
+            "p995": 3910700.0,
+            "p999": 5027500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "comunica - drop-graph-silent",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 472,
+            "min": 617300.0,
+            "max": 3506600.0,
+            "avg": 1080412.0,
+            "p75": 1173600.0,
+            "p99": 2791000.0,
+            "p995": 3017200.0,
+            "p999": 3506600.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "oxigraph - drop-graph-silent",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 65,
+            "min": 5694900.0,
+            "max": 19733100.0,
+            "avg": 9301171.0,
+            "p75": 9868000.0,
+            "p99": 19733100.0,
+            "p995": 19733100.0,
+            "p999": 19733100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "wazoo - add-graph",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 846,
+            "min": 275400.0,
+            "max": 3192900.0,
+            "avg": 597548.0,
+            "p75": 640100.0,
+            "p99": 2183400.0,
+            "p995": 2274200.0,
+            "p999": 3192900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "comunica - add-graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 214,
+            "min": 1226600.0,
+            "max": 15308900.0,
+            "avg": 2527303.0,
+            "p75": 2952100.0,
+            "p99": 5884800.0,
+            "p995": 5946100.0,
+            "p999": 15308900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "oxigraph - add-graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 67,
+            "min": 5218400.0,
+            "max": 15824100.0,
+            "avg": 8735424.0,
+            "p75": 9462400.0,
+            "p99": 15824100.0,
+            "p995": 15824100.0,
+            "p999": 15824100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "wazoo - add-graph-silent",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 882,
+            "min": 278000.0,
+            "max": 2795800.0,
+            "avg": 573543.0,
+            "p75": 605700.0,
+            "p99": 2176300.0,
+            "p995": 2291500.0,
+            "p999": 2795800.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "comunica - add-graph-silent",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 215,
+            "min": 1385300.0,
+            "max": 7212500.0,
+            "avg": 2484029.0,
+            "p75": 2895800.0,
+            "p99": 5508000.0,
+            "p995": 6681200.0,
+            "p999": 7212500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "oxigraph - add-graph-silent",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 65,
+            "min": 5859400.0,
+            "max": 18608700.0,
+            "avg": 9152596.0,
+            "p75": 10425000.0,
+            "p99": 18608700.0,
+            "p995": 18608700.0,
+            "p999": 18608700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "wazoo - copy-graph",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 182,
+            "min": 1704200.0,
+            "max": 6578900.0,
+            "avg": 2917044.0,
+            "p75": 3299200.0,
+            "p99": 6237400.0,
+            "p995": 6578900.0,
+            "p999": 6578900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "comunica - copy-graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 105,
+            "min": 3208400.0,
+            "max": 10243300.0,
+            "avg": 5266068.0,
+            "p75": 5914600.0,
+            "p99": 9603700.0,
+            "p995": 10243300.0,
+            "p999": 10243300.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "oxigraph - copy-graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 64,
+            "min": 6030300.0,
+            "max": 17394900.0,
+            "avg": 9299866.0,
+            "p75": 10330200.0,
+            "p99": 17394900.0,
+            "p995": 17394900.0,
+            "p999": 17394900.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "wazoo - copy-graph-silent",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 185,
+            "min": 1505800.0,
+            "max": 8002400.0,
+            "avg": 2859385.0,
+            "p75": 3047900.0,
+            "p99": 7348100.0,
+            "p995": 8002400.0,
+            "p999": 8002400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "comunica - copy-graph-silent",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 125,
+            "min": 2864200.0,
+            "max": 9237700.0,
+            "avg": 4390180.0,
+            "p75": 4652500.0,
+            "p99": 7876600.0,
+            "p995": 9237700.0,
+            "p999": 9237700.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "oxigraph - copy-graph-silent",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 64,
+            "min": 5818700.0,
+            "max": 18759300.0,
+            "avg": 9554343.0,
+            "p75": 11025900.0,
+            "p99": 18759300.0,
+            "p995": 18759300.0,
+            "p999": 18759300.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "wazoo - move-graph",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 148,
+            "min": 2152200.0,
+            "max": 9001500.0,
+            "avg": 3590008.0,
+            "p75": 3938600.0,
+            "p99": 7609300.0,
+            "p995": 9001500.0,
+            "p999": 9001500.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "comunica - move-graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 107,
+            "min": 3648700.0,
+            "max": 10543600.0,
+            "avg": 5221818.0,
+            "p75": 5790100.0,
+            "p99": 8057700.0,
+            "p995": 10543600.0,
+            "p999": 10543600.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "oxigraph - move-graph",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 68,
+            "min": 6144300.0,
+            "max": 16269400.0,
+            "avg": 8482374.0,
+            "p75": 8685600.0,
+            "p99": 16269400.0,
+            "p995": 16269400.0,
+            "p999": 16269400.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "wazoo - move-graph-silent",
+      "baseline": true,
+      "results": [
+        {
+          "ok": {
+            "n": 152,
+            "min": 2291900.0,
+            "max": 9236100.0,
+            "avg": 3555979.0,
+            "p75": 3845200.0,
+            "p99": 6707200.0,
+            "p995": 9236100.0,
+            "p999": 9236100.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "comunica - move-graph-silent",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 96,
+            "min": 3602000.0,
+            "max": 18755600.0,
+            "avg": 5839861.0,
+            "p75": 6250400.0,
+            "p99": 18755600.0,
+            "p995": 18755600.0,
+            "p999": 18755600.0,
+            "highPrecision": true,
+            "usedExplicitTimers": false
+          }
+        }
+      ]
+    },
+    {
+      "origin": "file:///C:/Users/ethan/Documents/wazootech/workspace/worktrees/sparql-engine/planner-join-order-search/bench/engine_bench.ts",
+      "group": "update-ops",
+      "name": "oxigraph - move-graph-silent",
+      "baseline": false,
+      "results": [
+        {
+          "ok": {
+            "n": 66,
+            "min": 5731900.0,
+            "max": 20821500.0,
+            "avg": 8916258.0,
+            "p75": 9746200.0,
+            "p99": 20821500.0,
+            "p995": 20821500.0,
+            "p999": 20821500.0,
             "highPrecision": true,
             "usedExplicitTimers": false
           }

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -209,12 +209,24 @@ engine's optimizer. It is a _dynamic_ greedy planner, not a static rewrite:
    from the pattern's already-scanned candidates — exact cardinality plus a
    distinct-value pass capped at `DISTINCT_SAMPLE_CAP`, so large stores never
    pay an unbounded counting pass. Named-graph scopes always use the scoped
-   candidate derivation (the hook cannot see the scope).
-4. A greedy loop repeatedly joins the remaining pattern with the lowest
-   estimated cost against the current bindings. The estimate comes from an
-   injectable `JoinCostEstimator` (`src/planner/join-cost-estimator.ts`; default
-   `BaselineJoinCostEstimator`, wired via `WazooSparqlEngineOptions.estimator`),
-   which receives each pattern's statistics:
+   candidate derivation (the hook cannot see the scope).4. With the default
+   estimator, small BGPs (≤ `DP_MAX_PATTERNS`, issue #130) skip the greedy loop:
+   `searchBestJoinOrder` (`src/planner/join-order-search.ts`) runs a subset DP
+   over the 2^n join orders — each state carries the cheapest plan's estimated
+   output cardinality and bound-variable set, and appending a pattern costs the
+   same formula the estimator uses. The DP is a plan search only (it never
+   materializes bindings), so it changes only which order the joins run in, and
+   it is globally optimal under the estimated model where greedy is only
+   stepwise-optimal — greedy can pick a locally cheap join that doubles the
+   cross product later (the `dp-join` bench row shows ~2×). Larger BGPs, and any
+   injected custom `JoinCostEstimator` (whose costs the DP cannot assume), keep
+   the greedy loop.
+4. The chosen order executes through the normal eager join loop
+   (`joinTriplePattern` per step, materializing the current result set). The
+   per-step estimate comes from the injectable `JoinCostEstimator`
+   (`src/planner/join-cost-estimator.ts`; default `BaselineJoinCostEstimator`,
+   wired via `WazooSparqlEngineOptions.estimator`), which receives each
+   pattern's statistics:
    - no pattern variable bound → `bindings.length × candidates.length`;
    - a pattern variable bound in the incoming solutions → the positional index
      is probed, costing `bindings.length × average bucket size`
@@ -223,7 +235,8 @@ engine's optimizer. It is a _dynamic_ greedy planner, not a static rewrite:
      count otherwise).
 
    The estimate affects only join order, never results (SPARQL §18.2.2 — joins
-   commute), so an estimator swap is guarded by the W3C differential gate.
+   commute), so both an estimator swap and the DP are guarded by the W3C
+   differential gate.
 
 ### Worked example: the `reorder-chain` benchmark
 

--- a/docs/03-api-contracts.md
+++ b/docs/03-api-contracts.md
@@ -324,8 +324,10 @@ scan), the current bindings, and the pattern's optional `PatternStats` — and
 nothing else: no store access. It must be pure and deterministic. Crucially, the
 estimate affects **only join order, never results** (SPARQL 1.1 §18.2.2: joins
 commute, so every order yields the same solution multiset); the W3C differential
-gate is the guard. Planner piece 3 (join-order search) plugs in behind this
-seam.
+gate is the guard. With the default estimator, small BGPs get the globally
+optimal order from the DP join-order search (`searchBestJoinOrder`, piece 3,
+issue #130), which optimizes exactly this cost model over the pattern
+statistics; an injected custom estimator keeps the greedy loop.
 
 ### 5a. Statistics source
 
@@ -396,15 +398,16 @@ Types:
 [`SparqlBinding`](https://jsr.io/@wazoo/sparql-engine/doc/~/SparqlBinding),
 [`WazooSparqlEngineOptions`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngineOptions),
 [`WazooSparqlTransaction`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlTransaction),
-`IriFunction`, `IriFunctionMap` (link on JSR once published),
-`JoinCostEstimator` (link on JSR once published), `PatternStats`,
-`StoreStatisticsHook` (link on JSR once published),
+`IriFunction`, `IriFunctionMap` (link on JSR once published),`JoinCostEstimator`
+(link on JSR once published), `PatternStats`, `StoreStatisticsHook` (link on JSR
+once published), `EstimatedJoinState` (link on JSR once published),
 [`CanonicalTerm`](https://jsr.io/@wazoo/sparql-engine/doc/~/CanonicalTerm).
 
 Values/classes:
 [`WazooSparqlEngine`](https://jsr.io/@wazoo/sparql-engine/doc/~/WazooSparqlEngine),
 `BaselineJoinCostEstimator` (link on JSR once published), `PatternStatistics`,
-`DISTINCT_SAMPLE_CAP` (link on JSR once published),
+`DISTINCT_SAMPLE_CAP` (link on JSR once published), `searchBestJoinOrder`,
+`DP_MAX_PATTERNS` (link on JSR once published),
 [`MemoryStore`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStore),
 [`MemoryStream`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStream),
 [`DataFactory`](https://jsr.io/@wazoo/sparql-engine/doc/~/DataFactory),

--- a/docs/07-benchmarking.md
+++ b/docs/07-benchmarking.md
@@ -60,40 +60,42 @@ run `deno task bench` for your own numbers.
 
 Core joins, 400-person graph (~2,200 quads):
 
-| query                        | wazoo   | comunica | oxigraph |
-| ---------------------------- | ------- | -------- | -------- |
-| full scan                    | 0.96 ms | 5.5 ms   | 12.2 ms  |
-| join (knows × name)          | 0.66 ms | 3.1 ms   | 3.4 ms   |
-| asymmetric join              | 1.2 ms  | 19.2 ms  | 19.3 ms  |
-| reorder chain, written order | 97.4 ms | 96.8 ms  | 4.2 ms   |
-| reorder chain, planner on    | 1.2 ms  | —        | —        |
+| query                        | wazoo    | comunica | oxigraph |
+| ---------------------------- | -------- | -------- | -------- |
+| full scan                    | 1.1 ms   | 6.0 ms   | 8.8 ms   |
+| join (knows × name)          | 0.91 ms  | 3.4 ms   | 1.6 ms   |
+| asymmetric join              | 1.7 ms   | 23.0 ms  | 11.5 ms  |
+| reorder chain, written order | 105.5 ms | 107.8 ms | 2.2 ms   |
+| reorder chain, planner on    | 1.5 ms   | —        | —        |
+| dp-join, DP plan             | 62.2 ms  | 190.4 ms | 1120 ms  |
+| dp-join, greedy plan         | 125.2 ms | —        | —        |
 
 EXISTS surface, 400-person graph:
 
-| query               | wazoo  | comunica | oxigraph |
-| ------------------- | ------ | -------- | -------- |
-| `FILTER EXISTS`     | 1.0 ms | 19.3 ms  | 1.6 ms   |
-| `FILTER NOT EXISTS` | 0.9 ms | 20.1 ms  | 1.4 ms   |
-| nested `EXISTS`     | 1.2 ms | 74.8 ms  | 1.7 ms   |
-| nested `NOT EXISTS` | 1.2 ms | 75.2 ms  | 1.8 ms   |
+| query               | wazoo   | comunica | oxigraph |
+| ------------------- | ------- | -------- | -------- |
+| `FILTER EXISTS`     | 0.70 ms | 21.5 ms  | 0.77 ms  |
+| `FILTER NOT EXISTS` | 0.64 ms | 23.4 ms  | 0.85 ms  |
+| nested `EXISTS`     | 0.87 ms | 88.8 ms  | 0.93 ms  |
+| nested `NOT EXISTS` | 0.86 ms | 127.7 ms | 0.93 ms  |
 
 EXISTS surface, 10,000-person graph (~55,000 quads):
 
 | query               | wazoo   | comunica | oxigraph |
 | ------------------- | ------- | -------- | -------- |
-| `FILTER EXISTS`     | 33.0 ms | 466.1 ms | 34.0 ms  |
-| `FILTER NOT EXISTS` | 33.2 ms | 466.2 ms | 32.9 ms  |
-| nested `EXISTS`     | 40.9 ms | 1.9 s    | 39.4 ms  |
-| nested `NOT EXISTS` | 43.0 ms | 1.8 s    | 40.6 ms  |
+| `FILTER EXISTS`     | 20.1 ms | 499.0 ms | 22.2 ms  |
+| `FILTER NOT EXISTS` | 19.3 ms | 484.7 ms | 21.4 ms  |
+| nested `EXISTS`     | 25.9 ms | 3.1 s    | 26.4 ms  |
+| nested `NOT EXISTS` | 26.8 ms | 2.2 s    | 31.5 ms  |
 
 Join surface, 10,000-person graph — UNION joins 10k × 20k bindings on the shared
 subject (~200M candidate pairs); OPTIONAL and MINUS join 10k × 5k (~50M pairs):
 
 | query               | wazoo   | comunica | oxigraph |
 | ------------------- | ------- | -------- | -------- |
-| UNION (10k × 20k)   | 37.9 ms | 87.1 ms  | 98.2 ms  |
-| OPTIONAL (10k × 5k) | 15.4 ms | 444.4 ms | 46.0 ms  |
-| MINUS (10k × 5k)    | 13.3 ms | 31.7 ms  | 17.1 ms  |
+| UNION (10k × 20k)   | 48.0 ms | 111.1 ms | 108.2 ms |
+| OPTIONAL (10k × 5k) | 20.8 ms | 576.7 ms | 55.0 ms  |
+| MINUS (10k × 5k)    | 16.9 ms | 47.3 ms  | 21.6 ms  |
 
 The same snapshot as a chart — one row per query class, three bars per row
 (wazoo green, Comunica orange, Oxigraph blue), bar length proportional to avg
@@ -132,6 +134,15 @@ ms/iter within the row:
   three-pattern chain (97.4 ms → 1.2 ms) — see
 
   [02 — System Architecture & Query Pipeline](02-architecture.md), Stage 3.
+- **The DP join-order search halves the greedy plan on the shared-variable
+  shape** (62.2 ms vs 125.2 ms, ~2×): two medium-selectivity patterns sharing
+  both variables plus a smaller unrelated pattern. Greedy joins the unrelated
+  pattern first (cheapest single join) and pays the 400 × 200 cross product
+  twice; the subset DP (issue #130) joins the shared pair first and pays it
+  once. The same query runs 190 ms on Comunica and 1.12 s on Oxigraph — the DP
+  plan also widens wazoo's cross-engine lead on joins. The "greedy plan" row
+  runs the identical baseline cost formula with the DP disabled, so the delta
+  isolates the ordering win.
 
 ## `deno task bench:check` — regression budget
 

--- a/docs/assets/chart-latency.svg
+++ b/docs/assets/chart-latency.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="780" height="588"
-  viewBox="0 0 780 588" font-family="ui-sans-serif, system-ui, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="780" height="648"
+  viewBox="0 0 780 648" font-family="ui-sans-serif, system-ui, sans-serif">
   <text x="12" y="18" font-size="14" font-weight="600"
     fill="#212529">Query latency by class</text>
   <rect x="12" y="30" width="10" height="10" rx="2" fill="#2f9e44" />
@@ -11,143 +11,157 @@
   <text x="12" y="62" font-size="11" font-weight="600"
     fill="#868e96">Core joins — 400-person graph</text>
   <text x="12" y="83" font-size="10" fill="#343a40">full scan</text>
-  <rect x="190" y="74" width="34.732999041147615" height="7" rx="1.5"
+  <rect x="190" y="74" width="53.89062143904138" height="7" rx="1.5"
     fill="#2f9e44" />
-  <text x="640" y="80" font-size="9" fill="#495057">0.96 ms</text>
-  <rect x="190" y="83" width="199.3796227531273" height="7" rx="1.5"
+  <text x="640" y="80" font-size="9" fill="#495057">1.1 ms</text>
+  <rect x="190" y="83" width="301.5186228123572" height="7" rx="1.5"
     fill="#f08c00" />
-  <text x="640" y="89" font-size="9" fill="#495057">5.5 ms</text>
+  <text x="640" y="89" font-size="9" fill="#495057">6.0 ms</text>
   <rect x="190" y="92" width="440" height="7" rx="1.5" fill="#1971c2" />
-  <text x="640" y="98" font-size="9" fill="#495057">12.2 ms</text>
+  <text x="640" y="98" font-size="9" fill="#495057">8.8 ms</text>
   <text x="12" y="113" font-size="10" fill="#343a40">join (knows × name)</text>
-  <rect x="190" y="104" width="84.49384330136337" height="7" rx="1.5"
+  <rect x="190" y="104" width="118.44875684423833" height="7" rx="1.5"
     fill="#2f9e44" />
-  <text x="640" y="110" font-size="9" fill="#495057">0.66 ms</text>
-  <rect x="190" y="113" width="395.1837011058611" height="7" rx="1.5"
-    fill="#f08c00" />
-  <text x="640" y="119" font-size="9" fill="#495057">3.1 ms</text>
-  <rect x="190" y="122" width="440" height="7" rx="1.5" fill="#1971c2" />
-  <text x="640" y="128" font-size="9" fill="#495057">3.4 ms</text>
+  <text x="640" y="110" font-size="9" fill="#495057">0.91 ms</text>
+  <rect x="190" y="113" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="119" font-size="9" fill="#495057">3.4 ms</text>
+  <rect x="190" y="122" width="209.01622824132966" height="7" rx="1.5"
+    fill="#1971c2" />
+  <text x="640" y="128" font-size="9" fill="#495057">1.6 ms</text>
   <text x="12" y="143" font-size="10" fill="#343a40">asymmetric join</text>
-  <rect x="190" y="134" width="27.056018074174524" height="7" rx="1.5"
+  <rect x="190" y="134" width="32.848490474939716" height="7" rx="1.5"
     fill="#2f9e44" />
-  <text x="640" y="140" font-size="9" fill="#495057">1.2 ms</text>
-  <rect x="190" y="143" width="438.6409920945212" height="7" rx="1.5"
-    fill="#f08c00" />
-  <text x="640" y="149" font-size="9" fill="#495057">19.2 ms</text>
-  <rect x="190" y="152" width="440" height="7" rx="1.5" fill="#1971c2" />
-  <text x="640" y="158" font-size="9" fill="#495057">19.3 ms</text>
+  <text x="640" y="140" font-size="9" fill="#495057">1.7 ms</text>
+  <rect x="190" y="143" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="149" font-size="9" fill="#495057">23.0 ms</text>
+  <rect x="190" y="152" width="220.20067664400736" height="7" rx="1.5"
+    fill="#1971c2" />
+  <text x="640" y="158" font-size="9" fill="#495057">11.5 ms</text>
   <text x="12" y="173" font-size="10"
     fill="#343a40">3-pattern chain, written order</text>
-  <rect x="190" y="164" width="440" height="7" rx="1.5" fill="#2f9e44" />
-  <text x="640" y="170" font-size="9" fill="#495057">97.4 ms</text>
-  <rect x="190" y="173" width="437.42169432902773" height="7" rx="1.5"
-    fill="#f08c00" />
-  <text x="640" y="179" font-size="9" fill="#495057">96.8 ms</text>
-  <rect x="190" y="182" width="19.009630650484816" height="7" rx="1.5"
+  <rect x="190" y="164" width="430.65162611286945" height="7" rx="1.5"
+    fill="#2f9e44" />
+  <text x="640" y="170" font-size="9" fill="#495057">105.5 ms</text>
+  <rect x="190" y="173" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="179" font-size="9" fill="#495057">107.8 ms</text>
+  <rect x="190" y="182" width="8.817805695598928" height="7" rx="1.5"
     fill="#1971c2" />
-  <text x="640" y="188" font-size="9" fill="#495057">4.2 ms</text>
+  <text x="640" y="188" font-size="9" fill="#495057">2.2 ms</text>
   <text x="12" y="203" font-size="10"
     fill="#343a40">3-pattern chain, planner on</text>
   <rect x="190" y="194" width="440" height="7" rx="1.5" fill="#2f9e44" />
-  <text x="640" y="200" font-size="9" fill="#495057">1.2 ms</text>
-  <text x="12" y="233" font-size="10" fill="#343a40">ASK</text>
-  <rect x="190" y="224" width="4.314649341734293" height="7" rx="1.5"
+  <text x="640" y="200" font-size="9" fill="#495057">1.5 ms</text>
+  <text x="12" y="233" font-size="10"
+    fill="#343a40">shared-variable pair, DP plan</text>
+  <rect x="190" y="224" width="24.438278159656146" height="7" rx="1.5"
     fill="#2f9e44" />
-  <text x="640" y="230" font-size="9" fill="#495057">3 µs</text>
-  <rect x="190" y="233" width="440" height="7" rx="1.5" fill="#f08c00" />
-  <text x="640" y="239" font-size="9" fill="#495057">0.29 ms</text>
-  <rect x="190" y="242" width="74.65275441908356" height="7" rx="1.5"
-    fill="#1971c2" />
-  <text x="640" y="248" font-size="9" fill="#495057">49 µs</text>
-  <text x="12" y="263" font-size="10" fill="#343a40">CONSTRUCT</text>
-  <rect x="190" y="254" width="42.0568018434995" height="7" rx="1.5"
-    fill="#2f9e44" />
-  <text x="640" y="260" font-size="9" fill="#495057">0.21 ms</text>
-  <rect x="190" y="263" width="440" height="7" rx="1.5" fill="#f08c00" />
-  <text x="640" y="269" font-size="9" fill="#495057">2.2 ms</text>
-  <rect x="190" y="272" width="267.99027041931737" height="7" rx="1.5"
-    fill="#1971c2" />
-  <text x="640" y="278" font-size="9" fill="#495057">1.4 ms</text>
-  <text x="12" y="293" font-size="10"
-    fill="#343a40">UPDATE (self-restoring)</text>
-  <rect x="190" y="284" width="429.3251445117704" height="7" rx="1.5"
-    fill="#2f9e44" />
-  <text x="640" y="290" font-size="9" fill="#495057">120.5 ms</text>
-  <rect x="190" y="293" width="440" height="7" rx="1.5" fill="#f08c00" />
-  <text x="640" y="299" font-size="9" fill="#495057">123.5 ms</text>
-  <rect x="190" y="302" width="1.6410969574707732" height="7" rx="1.5"
-    fill="#1971c2" />
-  <text x="640" y="308" font-size="9" fill="#495057">0.46 ms</text>
-  <text x="12" y="322" font-size="11" font-weight="600"
-    fill="#868e96">EXISTS surface — 10k-person graph</text>
-  <text x="12" y="343" font-size="10" fill="#343a40">FILTER EXISTS</text>
-  <rect x="190" y="334" width="31.17318937550949" height="7" rx="1.5"
-    fill="#2f9e44" />
-  <text x="640" y="340" font-size="9" fill="#495057">33.0 ms</text>
-  <rect x="190" y="343" width="440" height="7" rx="1.5" fill="#f08c00" />
-  <text x="640" y="349" font-size="9" fill="#495057">466.1 ms</text>
-  <rect x="190" y="352" width="32.09097742686481" height="7" rx="1.5"
-    fill="#1971c2" />
-  <text x="640" y="358" font-size="9" fill="#495057">34.0 ms</text>
-  <text x="12" y="373" font-size="10" fill="#343a40">FILTER NOT EXISTS</text>
-  <rect x="190" y="364" width="31.319768997619615" height="7" rx="1.5"
-    fill="#2f9e44" />
-  <text x="640" y="370" font-size="9" fill="#495057">33.2 ms</text>
-  <rect x="190" y="373" width="440" height="7" rx="1.5" fill="#f08c00" />
-  <text x="640" y="379" font-size="9" fill="#495057">466.2 ms</text>
-  <rect x="190" y="382" width="31.032220635511255" height="7" rx="1.5"
-    fill="#1971c2" />
-  <text x="640" y="388" font-size="9" fill="#495057">32.9 ms</text>
-  <text x="12" y="403" font-size="10" fill="#343a40">nested EXISTS</text>
-  <rect x="190" y="394" width="9.588401505752797" height="7" rx="1.5"
-    fill="#2f9e44" />
-  <text x="640" y="400" font-size="9" fill="#495057">40.9 ms</text>
-  <rect x="190" y="403" width="440" height="7" rx="1.5" fill="#f08c00" />
-  <text x="640" y="409" font-size="9" fill="#495057">1.9 s</text>
-  <rect x="190" y="412" width="9.232172396850427" height="7" rx="1.5"
-    fill="#1971c2" />
-  <text x="640" y="418" font-size="9" fill="#495057">39.4 ms</text>
-  <text x="12" y="433" font-size="10" fill="#343a40">nested NOT EXISTS</text>
-  <rect x="190" y="424" width="10.313548931359266" height="7" rx="1.5"
-    fill="#2f9e44" />
-  <text x="640" y="430" font-size="9" fill="#495057">43.0 ms</text>
-  <rect x="190" y="433" width="440" height="7" rx="1.5" fill="#f08c00" />
-  <text x="640" y="439" font-size="9" fill="#495057">1.8 s</text>
-  <rect x="190" y="442" width="9.718617926629296" height="7" rx="1.5"
-    fill="#1971c2" />
-  <text x="640" y="448" font-size="9" fill="#495057">40.6 ms</text>
-  <text x="12" y="462" font-size="11" font-weight="600"
-    fill="#868e96">Join surface — 10k-person graph</text>
-  <text x="12" y="483" font-size="10" fill="#343a40">UNION (10k × 20k)</text>
-  <rect x="190" y="474" width="169.91213810701166" height="7" rx="1.5"
-    fill="#2f9e44" />
-  <text x="640" y="480" font-size="9" fill="#495057">37.9 ms</text>
-  <rect x="190" y="483" width="390.2903062283609" height="7" rx="1.5"
+  <text x="640" y="230" font-size="9" fill="#495057">62.2 ms</text>
+  <rect x="190" y="233" width="74.81866978024851" height="7" rx="1.5"
     fill="#f08c00" />
-  <text x="640" y="489" font-size="9" fill="#495057">87.1 ms</text>
-  <rect x="190" y="492" width="440" height="7" rx="1.5" fill="#1971c2" />
-  <text x="640" y="498" font-size="9" fill="#495057">98.2 ms</text>
-  <text x="12" y="513" font-size="10" fill="#343a40">OPTIONAL (10k × 5k)</text>
-  <rect x="190" y="504" width="15.249759403270698" height="7" rx="1.5"
+  <text x="640" y="239" font-size="9" fill="#495057">190.4 ms</text>
+  <rect x="190" y="242" width="440" height="7" rx="1.5" fill="#1971c2" />
+  <text x="640" y="248" font-size="9" fill="#495057">1.1 s</text>
+  <text x="12" y="263" font-size="10"
+    fill="#343a40">shared-variable pair, greedy plan</text>
+  <rect x="190" y="254" width="440" height="7" rx="1.5" fill="#2f9e44" />
+  <text x="640" y="260" font-size="9" fill="#495057">125.2 ms</text>
+  <text x="12" y="293" font-size="10" fill="#343a40">ASK</text>
+  <rect x="190" y="284" width="5.076274594875335" height="7" rx="1.5"
     fill="#2f9e44" />
-  <text x="640" y="510" font-size="9" fill="#495057">15.4 ms</text>
-  <rect x="190" y="513" width="440" height="7" rx="1.5" fill="#f08c00" />
-  <text x="640" y="519" font-size="9" fill="#495057">444.4 ms</text>
-  <rect x="190" y="522" width="45.55257326740123" height="7" rx="1.5"
+  <text x="640" y="290" font-size="9" fill="#495057">4 µs</text>
+  <rect x="190" y="293" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="299" font-size="9" fill="#495057">0.32 ms</text>
+  <rect x="190" y="302" width="43.23821045264388" height="7" rx="1.5"
     fill="#1971c2" />
-  <text x="640" y="528" font-size="9" fill="#495057">46.0 ms</text>
-  <text x="12" y="543" font-size="10" fill="#343a40">MINUS (10k × 5k)</text>
-  <rect x="190" y="534" width="184.07631397601318" height="7" rx="1.5"
+  <text x="640" y="308" font-size="9" fill="#495057">31 µs</text>
+  <text x="12" y="323" font-size="10" fill="#343a40">CONSTRUCT</text>
+  <rect x="190" y="314" width="40.775464448609" height="7" rx="1.5"
     fill="#2f9e44" />
-  <text x="640" y="540" font-size="9" fill="#495057">13.3 ms</text>
+  <text x="640" y="320" font-size="9" fill="#495057">0.26 ms</text>
+  <rect x="190" y="323" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="329" font-size="9" fill="#495057">2.8 ms</text>
+  <rect x="190" y="332" width="98.062679525468" height="7" rx="1.5"
+    fill="#1971c2" />
+  <text x="640" y="338" font-size="9" fill="#495057">0.63 ms</text>
+  <text x="12" y="353" font-size="10"
+    fill="#343a40">UPDATE (self-restoring)</text>
+  <rect x="190" y="344" width="440" height="7" rx="1.5" fill="#2f9e44" />
+  <text x="640" y="350" font-size="9" fill="#495057">149.0 ms</text>
+  <rect x="190" y="353" width="423.6757810078182" height="7" rx="1.5"
+    fill="#f08c00" />
+  <text x="640" y="359" font-size="9" fill="#495057">143.4 ms</text>
+  <rect x="190" y="362" width="1.728978606312966" height="7" rx="1.5"
+    fill="#1971c2" />
+  <text x="640" y="368" font-size="9" fill="#495057">0.59 ms</text>
+  <text x="12" y="382" font-size="11" font-weight="600"
+    fill="#868e96">EXISTS surface — 10k-person graph</text>
+  <text x="12" y="403" font-size="10" fill="#343a40">FILTER EXISTS</text>
+  <rect x="190" y="394" width="17.729817928549647" height="7" rx="1.5"
+    fill="#2f9e44" />
+  <text x="640" y="400" font-size="9" fill="#495057">20.1 ms</text>
+  <rect x="190" y="403" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="409" font-size="9" fill="#495057">499.0 ms</text>
+  <rect x="190" y="412" width="19.5384732023963" height="7" rx="1.5"
+    fill="#1971c2" />
+  <text x="640" y="418" font-size="9" fill="#495057">22.2 ms</text>
+  <text x="12" y="433" font-size="10" fill="#343a40">FILTER NOT EXISTS</text>
+  <rect x="190" y="424" width="17.545946811324328" height="7" rx="1.5"
+    fill="#2f9e44" />
+  <text x="640" y="430" font-size="9" fill="#495057">19.3 ms</text>
+  <rect x="190" y="433" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="439" font-size="9" fill="#495057">484.7 ms</text>
+  <rect x="190" y="442" width="19.451624448487166" height="7" rx="1.5"
+    fill="#1971c2" />
+  <text x="640" y="448" font-size="9" fill="#495057">21.4 ms</text>
+  <text x="12" y="463" font-size="10" fill="#343a40">nested EXISTS</text>
+  <rect x="190" y="454" width="3.734657637445656" height="7" rx="1.5"
+    fill="#2f9e44" />
+  <text x="640" y="460" font-size="9" fill="#495057">25.9 ms</text>
+  <rect x="190" y="463" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="469" font-size="9" fill="#495057">3.1 s</text>
+  <rect x="190" y="472" width="3.801905589996579" height="7" rx="1.5"
+    fill="#1971c2" />
+  <text x="640" y="478" font-size="9" fill="#495057">26.4 ms</text>
+  <text x="12" y="493" font-size="10" fill="#343a40">nested NOT EXISTS</text>
+  <rect x="190" y="484" width="5.321450827713012" height="7" rx="1.5"
+    fill="#2f9e44" />
+  <text x="640" y="490" font-size="9" fill="#495057">26.8 ms</text>
+  <rect x="190" y="493" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="499" font-size="9" fill="#495057">2.2 s</text>
+  <rect x="190" y="502" width="6.258304379665723" height="7" rx="1.5"
+    fill="#1971c2" />
+  <text x="640" y="508" font-size="9" fill="#495057">31.5 ms</text>
+  <text x="12" y="522" font-size="11" font-weight="600"
+    fill="#868e96">Join surface — 10k-person graph</text>
+  <text x="12" y="543" font-size="10" fill="#343a40">UNION (10k × 20k)</text>
+  <rect x="190" y="534" width="189.91491210480703" height="7" rx="1.5"
+    fill="#2f9e44" />
+  <text x="640" y="540" font-size="9" fill="#495057">48.0 ms</text>
   <rect x="190" y="543" width="440" height="7" rx="1.5" fill="#f08c00" />
-  <text x="640" y="549" font-size="9" fill="#495057">31.7 ms</text>
-  <rect x="190" y="552" width="237.83398391543747" height="7" rx="1.5"
+  <text x="640" y="549" font-size="9" fill="#495057">111.1 ms</text>
+  <rect x="190" y="552" width="428.3971851465033" height="7" rx="1.5"
     fill="#1971c2" />
-  <text x="640" y="558" font-size="9" fill="#495057">17.1 ms</text>
-  <text x="12" y="580" font-size="9"
+  <text x="640" y="558" font-size="9" fill="#495057">108.2 ms</text>
+  <text x="12" y="573" font-size="10" fill="#343a40">OPTIONAL (10k × 5k)</text>
+  <rect x="190" y="564" width="15.854316902731496" height="7" rx="1.5"
+    fill="#2f9e44" />
+  <text x="640" y="570" font-size="9" fill="#495057">20.8 ms</text>
+  <rect x="190" y="573" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="579" font-size="9" fill="#495057">576.7 ms</text>
+  <rect x="190" y="582" width="41.93047266950318" height="7" rx="1.5"
+    fill="#1971c2" />
+  <text x="640" y="588" font-size="9" fill="#495057">55.0 ms</text>
+  <text x="12" y="603" font-size="10" fill="#343a40">MINUS (10k × 5k)</text>
+  <rect x="190" y="594" width="157.01512642480435" height="7" rx="1.5"
+    fill="#2f9e44" />
+  <text x="640" y="600" font-size="9" fill="#495057">16.9 ms</text>
+  <rect x="190" y="603" width="440" height="7" rx="1.5" fill="#f08c00" />
+  <text x="640" y="609" font-size="9" fill="#495057">47.3 ms</text>
+  <rect x="190" y="612" width="201.00776421986" height="7" rx="1.5"
+    fill="#1971c2" />
+  <text x="640" y="618" font-size="9" fill="#495057">21.6 ms</text>
+  <text x="12" y="640" font-size="9"
     fill="#868e96">Average ms per iteration, lower is better — each row normalized to its slowest engine; bars are not to scale across rows.</text>
-  <text x="12" y="570" font-size="9"
+  <text x="12" y="630" font-size="9"
     fill="#adb5bd">Snapshot: Deno/2.9.5 x86_64-pc-windows-msvc — regenerate with `deno task bench:latency`.</text>
 </svg>

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -47,6 +47,11 @@ import {
 } from "@/planner/join-cost-estimator.ts";
 import { PatternStatistics } from "@/planner/pattern-statistics.ts";
 import {
+  boundVariables,
+  DP_MAX_PATTERNS,
+  searchBestJoinOrder,
+} from "@/planner/join-order-search.ts";
+import {
   expandReifiedTriples,
   isReifiesPattern,
   RDF_REIFIES,
@@ -93,12 +98,14 @@ export interface BgpEvaluatorOptions {
   functions?: IriFunctionMap;
 
   /**
-   * estimator supplies the join-cost estimator the greedy reorderer uses
-   * to pick the next pattern to join (see JoinCostEstimator for the
-   * contract). Defaults to BaselineJoinCostEstimator, which also consumes
-   * the per-pattern statistics from PatternStatistics (issue #129). The
-   * estimate affects only join order — never results (SPARQL 1.1 §18.2.2).
-   * Planner piece 3 (#130) plugs the join-order search behind this seam.
+   * estimator supplies the join-cost estimator the reorderer uses to pick
+   * the next pattern to join (see JoinCostEstimator for the contract).
+   * Defaults to BaselineJoinCostEstimator, whose costs match the DP
+   * join-order search (issue #130): small BGPs get the globally optimal
+   * order, larger ones the greedy stepwise choice. An injected custom
+   * estimator keeps the greedy loop, which consults it per step with the
+   * real bindings. The estimate affects only join order — never results
+   * (SPARQL 1.1 §18.2.2).
    */
   estimator?: JoinCostEstimator;
 }
@@ -1146,7 +1153,7 @@ export class BgpEvaluator {
       triplePatterns.map((pattern) => scanEntry(store, pattern)),
     );
     // Resolve each pattern's statistics once for this BGP (cached by the
-    // per-query source by pattern signature), never inside the greedy loop.
+    // per-query source by pattern signature), never inside the join loop.
     const perEntryStats = await Promise.all(
       remaining.map((entry) => stats.statsFor(store, entry)),
     );
@@ -1154,6 +1161,30 @@ export class BgpEvaluator {
     let result: TermBinding[] = Array.isArray(bindings)
       ? bindings
       : [...bindings];
+    // The default estimator's costs are exactly the join-order search's
+    // estimated model (planner piece 3, issue #130), so for small BGPs a
+    // subset DP replaces the greedy stepwise choice with the globally
+    // optimal order under that model. An injected custom estimator keeps
+    // the greedy loop, which consults it per step with the real bindings.
+    if (
+      this.estimator instanceof BaselineJoinCostEstimator &&
+      remaining.length <= DP_MAX_PATTERNS
+    ) {
+      const order = searchBestJoinOrder(
+        remaining,
+        perEntryStats,
+        {
+          card: result.length,
+          bound: boundVariables(result),
+        },
+      );
+      if (order !== null) {
+        for (const index of order) {
+          result = joinTriplePattern(result, remaining[index], prebuiltIndex);
+        }
+        return result;
+      }
+    }
     while (remaining.length > 0) {
       let bestIndex = 0;
       let bestCost = Number.POSITIVE_INFINITY;

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -63,9 +63,9 @@ export interface SparqlEvaluatorOptions {
 
   /**
    * estimator supplies the BGP join-cost estimator (see
-   * JoinCostEstimator); defaults to the baseline greedy formula (which
-   * also consumes the per-pattern statistics source, issue #129). Only
-   * affects join order, never results.
+   * JoinCostEstimator); defaults to the baseline formula, whose costs
+   * match the DP join-order search (issue #130). Only affects join
+   * order, never results.
    */
   estimator?: JoinCostEstimator;
 }

--- a/src/evaluator/update-evaluator.ts
+++ b/src/evaluator/update-evaluator.ts
@@ -61,9 +61,9 @@ export interface UpdateEvaluatorOptions {
 
   /**
    * estimator supplies the BGP join-cost estimator (see
-   * JoinCostEstimator); defaults to the baseline greedy formula (which
-   * also consumes the per-pattern statistics source, issue #129). Only
-   * affects join order, never results.
+   * JoinCostEstimator); defaults to the baseline formula, whose costs
+   * match the DP join-order search (issue #130). Only affects join
+   * order, never results.
    */
   estimator?: JoinCostEstimator;
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -28,6 +28,11 @@ export type {
   PatternStats,
   StoreStatisticsHook,
 } from "@/planner/pattern-statistics.ts";
+export {
+  DP_MAX_PATTERNS,
+  searchBestJoinOrder,
+} from "@/planner/join-order-search.ts";
+export type { EstimatedJoinState } from "@/planner/join-order-search.ts";
 
 export { MemoryStore, MemoryStream } from "@/store/memory-store.ts";
 export { DataFactory, dataFactory } from "@/term/mod.ts";

--- a/src/planner/join-cost-estimator.ts
+++ b/src/planner/join-cost-estimator.ts
@@ -19,7 +19,9 @@ import { termKey } from "@/term/mod.ts";
  * when a variable's distinct count is unknown). It may assume nothing else:
  * no store access. The estimator must be pure and deterministic: the same
  * entry, bindings, and stats always produce the same cost, and calling it
- * must have no side effects.
+ * must have no side effects. The default baseline's costs are exactly the
+ * model the DP join-order search (planner piece 3, issue #130) optimizes
+ * over for small BGPs, so the two stay in agreement.
  */
 export interface JoinCostEstimator {
   /**

--- a/src/planner/join-order-search.test.ts
+++ b/src/planner/join-order-search.test.ts
@@ -1,0 +1,256 @@
+import { assertEquals } from "@std/assert";
+import { DataFactory } from "@/term/mod.ts";
+import type { ScanEntry } from "@/evaluator/join.ts";
+import { MemoryStore as Store } from "@/store/memory-store.ts";
+import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
+import {
+  boundVariables,
+  DP_MAX_PATTERNS,
+  estimatedJoinCost,
+  searchBestJoinOrder,
+} from "@/planner/join-order-search.ts";
+import type { EstimatedJoinState } from "@/planner/join-order-search.ts";
+import type { PatternStats } from "@/planner/pattern-statistics.ts";
+import type { Term as SparqlTerm } from "@/parser/sparql-parser.ts";
+
+const { namedNode, literal, quad, variable } = DataFactory;
+
+const knows = namedNode("http://example.org/knows");
+const name = namedNode("http://example.org/name");
+const spouse = namedNode("http://example.org/spouse");
+
+/** entry builds a ScanEntry for the given pattern positions (no candidates). */
+function entry(
+  subject: SparqlTerm,
+  predicate: SparqlTerm,
+  object: SparqlTerm,
+): ScanEntry {
+  return { subject, predicate, object, candidates: [] };
+}
+
+const s = variable("s");
+const o = variable("o");
+const n = variable("n");
+const z = variable("z");
+const w = variable("w");
+
+/** dense stats: every pattern variable distinct, buckets of ~1. */
+function dense(candidates: number, ...vars: string[]): PatternStats {
+  const distinctByVar: Partial<Record<string, number>> = {};
+  for (const v of vars) {
+    distinctByVar[v] = candidates;
+  }
+  return { candidates, distinctByVar };
+}
+
+const EMPTY: EstimatedJoinState = { card: 1, bound: new Set() };
+
+/** planCost computes the estimated total work of an order under the model. */
+function planCost(
+  entries: ScanEntry[],
+  stats: PatternStats[],
+  order: number[],
+  initial: EstimatedJoinState = EMPTY,
+): number {
+  let card = initial.card;
+  const bound = new Set(initial.bound);
+  let total = 0;
+  for (const index of order) {
+    const cost = estimatedJoinCost(entries[index], stats[index], {
+      card,
+      bound,
+    });
+    total += cost;
+    card = cost;
+    for (
+      const term of [
+        entries[index].subject,
+        entries[index].predicate,
+        entries[index].object,
+      ]
+    ) {
+      if (term.termType === "Variable") {
+        bound.add(term.value);
+      }
+    }
+  }
+  return total;
+}
+
+Deno.test(
+  "searchBestJoinOrder - DP beats greedy on the two-shared-variable shape",
+  () => {
+    // ?s knows ?o and ?s name ?o share both variables; ?z spouse ?w shares
+    // none and is smaller. Greedy (cheapest-first) joins spouse first, then
+    // pays the full cross product twice; the DP joins the shared pair first
+    // and pays the cross product once.
+    const entries = [
+      entry(s, knows, o),
+      entry(s, name, n),
+      entry(z, spouse, w),
+    ];
+    const stats = [
+      dense(10_000, "s", "o"),
+      dense(10_000, "s", "n"),
+      dense(5_000, "z", "w"),
+    ];
+    const order = searchBestJoinOrder(entries, stats, EMPTY)!;
+    assertEquals(order, [0, 1, 2]);
+    // Greedy picks the cheapest first: spouse (5k) before either 10k
+    // pattern, yielding the [2, 0, 1] order and double the work.
+    const greedyOrder = [2, 0, 1];
+    assertEquals(
+      planCost(entries, stats, order),
+      10_000 + 10_000 + 10_000 * 5_000,
+    );
+    assertEquals(
+      planCost(entries, stats, greedyOrder),
+      5_000 + 5_000 * 10_000 + 50_000_000,
+    );
+    assertEquals(
+      planCost(entries, stats, order) < planCost(entries, stats, greedyOrder),
+      true,
+    );
+  },
+);
+
+Deno.test("searchBestJoinOrder - returns null above the DP threshold", () => {
+  const entries: ScanEntry[] = [];
+  const stats: PatternStats[] = [];
+  for (let index = 0; index < DP_MAX_PATTERNS + 1; index++) {
+    entries.push(entry(s, name, o));
+    stats.push(dense(10, "s", "o"));
+  }
+  assertEquals(searchBestJoinOrder(entries, stats, EMPTY), null);
+});
+
+Deno.test("searchBestJoinOrder - empty BGP yields an empty order", () => {
+  assertEquals(searchBestJoinOrder([], [], EMPTY), []);
+});
+
+Deno.test(
+  "searchBestJoinOrder - a pre-bound variable steers the plan to its pattern",
+  () => {
+    // ?s is already bound (card 1): joining the knows pattern probes its
+    // index (cost 1) instead of scanning all 10,000 candidates, so the
+    // bound pattern goes first even though the other pattern is smaller.
+    const entries = [entry(s, knows, o), entry(z, spouse, w)];
+    const stats = [dense(10_000, "s", "o"), dense(5_000, "z", "w")];
+    const bound = new Set(["s"]);
+    const order = searchBestJoinOrder(entries, stats, { card: 1, bound })!;
+    assertEquals(order, [0, 1]);
+    assertEquals(
+      planCost(entries, stats, order, { card: 1, bound }),
+      1 + 5_000,
+    );
+  },
+);
+
+Deno.test("estimatedJoinCost - unbound pattern variable scans all candidates", () => {
+  assertEquals(
+    estimatedJoinCost(entry(s, knows, o), dense(100, "s", "o"), {
+      card: 7,
+      bound: new Set(["z"]),
+    }),
+    700,
+  );
+});
+
+Deno.test("estimatedJoinCost - bound variable costs card times the bucket", () => {
+  assertEquals(
+    estimatedJoinCost(entry(s, knows, o), dense(100, "s", "o"), {
+      card: 7,
+      bound: new Set(["s"]),
+    }),
+    7,
+  );
+});
+
+Deno.test("estimatedJoinCost - a variable without stats is never assumed", () => {
+  // The stats carry no distinct count for ?s: the variable contributes
+  // nothing, so the join falls back to scanning all candidates.
+  const stats: PatternStats = { candidates: 100, distinctByVar: { o: 100 } };
+  assertEquals(
+    estimatedJoinCost(entry(s, knows, o), stats, {
+      card: 7,
+      bound: new Set(["s"]),
+    }),
+    700,
+  );
+});
+
+Deno.test("estimatedJoinCost - zero-cardinality state costs zero", () => {
+  assertEquals(
+    estimatedJoinCost(entry(s, knows, o), dense(100, "s", "o"), {
+      card: 0,
+      bound: new Set(["s"]),
+    }),
+    0,
+  );
+});
+
+Deno.test("boundVariables - collects the union of bound keys", () => {
+  const bound = boundVariables([
+    {
+      s: namedNode("http://example.org/a"),
+      o: namedNode("http://example.org/b"),
+    },
+    { z: namedNode("http://example.org/c") },
+  ]);
+  assertEquals([...bound].sort(), ["o", "s", "z"]);
+});
+
+Deno.test(
+  "WazooSparqlEngine - the DP order never changes the result multiset",
+  async () => {
+    // A small two-shared-variable shape: 50 people (knows + name each), 25
+    // spouse edges. The DP joins the shared pair first; the result must be
+    // the same multiset as the written-order (reorder off) evaluation.
+    const store = new Store();
+    for (let index = 0; index < 50; index++) {
+      const person = namedNode(`http://example.org/p${index}`);
+      store.addQuad(
+        quad(
+          person,
+          knows,
+          namedNode(`http://example.org/p${(index + 1) % 50}`),
+        ),
+      );
+      store.addQuad(quad(person, name, literal(`Name ${index}`)));
+    }
+    for (let index = 0; index < 25; index++) {
+      store.addQuad(
+        quad(
+          namedNode(`http://example.org/z${index}`),
+          spouse,
+          namedNode(`http://example.org/w${index}`),
+        ),
+      );
+    }
+    const query = "SELECT * WHERE { ?s <http://example.org/knows> ?o . " +
+      "?s <http://example.org/name> ?n . ?z <http://example.org/spouse> ?w }";
+
+    const dpEngine = new WazooSparqlEngine({ store });
+    const writtenEngine = new WazooSparqlEngine({
+      store,
+      reorderPatterns: false,
+    });
+    const dpResult = await dpEngine.execute({ query });
+    const writtenResult = await writtenEngine.execute({ query });
+    if (dpResult.kind !== "select" || writtenResult.kind !== "select") {
+      throw new Error("expected select results");
+    }
+    const key = (b: Record<string, unknown>): string =>
+      JSON.stringify(
+        Object.fromEntries(
+          Object.entries(b)
+            .map(([k, v]) => [k, JSON.stringify(v)])
+            .sort(),
+        ),
+      );
+    const dpBindings = dpResult.data.results.bindings.map(key).sort();
+    const writtenBindings = writtenResult.data.results.bindings.map(key).sort();
+    assertEquals(dpBindings, writtenBindings);
+    assertEquals(dpBindings.length, 50 * 25);
+  },
+);

--- a/src/planner/join-order-search.ts
+++ b/src/planner/join-order-search.ts
@@ -1,0 +1,178 @@
+import type { ScanEntry, TermBinding } from "@/evaluator/join.ts";
+import type { PatternStats } from "@/planner/pattern-statistics.ts";
+
+/**
+ * DP_MAX_PATTERNS is the largest BGP the DP join-order search explores.
+ * The subset DP costs 2^n states, each with up to n transitions, so 8
+ * patterns means at most 256 states and ~1,024 transitions of pure
+ * arithmetic — well under a millisecond, never a measurable fraction of the
+ * joins it plans. Real-world BGPs (and the entire W3C suite) stay at or
+ * below this; beyond it the greedy stepwise planner (planner pieces 1–2)
+ * takes over, where its per-step choice is within noise of optimal for the
+ * large shapes that hit the fallback.
+ */
+export const DP_MAX_PATTERNS = 8;
+
+/**
+ * EstimatedJoinState is the search's model of the solutions a partial plan
+ * has produced, without materializing them:
+ *
+ *   - card — the estimated number of solution bindings the partial plan
+ *     outputs (the next join's bindings count);
+ *   - bound — the variables bound in at least one output binding (the next
+ *     join's probeable pattern variables).
+ *
+ * The model is exact for the join semantics this engine uses: joining a
+ * pattern probes the positional index once per (binding, candidate) pair, so
+ * the estimated output cardinality equals the estimated join cost — no extra
+ * state beyond card and bound is needed to score the next join.
+ */
+export interface EstimatedJoinState {
+  card: number;
+  bound: ReadonlySet<string>;
+}
+
+/**
+ * boundVariables returns the variables bound in at least one binding — the
+ * initial bound set of a BGP reorder, mirroring the greedy estimator's
+ * "bound in the current bindings" check.
+ */
+export function boundVariables(bindings: TermBinding[]): Set<string> {
+  const bound = new Set<string>();
+  for (const binding of bindings) {
+    for (const key of Object.keys(binding)) {
+      bound.add(key);
+    }
+  }
+  return bound;
+}
+
+/**
+ * estimatedJoinCost scores joining one pattern after the given estimated
+ * state, using the same formula as BaselineJoinCostEstimator over the
+ * pattern's statistics: a bound pattern variable probes the index at
+ * candidates ÷ distinct values for that variable; with no bound pattern
+ * variable every binding iterates all candidates. A variable the statistics
+ * carry no distinct count for contributes nothing (the same degradation the
+ * estimator applies), so a plan never assumes selectivity the source did not
+ * provide.
+ */
+export function estimatedJoinCost(
+  entry: ScanEntry,
+  stats: PatternStats,
+  state: EstimatedJoinState,
+): number {
+  if (state.card === 0) {
+    return 0;
+  }
+  const candidates = stats.candidates;
+  let mostSelectiveDistinct = Number.POSITIVE_INFINITY;
+  for (const term of [entry.subject, entry.predicate, entry.object]) {
+    if (term.termType !== "Variable") {
+      continue;
+    }
+    if (!state.bound.has(term.value)) {
+      continue;
+    }
+    const distinct = stats.distinctByVar[term.value];
+    if (
+      distinct !== undefined && distinct > 0 &&
+      distinct < mostSelectiveDistinct
+    ) {
+      mostSelectiveDistinct = distinct;
+    }
+  }
+  if (mostSelectiveDistinct === Number.POSITIVE_INFINITY) {
+    return state.card * candidates;
+  }
+  return state.card * Math.max(1, candidates / mostSelectiveDistinct);
+}
+
+/**
+ * patternVariables returns the variables a pattern binds — the positions the
+ * join extends with — for the search's bound-set tracking. Blank-node
+ * positions act as query variables in the join but never as probeable
+ * pattern variables in the cost model, mirroring the estimator.
+ */
+function patternVariables(entry: ScanEntry): string[] {
+  const vars: string[] = [];
+  for (const term of [entry.subject, entry.predicate, entry.object]) {
+    if (term.termType === "Variable" && !vars.includes(term.value)) {
+      vars.push(term.value);
+    }
+  }
+  return vars;
+}
+
+/**
+ * searchBestJoinOrder returns the join order (indices into the entries
+ * array) minimizing the estimated total join work, or null when the BGP is
+ * too large for the DP (see DP_MAX_PATTERNS) — the caller then falls back to
+ * the greedy planner. The search is a subset DP over 2^n states: the state
+ * for a set S of joined patterns carries the cheapest plan's estimated cost
+ * (total work) and output state (card + bound), and the transition appends
+ * each remaining pattern at its estimated marginal cost. Ties keep the
+ * lowest-index pattern first, so the order is deterministic.
+ *
+ * The search is a plan search only — it never materializes bindings. The
+ * winning order is then executed by the normal eager join loop, so the DP
+ * changes only which order joins run in, never the result multiset
+ * (SPARQL 1.1 §18.2.2: joins commute).
+ */
+export function searchBestJoinOrder(
+  entries: ScanEntry[],
+  statsList: PatternStats[],
+  initialState: EstimatedJoinState,
+): number[] | null {
+  const n = entries.length;
+  if (n === 0) {
+    return [];
+  }
+  if (n > DP_MAX_PATTERNS) {
+    return null;
+  }
+  const varLists = entries.map(patternVariables);
+  const total = 1 << n;
+  // cost[mask] is the cheapest plan's estimated total work; card[mask] the
+  // same plan's estimated output cardinality; parent[mask] the last pattern
+  // index of that plan (for reconstruction); bound[mask] its bound set.
+  const cost = new Float64Array(total).fill(Number.POSITIVE_INFINITY);
+  const card = new Float64Array(total);
+  const parent = new Int8Array(total).fill(-1);
+  const bound: (Set<string> | null)[] = new Array(total).fill(null);
+  cost[0] = 0;
+  card[0] = initialState.card;
+  bound[0] = new Set(initialState.bound);
+  for (let mask = 0; mask < total; mask++) {
+    for (let index = 0; index < n; index++) {
+      const bit = 1 << index;
+      if (mask & bit) {
+        continue;
+      }
+      const marginal = estimatedJoinCost(entries[index], statsList[index], {
+        card: card[mask],
+        bound: bound[mask]!,
+      });
+      const next = mask | bit;
+      const candidate = cost[mask] + marginal;
+      if (candidate < cost[next]) {
+        cost[next] = candidate;
+        card[next] = marginal;
+        parent[next] = index;
+        const nextBound = new Set(bound[mask]!);
+        for (const variable of varLists[index]) {
+          nextBound.add(variable);
+        }
+        bound[next] = nextBound;
+      }
+    }
+  }
+  const order: number[] = [];
+  let mask = total - 1;
+  while (mask !== 0) {
+    const last = parent[mask];
+    order.push(last);
+    mask = mask & ~(1 << last);
+  }
+  return order.reverse();
+}

--- a/src/wazoo-sparql-engine.ts
+++ b/src/wazoo-sparql-engine.ts
@@ -69,10 +69,10 @@ export interface WazooSparqlEngineOptions {
 
   /**
    * estimator supplies the BGP join-cost estimator (see JoinCostEstimator);
-   * defaults to the baseline greedy formula (which also consumes the
-   * per-pattern statistics source, issue #129). The estimate affects only
-   * join order — never results (SPARQL 1.1 §18.2.2). Planner piece 3
-   * (#130) plugs the join-order search behind this seam.
+   * defaults to the baseline formula, whose costs match the DP join-order
+   * search (issue #130) — small BGPs get the globally optimal order, larger
+   * ones the greedy stepwise choice. An injected custom estimator keeps the
+   * greedy loop. Only affects join order, never results.
    */
   estimator?: JoinCostEstimator;
 }


### PR DESCRIPTION
Closes #130 — planner piece 3 of 3 (splits #75). Stacked on #134 (piece 2, statistics source); retargets to main automatically as the stack merges.

## What lands

**The DP join-order search** (`src/planner/join-order-search.ts`): for BGPs up to `DP_MAX_PATTERNS` (8), `searchBestJoinOrder` replaces the greedy stepwise choice with the globally optimal order under the estimator's cost model. The DP plans over **estimated state** — per subset it tracks only the cheapest plan's estimated output cardinality and bound-variable set, scoring each append with the exact baseline formula over the piece-2 statistics — never materializing bindings. The winning order executes through the normal eager join loop, so **only order changes, never results** (SPARQL §18.2.2). Greedy stays for larger BGPs and for injected custom estimators, whose costs the DP cannot assume (documented on the `estimator` option).

**Bench win** (`dp-join` group): two medium-selectivity patterns sharing both variables plus a smaller unrelated pattern. Greedy joins the unrelated pattern first (cheapest single join) and pays the 400×200 cross product twice; the DP joins the shared pair first and pays it once. Fresh snapshot: **wazoo DP 62.2 ms vs greedy surrogate 125.2 ms (~2×, identical cost formula)** — comunica 190.4 ms, oxigraph 1120 ms. Cross-verified identical 80,000-row results on all three engines.

**Planner overhead**: 8-pattern worst-case search 0.041 µs vs the ~62 ms join it plans (~1.5M× cheaper) — the search never dominates the join.

**Research note** (greedy vs DP on representative shapes: two-shared-variable, selective-first, wide-star, path-chain, path-mixed + the joined-vs-materialized story) recorded on #75.

## Verification
- `deno task ci` green (443 tests; 10 new: DP optimality, threshold fallback, initial-bound steering, cost model, engine-level result equivalence)
- `deno task test:w3c` 345/345 — no result change with the DP active
- `test:exists-ref`, `interface-parity`, `publish:dry` all green; `bench:check` budgets pass; `bench:latency:check` inventory matches; docs 0 broken
- `reorder-chain` row unchanged (1.5 ms) — DP matches greedy where greedy is already optimal