### PR TITLE
fix: harden the SqliteStore concurrent-writers recovery test against lock flakes

### DIFF
--- a/src/store/sqlite-store-recovery.test.ts
+++ b/src/store/sqlite-store-recovery.test.ts
@@ -19,16 +19,22 @@ import { SqliteStore } from "@/store/sqlite-store.ts";
 const REPO_ROOT = resolve(dirname(fromFileUrl(import.meta.url)), "../..");
 const CHILD_SCRIPT = join(REPO_ROOT, "test", "sqlite-recovery-child.ts");
 
-/** runChild spawns the recovery child and resolves with its exit code. */
-async function runChild(...args: string[]): Promise<number> {
+/**
+ * runChild spawns the recovery child and resolves with its exit code and
+ * stderr (stderr is attached to assertion messages so a child failure is
+ * diagnosable — the child prints the underlying SQLite error).
+ */
+async function runChild(
+  ...args: string[]
+): Promise<{ code: number; stderr: string }> {
   const command = new Deno.Command(Deno.execPath(), {
     args: ["run", "--allow-all", CHILD_SCRIPT, ...args],
     cwd: REPO_ROOT,
     stdout: "piped",
     stderr: "piped",
   });
-  const { code } = await command.output();
-  return code;
+  const { code, stderr } = await command.output();
+  return { code, stderr: new TextDecoder().decode(stderr) };
 }
 
 /** tempDbPath returns a fresh temp db path for one scenario. */
@@ -50,8 +56,8 @@ function collectQuads(path: string): unknown[] {
 Deno.test("SqliteStore recovery - committed update survives a hard process exit", async () => {
   const path = tempDbPath();
   // The child commits then dies without close().
-  const code = await runChild("commit-exit", path);
-  assertEquals(code, 0);
+  const { code, stderr } = await runChild("commit-exit", path);
+  assertEquals(code, 0, stderr);
   const quads = collectQuads(path);
   assertEquals(quads.length, 1);
   assertEquals(
@@ -63,28 +69,28 @@ Deno.test("SqliteStore recovery - committed update survives a hard process exit"
 Deno.test("SqliteStore recovery - uncommitted buffered writes roll back", async () => {
   const path = tempDbPath();
   // The child buffers writes in a transaction and exits before commit.
-  const code = await runChild("buffered-exit", path);
-  assertEquals(code, 1);
+  const { code, stderr } = await runChild("buffered-exit", path);
+  assertEquals(code, 1, stderr);
   assertEquals(collectQuads(path).length, 0);
 });
 
 Deno.test("SqliteStore recovery - kill mid-BEGIN IMMEDIATE rolls back on reopen", async () => {
   const path = tempDbPath();
   // The child writes raw WAL frames inside an uncommitted transaction.
-  const code = await runChild("raw-mid-transaction", path);
-  assertEquals(code, 1);
+  const { code, stderr } = await runChild("raw-mid-transaction", path);
+  assertEquals(code, 1, stderr);
   assertEquals(collectQuads(path).length, 0);
 });
 
 Deno.test("SqliteStore recovery - concurrent writers never interleave partial commits", async () => {
   const path = tempDbPath();
   // Two writers race on the write lock; busy_timeout serializes them.
-  const [codeA, codeB] = await Promise.all([
+  const [writerA, writerB] = await Promise.all([
     runChild("concurrent-writer", path, "a"),
     runChild("concurrent-writer", path, "b"),
   ]);
-  assertEquals(codeA, 0);
-  assertEquals(codeB, 0);
+  assertEquals(writerA.code, 0, writerA.stderr);
+  assertEquals(writerB.code, 0, writerB.stderr);
   const quads = collectQuads(path);
   // Each writer committed 5 rounds x 20 quads = 100; both must be complete.
   assertEquals(quads.length, 200);

--- a/test/sqlite-recovery-child.ts
+++ b/test/sqlite-recovery-child.ts
@@ -66,25 +66,66 @@ switch (mode) {
     // writers genuinely overlap on the write lock. busy_timeout makes the
     // second writer wait instead of failing with SQLITE_BUSY; the parent
     // asserts both writers' data lands in full — no interleaved partials.
-    const store = new SqliteStore({ path });
-    for (let round = 0; round < 5; round++) {
-      const transaction = store.createTransaction();
-      for (let index = 0; index < 20; index++) {
-        transaction.add(
-          quad(
-            namedNode(`http://example.org/${tag}-${round}-${index}`),
-            namedNode("http://example.org/p"),
-            literal(`${index}`),
-          ),
-        );
+    // Both commit() and the store's open/close can hit "database is locked"
+    // under contention, so the whole sequence is retried with a fresh store
+    // (writes are upserts, so a partial retry is idempotent). The parent's
+    // 200-quad completeness assertion is what proves no interleaving.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const store = new SqliteStore({ path });
+        for (let round = 0; round < 5; round++) {
+          await commitWithRetry(store, tag, round);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        store.close();
+        Deno.exit(0);
+      } catch (error) {
+        if (attempt === 2) {
+          console.error(error);
+          Deno.exit(1);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
       }
-      transaction.commit();
-      await new Promise((resolve) => setTimeout(resolve, 5));
     }
-    store.close();
-    Deno.exit(0);
     break;
   }
   default:
     throw new Error(`unknown recovery child mode: ${mode}`);
+}
+
+/**
+ * commitWithRetry commits one 20-quad round, retrying with a 200ms backoff
+ * (10 attempts ≈ 2s) when the write lock is contended past busy_timeout. A
+ * fresh transaction is created per attempt; a failed commit already rolled
+ * back at the SQLite level, and each transaction is atomic, so a retry can
+ * never interleave partial writes.
+ */
+async function commitWithRetry(
+  store: SqliteStore,
+  tag: string,
+  round: number,
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    const transaction = store.createTransaction();
+    for (let index = 0; index < 20; index++) {
+      transaction.add(
+        quad(
+          namedNode(`http://example.org/${tag}-${round}-${index}`),
+          namedNode("http://example.org/p"),
+          literal(`${index}`),
+        ),
+      );
+    }
+    try {
+      await transaction.commit();
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt < 9) {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      }
+    }
+  }
+  throw lastError;
 }


### PR DESCRIPTION
**What:** the `SqliteStore recovery - concurrent writers never interleave partial commits` test intermittently fails on main CI (first seen on the #133 merge run `330e31a`): one writer's child exits 1 with `Uncaught (in promise) Error: database is locked`.

**Root cause:** the child never awaited `transaction.commit()`. Under runner contention the rejection surfaced as an unhandled promise rejection and killed the process; `assertEquals(codeB, 0)` then failed with an opaque diff.

**Fix (2 files):**
- `test/sqlite-recovery-child.ts`: commit is awaited and retried per round (10 × 200ms backoff, fresh transaction per attempt); the whole write sequence also retries with a fresh store (3 attempts) so an open/close lock race can't kill the child — writes are upserts, so retries are idempotent.
- `src/store/sqlite-store-recovery.test.ts`: `runChild` now returns `{ code, stderr }` and assertions carry the child's stderr, so any future child failure is diagnosable.

**Verification:** 12/12 local runs of the recovery suite green (previously ~2/5 failed), plus the full `src/store` suite. The 200-quad completeness assertion is unchanged — the test still proves no interleaved partial commits.