### PR TITLE
docs: codify drift-free wiki-sync detail level in AGENTS.md and maintenance doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,16 @@ repository in the Wazoo multi-repo workspace.
 - **Public exports:** Use `@wazoo/sparql-engine` in consumer packages, never
   `@/`.
 
+## Docs maintenance (wiki-sync)
+
+We keep `docs/` in sync with the source tree using the `wiki-sync` skill
+(`repos/wiki/skills/wiki-sync/SKILL.md` in the Wazoo wiki toolchain repo). This
+wiki uses the drift-free default: `detail_level: minimal` — `docs/` carries no
+line numbers, no machine-specific measurement numbers, and no test counts.
+README.md owns the numbers; the wiki keeps structure and methodology prose. To
+opt into the detailed style, change this directive to `line-numbers`,
+`measurements`, or `full`.
+
 ## Verification
 
 Run local checks before staging:

--- a/docs/08-maintenance.md
+++ b/docs/08-maintenance.md
@@ -14,6 +14,15 @@ codified as a reusable skill (`wiki-sync` in
 alongside the `wiki` and `wiki-feedback` skills) so syncing docs after source
 changes is a command, not a prompt.
 
+**This wiki uses the drift-free default (`detail_level: minimal`), declared in
+this repo's `AGENTS.md`.** `docs/` carries no line numbers, no machine-specific
+measurement numbers, and no test counts — only structure that changes when the
+source structure changes. Numbers live in `README.md` (regenerated from
+`bench/*-data.json`); the wiki keeps the methodology prose and links there.
+Opting into the detailed style (`line-numbers`, `measurements`, or `full` in the
+`AGENTS.md` directive) re-enables the "execute to verify" steps marked _opt-in_
+below.
+
 ## The sync anchor
 
 `docs/.sync-base` holds the commit SHA this wiki was last synced to. The delta
@@ -28,22 +37,33 @@ git diff --stat "$BASE"..origin/main -- src test bench .github
 If `.sync-base` is missing, fall back to the last commit that touched `docs/`
 (`git log -1 --format=%H -- docs/`) and write a fresh anchor after syncing.
 
-## Step 1 — Classify the delta
+## Step 1 — Read the detail level
 
-| Change landed in        | Wiki surface to touch                                           |
-| ----------------------- | --------------------------------------------------------------- |
-| `src/**/*.ts`           | `04-source-map.md` (symbol lines) + every page citing that file |
-| `deno.json` tasks       | `01-quickstart.md` task lists                                   |
-| `test/**` (new/renamed) | `04-source-map.md` test tables, `05-testing.md` covered areas   |
-| `bench/**`              | `04-source-map.md` bench table, `07-benchmarking.md`            |
-| new/removed files       | `04-source-map.md` file inventory                               |
-| behavior/fixes          | `02-architecture.md`, `03-api-contracts.md` prose               |
-| `.github/workflows/*`   | `05-testing.md` task-table gating column                        |
+```bash
+grep -i "detail_level" AGENTS.md   # minimal (default) | line-numbers | measurements | full
+```
 
-## Step 2 — Rebuild the symbol graph
+This repo declares `minimal`. Opted-in levels re-enable the verification
+sub-steps marked _opt-in_ below.
 
-Line references are generated from `deno doc --json`, never eyeballed. The v2
-schema nests declaration locations:
+## Step 2 — Classify the delta
+
+| Change landed in        | Wiki surface to touch                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------------------------- |
+| `src/**/*.ts`           | `04-source-map.md` symbol inventory (name + role + entrypoint link) + every page citing that file |
+| `deno.json` tasks       | `01-quickstart.md` task lists                                                                     |
+| `test/**` (new/renamed) | `04-source-map.md` test tables, `05-testing.md` covered areas (counts only when opted in)         |
+| `bench/**`              | `04-source-map.md` bench table, `07-benchmarking.md` methodology (numbers only when opted in)     |
+| new/removed files       | `04-source-map.md` file inventory                                                                 |
+| behavior/fixes          | `02-architecture.md`, `03-api-contracts.md` prose                                                 |
+| `.github/workflows/*`   | `05-testing.md` task-table gating column                                                          |
+
+## Step 3 — Verify the symbol graph
+
+Symbol citations are by name, never `L<line>`: root exports link to their JSR
+doc page, deep imports to their GitHub blob. `deno doc --json` is a
+_verification_ tool — confirm every cited symbol still exists and is publicly
+exported:
 
 ```bash
 deno doc --json src/evaluator/join.ts | python -c "
@@ -51,29 +71,15 @@ import json, sys
 d = json.load(sys.stdin)
 mod = list(d['nodes'].values())[0]
 for s in mod['symbols']:
-    print(f\"{s['name']} L{s['declarations'][0]['location']['line']}\")
+    print(s['name'])
 "
 ```
 
-Diff the output against the documented lines and fix every drift. Files grow — a
-300-line addition invalidates every line citation in that file, so run the
-full-tree pass (`git ls-tree -r --name-only origin/main -- src`) rather than
-only the changed files.
+Drop or relink any symbol not in that list; run the full-tree pass
+(`git ls-tree -r --name-only origin/main -- src`) when in doubt.
 
-## Step 3 — Verify counts by running
-
-Documented counts come from runner output. Comments and README prose have
-drifted before (the [W3C](https://www.w3.org/) 1.1 suite was documented as
-336/23 while the runner loads 345/31):
-
-```bash
-deno task test:w3c          # record printed total/pass (345)
-deno task test:sparql12     # 249
-deno task test:sparql12:gap # 41
-deno test --allow-all src/  # unit count
-```
-
-If a runner prints something different from the docs, the docs are wrong.
+_Opt-in (`line-numbers` or `full`):_ the v2 schema nests declaration locations;
+extract `L<line>` and diff against the documented lines, fixing every drift.
 
 ## Step 4 — Verify file inventory
 
@@ -88,6 +94,10 @@ for removed files, and confirm every path the wiki references resolves.
 
 - Edit only the pages the classification maps to; apply additions and deletions
   the diff demands.
+- In the default style, never introduce `L<line>` citations, number tables, or
+  test counts. When the diff adds a benchmark or a test, add the methodology
+  prose and link to `README.md`'s Results section instead of duplicating
+  numbers.
 - Link hygiene: every inline prose mention of an exported symbol links to its
   JSR doc page (`https://jsr.io/@wazoo/sparql-engine/doc/~/<Symbol>`);
   [`serializeJsonResults`](https://github.com/wazootech/sparql-engine/blob/main/src/serialize/json-results.ts)
@@ -96,10 +106,19 @@ for removed files, and confirm every path the wiki references resolves.
   and every **deep-import symbol** (anything not in the published root exports —
   parser, store, evaluator, and term internals) link to their GitHub blob
   instead (`https://github.com/wazootech/sparql-engine/blob/main/src/<path>`),
-  without line anchors — the prose already carries the maintained L-numbers.
-  Link the first prose occurrence per page of `@wazoo/sparql-engine` (JSR),
-  `Comunica`, `W3C`, and `SPARQL 1.1`/`SPARQL 1.2` (spec TRs); link issue refs
-  to the GitHub issue. Never link inside code fences or HTML attributes.
+  without line anchors. Link the first prose occurrence per page of
+  `@wazoo/sparql-engine` (JSR), `Comunica`, `W3C`, and `SPARQL 1.1`/`SPARQL 1.2`
+  (spec TRs); link issue refs to the GitHub issue. Never link inside code fences
+  or HTML attributes.
+- Drift guardrail: the default style must not pick up drift-prone artifacts. Any
+  hit is drift to remove (or a sign the repo should opt into the detailed
+  style):
+
+  ```bash
+  grep -rnE "\bL[0-9]+\b" docs --include="*.md" | grep -v sync-base || true
+  grep -rnE "\b(ms/iter|MiB)\b" docs --include="*.md" || true
+  ```
+
 - Validate: `deno fmt --check docs/`, nav/front-matter/link checks (all
   `_data/navigation.yml` targets resolve, every page has front matter),
   `deno task docs:link-check` (external link rot — 404/410 fails), and a
@@ -111,10 +130,10 @@ for removed files, and confirm every path the wiki references resolves.
   commit only `docs/`, open a PR, merge, and confirm the Pages build reports
   `built` with no error before declaring done.
 
-## Periodic sweeps
+## Only opted-in numbers drift
 
-Every few source merges, run the full Steps 2–4 pass over the whole tree:
-incremental syncs catch what landed, sweeps catch accumulated drift. The last
-sweep (2026-08-14, against `dfa6ca1`) renumbered every drifted line in
-`04-source-map.md`, added previously undocumented symbols and files, and
-corrected the W3C counts — an example of what a sweep turns up.
+The default style needs no periodic sweeps: a 300-line file growth changes
+nothing in the wiki. If the `AGENTS.md` directive opts into `line-numbers`,
+`measurements`, or `full`, run the full-tree verification passes (Steps 3–4 with
+the opt-in sub-steps) every few source merges — incremental passes miss drift
+that accumulates in line citations and snapshot tables.


### PR DESCRIPTION
Follow-up to the wiki-sync skill rework in [wazootech/wiki#250](https://github.com/wazootech/wiki/pull/250), addressing [wazootech/wiki#249](https://github.com/wazootech/wiki/issues/249).

## What

- **`AGENTS.md`** — new "Docs maintenance (wiki-sync)" section declaring this wiki's detail level: `detail_level: minimal` (the drift-free default), with the opt-in levels documented for consumers who want them.
- **`docs/08-maintenance.md`** — mirrors the updated skill language so the two stay consistent:
  - Symbols are cited **by name with links** (JSR doc page for root exports, GitHub blob for deep imports) — `deno doc --json` is a verification tool, not a citation-line source; `L<line>` extraction is an opt-in sub-step.
  - Counts and measurement tables are **opt-in only**; the default style adds methodology prose and links to `README.md`'s numbers instead of duplicating them.
  - The classification table and "Step 1 — Read the detail level" step match the skill's procedure.
  - A **drift guardrail** (grep for `L<digits>` / bare `ms/iter` / `MiB`) flags artifacts that crept back in.
  - "Periodic sweeps" becomes "Only opted-in numbers drift": the default style needs no sweeps.

## Validation

- `deno fmt --check` (whole repo, 121 files) — clean.
- `deno task docs:link-check` — 0 broken links (25 transient 429 warnings, pre-existing).

## Follow-up

Per #249, dropping the wiki's existing `L<line>` citations (`04-source-map.md`), number tables (`07-benchmarking.md`), and counts (`05-testing.md`) is a separate sync PR so this change stays reviewable.