### PR TITLE
ci: add wiki drift guardrail for detail_level minimal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,33 @@ jobs:
           deno-version: v2.x
       - if: steps.bench-changed.outputs.bench == 'true'
         run: deno task bench:latency:check
+  # Wiki drift guardrail (wiki-sync detail_level: minimal): the wiki declares
+  # its detail level in AGENTS.md and must never re-introduce L<line>
+  # citations — the drift-prone artifact the minimal default removes. Greps
+  # docs/*.md only; committed SVG charts (regenerated artifacts) are out of
+  # scope. Runs only when the wiki, the declaration, or the check changes.
+  docs-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: docs-changed
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'AGENTS.md'
+              - '.github/workflows/ci.yml'
+      - if: steps.docs-changed.outputs.docs == 'true'
+        run: |
+          grep -q "detail_level" AGENTS.md \
+            || { echo "AGENTS.md must declare the wiki-sync detail_level (see the wiki-sync skill)"; exit 1; }
+          hits=$(grep -rnE "\bL[0-9]+\b" docs --include="*.md" | grep -v sync-base || true)
+          if [ -n "$hits" ]; then
+            echo "L<line> citations found in docs/ — forbidden under detail_level: minimal:"
+            echo "$hits"
+            exit 1
+          fi
   # Wiki link-rot gate: every external markdown link in the wiki (README.md +
   # docs/*.md) must resolve — JSR doc pages, GitHub blob/issues, spec TRs.
   # Hard-fails on 404/410 only, so a transient host outage never false-reds


### PR DESCRIPTION
Adds the guardrail recommended in [wazootech/wiki#251](https://github.com/wazootech/wiki/issues/251) (rollout of the drift-free `detail_level: minimal` default from [wazootech/wiki#249](https://github.com/wazootech/wiki/issues/249)).

## What

New path-gated `docs-drift` job in `ci.yml` (runs only when `docs/**`, `AGENTS.md`, or the workflow changes):

1. Fails if `AGENTS.md` stops declaring the wiki-sync `detail_level` (the wiki must never silently lose its style declaration).
2. Fails if `docs/*.md` contains any `L<line>` citation — the drift-prone artifact the minimal default removes. Matches the guardrail grep documented in `docs/08-maintenance.md` and the `wiki-sync` skill.

Committed SVG charts are regenerated artifacts (`bench/treemap.ts` / `bench/latency-chart.ts`) and are out of scope — the scan is `.md`-only, consistent with `docs-links`.

## Validation

- Logic verified locally: passes on current `main` (declares `detail_level: minimal`, zero L-citations), and flags a planted `L42` citation.
- YAML parses clean.