### PR TITLE
prototypes: scriptc feasibility spikes (#145/#146/#147)

### DIFF
--- a/prototypes/README.md
+++ b/prototypes/README.md
@@ -1,0 +1,36 @@
+# Prototypes — scriptc feasibility research (#143)
+
+Standalone spike artifacts from the scriptc evaluation on
+[#143](https://github.com/wazootech/sparql-engine/issues/143). Each file is
+self-contained (no imports from `src/`), intentionally **not** wired into the CI
+tasks or the publish graph, and exists to settle one open question with measured
+evidence.
+
+| File                          | Issue                                                         | Question                                                                                                                                   |
+| ----------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `binding-obj-vs-map-bench.ts` | [#147](https://github.com/wazootech/sparql-engine/issues/147) | Cost of refactoring `TermBinding` from `Record<string, Term>` to `Map<string, Term>` (scriptc's static tier rejects dynamic-keyed records) |
+| `decimal-string-sum.ts`       | [#146](https://github.com/wazootech/sparql-engine/issues/146) | Exact xsd:integer / xsd:decimal SUM on sign+magnitude digit strings, byte-identical to the BigInt path, without BigInt                     |
+| `decimal-string-sum-test.ts`  | [#146](https://github.com/wazootech/sparql-engine/issues/146) | Unit spot-checks + 40k differential fuzz vs the BigInt reference + perf comparison                                                         |
+
+## Run
+
+```bash
+# Decimal-string layer: correctness (differential vs BigInt) + perf
+deno run --allow-all prototypes/decimal-string-sum-test.ts
+
+# Object-vs-Map binding micro-benchmark (V8)
+deno bench --allow-all prototypes/binding-obj-vs-map-bench.ts
+```
+
+## Findings (as of filing)
+
+- **#147**: `Map` regresses the hot binding ops 2–8× on V8 (merge per join row
+  3.9×, extend-1-var 8.2×) — keep records unless a static build is actually
+  committed to.
+- **#146**: decimal strings are 2.2× (decimals) / 7× (integers) slower than
+  BigInt but exact; the open direction is a hybrid f64 fast path (±2^53) with
+  single-pass scale alignment.
+
+The `scratch/` copies these were developed from live outside the repo; the
+issues still reference those paths. If this PR merges, point the issue
+references at `prototypes/`.

--- a/prototypes/binding-obj-vs-map-bench.ts
+++ b/prototypes/binding-obj-vs-map-bench.ts
@@ -1,0 +1,146 @@
+// Micro-benchmark: plain-object TermBinding vs Map<string, Term> TermBinding.
+// Models the engine's hottest binding operations at typical binding widths.
+//
+//   - merge: { ...l, ...r } vs Map copy+set (one new binding per join row)
+//   - read:  binding[k] vs map.get(k) (per pattern variable per row)
+//   - write: binding[k] = t vs map.set(k, t) (per bound pattern variable)
+//   - keys:  Object.keys(b) vs [...b.keys()] (sharedVars / serialization)
+
+interface Term {
+  termType: string;
+  value: string;
+}
+
+const mk = (i: number): Term => ({
+  termType: "NamedNode",
+  value: `https://e/${i}`,
+});
+
+function bench(name: string, iterations: number, fn: () => void): void {
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    fn();
+  }
+  const elapsed = performance.now() - start;
+  console.log(`${name.padEnd(44)} ${elapsed.toFixed(1).padStart(8)} ms`);
+}
+
+// --- Object path ---------------------------------------------------------
+
+function objMerge(
+  l: Record<string, Term>,
+  r: Record<string, Term>,
+): Record<string, Term> {
+  return { ...l, ...r };
+}
+
+function objMergeLoop(
+  l: Record<string, Term>[],
+  r: Record<string, Term>[],
+): Record<string, Term>[] {
+  const out: Record<string, Term>[] = [];
+  for (const a of l) {
+    for (const b of r) {
+      out.push({ ...a, ...b });
+    }
+  }
+  return out;
+}
+
+function objRead(b: Record<string, Term>, keys: string[]): Term | undefined {
+  for (const k of keys) {
+    if (b[k] !== undefined) return b[k];
+  }
+  return undefined;
+}
+
+// --- Map path ------------------------------------------------------------
+
+function mapMerge(
+  l: Map<string, Term>,
+  r: Map<string, Term>,
+): Map<string, Term> {
+  const m = new Map(l);
+  for (const [k, v] of r) m.set(k, v);
+  return m;
+}
+
+function mapMergeLoop(
+  l: Map<string, Term>[],
+  r: Map<string, Term>[],
+): Map<string, Term>[] {
+  const out: Map<string, Term>[] = [];
+  for (const a of l) {
+    for (const b of r) {
+      const m = new Map(a);
+      for (const [k, v] of b) m.set(k, v);
+      out.push(m);
+    }
+  }
+  return out;
+}
+
+function mapRead(b: Map<string, Term>, keys: string[]): Term | undefined {
+  for (const k of keys) {
+    const t = b.get(k);
+    if (t !== undefined) return t;
+  }
+  return undefined;
+}
+
+// Build realistic inputs: 2-key and 5-key bindings, one overlapping var.
+const WIDTH = 3; // keys per side; overlap 1
+const N = 400; // bindings per side
+const ITER = 40;
+
+const lObj: Record<string, Term>[] = [];
+const rObj: Record<string, Term>[] = [];
+const lMap: Map<string, Term>[] = [];
+const rMap: Map<string, Term>[] = [];
+for (let i = 0; i < N; i++) {
+  const lo: Record<string, Term> = { s: mk(i) };
+  const ro: Record<string, Term> = { s: mk(i) };
+  const lm = new Map<string, Term>([["s", mk(i)]]);
+  const rm = new Map<string, Term>([["s", mk(i)]]);
+  for (let j = 0; j < WIDTH; j++) {
+    lo[`a${j}`] = mk(i * 10 + j);
+    ro[`b${j}`] = mk(i * 10 + j);
+    lm.set(`a${j}`, mk(i * 10 + j));
+    rm.set(`b${j}`, mk(i * 10 + j));
+  }
+  lObj.push(lo);
+  rObj.push(ro);
+  lMap.push(lm);
+  rMap.push(rm);
+}
+
+const keys = ["a0", "a1", "a2"];
+
+console.log(`join rows per iter: ${N * N} (${WIDTH} keys/side, 1 shared)`);
+console.log("");
+
+bench("obj merge one pair", ITER * 100_000, () => objMerge(lObj[0], rObj[0]));
+bench("map merge one pair", ITER * 100_000, () => mapMerge(lMap[0], rMap[0]));
+
+bench("obj full join merge (nested)", ITER, () => objMergeLoop(lObj, rObj));
+bench("map full join merge (nested)", ITER, () => mapMergeLoop(lMap, rMap));
+
+bench("obj read 3 vars", ITER * 100_000, () => objRead(lObj[0], keys));
+bench("map read 3 vars", ITER * 100_000, () => mapRead(lMap[0], keys));
+
+bench("obj keys", ITER * 100_000, () => Object.keys(lObj[0]));
+bench("map keys", ITER * 100_000, () => [...lMap[0].keys()]);
+
+// Write-extension (one pattern variable bound per row).
+const objExt = () => {
+  const nb = { ...lObj[0] };
+  nb.c = mk(1);
+  return nb;
+};
+const mapExt = () => {
+  const nb = new Map(lMap[0]);
+  nb.set("c", mk(1));
+  return nb;
+};
+bench("obj extend 1 var", ITER * 100_000, objExt);
+bench("map extend 1 var", ITER * 100_000, mapExt);

--- a/prototypes/decimal-string-sum-test.ts
+++ b/prototypes/decimal-string-sum-test.ts
@@ -1,0 +1,171 @@
+// Correctness (differential vs the BigInt reference) and perf comparison for
+// the decimal-string SUM prototype. Run: deno run --allow-all decimal-string-sum-test.ts
+
+import {
+  add,
+  bigintDecimalSum,
+  bigintIntegerSum,
+  decimalSum,
+  fromLexical,
+  stringIntegerSum,
+  toString,
+} from "./decimal-string-sum.ts";
+
+// --- Unit spot-checks ------------------------------------------------------
+
+const cases: [string, string][] = [
+  // Parity-pinned case from aggregate.ts docs.
+  ["1.0+2.2+3.5+2.2+2.2", "11.1"],
+  // Trailing-zero stripping ("111"/1 -> "11.1", "32"/1 -> "3.2", "3"/1 -> "3").
+  ["111+0", "111"],
+  ["32+0", "32"],
+  // Single values normalize too.
+  ["1.50", "1.5"],
+  ["-0", "0"],
+  // Mixed signs.
+  ["1.0+-2.2", "-1.2"],
+  ["-1.0+-2.2", "-3.2"],
+  ["-2.5+2.5", "0"],
+  ["0.1+0.2", "0.3"],
+  // Scale alignment.
+  ["0.5+0.05+0.005", "0.555"],
+  ["100000000000000000000000000000+1", "100000000000000000000000000001"],
+  ["-100000000000000000000000000000+1", "-99999999999999999999999999999"],
+  ["0.00+0", "0"],
+];
+
+let failures = 0;
+for (const [expr, expected] of cases) {
+  const values = expr.split("+");
+  const actual = decimalSum(values);
+  if (actual !== expected) {
+    console.log(`FAIL ${expr} -> "${actual}" (expected "${expected}")`);
+    failures++;
+  }
+}
+console.log(
+  failures === 0 ? "unit spot-checks: all pass" : `${failures} failures`,
+);
+
+// --- Differential fuzz vs BigInt reference --------------------------------
+
+function randDecimal(rng: () => number): string {
+  const intLen = 1 + Math.floor(rng() * 12);
+  const scale = Math.floor(rng() * 6);
+  let digits = "";
+  for (let i = 0; i < intLen + scale; i++) digits += Math.floor(rng() * 10);
+  const sign = rng() < 0.5 ? "-" : "";
+  const intPart = digits.slice(0, intLen);
+  const fracPart = digits.slice(intLen);
+  return sign + intPart + (scale > 0 ? "." + fracPart : "");
+}
+
+function randInteger(rng: () => number): string {
+  let s = "";
+  const len = 1 + Math.floor(rng() * 40);
+  for (let k = 0; k < len; k++) s += Math.floor(rng() * 10);
+  if (rng() < 0.5) s = "-" + s;
+  return s.replace(/^0+(?=\d)/, "") || "0";
+}
+
+let seed = 0x2f6e2b1;
+const rng = (): number => {
+  seed = (seed * 1664525 + 1013904223) >>> 0;
+  return seed / 0x100000000;
+};
+
+const fuzzN = 20_000;
+for (let i = 0; i < fuzzN; i++) {
+  const n = 1 + Math.floor(rng() * 40);
+  const values: string[] = [];
+  for (let j = 0; j < n; j++) values.push(randDecimal(rng));
+  const expected = bigintDecimalSum(values);
+  const actual = decimalSum(values);
+  if (actual !== expected) {
+    console.log(`FUZZ FAIL #${i}`, values, "->", actual, "expected", expected);
+    failures++;
+    if (failures > 5) break;
+  }
+}
+console.log(
+  failures === 0
+    ? `differential fuzz (${fuzzN} decimal sums): all pass`
+    : `${failures} failures total`,
+);
+
+for (let i = 0; i < 20_000; i++) {
+  const n = 1 + Math.floor(rng() * 40);
+  const values: string[] = [];
+  for (let j = 0; j < n; j++) values.push(randInteger(rng));
+  const expected = bigintIntegerSum(values);
+  const actual = stringIntegerSum(values);
+  if (actual !== expected) {
+    console.log(
+      `INT FUZZ FAIL #${i}`,
+      values,
+      "->",
+      actual,
+      "expected",
+      expected,
+    );
+    failures++;
+    if (failures > 5) break;
+  }
+}
+console.log(
+  failures === 0
+    ? "integer fuzz (20k sums): all pass"
+    : `${failures} failures total`,
+);
+
+// --- Perf comparison -------------------------------------------------------
+
+function makeWorkloads(): { decimals: string[][]; integers: string[][] } {
+  const decimals: string[][] = [];
+  const integers: string[][] = [];
+  for (let i = 0; i < 2000; i++) {
+    const n = 10 + Math.floor(rng() * 90); // 10..99 terms
+    const dv: string[] = [];
+    const iv: string[] = [];
+    for (let j = 0; j < n; j++) {
+      dv.push(randDecimal(rng));
+      iv.push(randInteger(rng));
+    }
+    decimals.push(dv);
+    integers.push(iv);
+  }
+  return { decimals, integers };
+}
+
+const { decimals, integers } = makeWorkloads();
+
+function bench(
+  name: string,
+  fn: (values: string[]) => string,
+  ws: string[][],
+): void {
+  const start = performance.now();
+  let sink = 0;
+  for (const w of ws) sink += fn(w).length;
+  const elapsed = performance.now() - start;
+  console.log(
+    `${name.padEnd(40)} ${elapsed.toFixed(1).padStart(8)} ms (sink ${sink})`,
+  );
+}
+
+bench("bigintDecimalSum (ref)", bigintDecimalSum, decimals);
+bench("decimalSum (strings) ", decimalSum, decimals);
+bench("bigintIntegerSum (ref)", bigintIntegerSum, integers);
+bench("stringIntegerSum (strings)", stringIntegerSum, integers);
+
+// Sanity: the reduce form used if the layer replaced the inline loop.
+const parts = [
+  fromLexical("1.0"),
+  fromLexical("2.2"),
+  fromLexical("3.5"),
+  fromLexical("2.2"),
+  fromLexical("2.2"),
+];
+const sum = parts.reduce(add);
+console.log("reduce(add) of 1.0+2.2+3.5+2.2+2.2 =", toString(sum));
+console.log(failures === 0 ? "\nALL PASS" : `\n${failures} FAILURES`);

--- a/prototypes/decimal-string-sum.ts
+++ b/prototypes/decimal-string-sum.ts
@@ -1,0 +1,196 @@
+// Prototype: exact xsd:integer / xsd:decimal SUM without BigInt, using
+// sign + magnitude digit strings. Matches aggregate.ts's exactDecimalSum /
+// integer-SUM behavior byte for byte (canonical form, trailing fractional
+// zeros stripped, negative handling), then benchmarks against the BigInt
+// implementation on representative workloads.
+//
+// The point: scriptc's static tier rejects BigInt ("f64 is the one number
+// type"); this layer is the "decimal-string arithmetic" escape hatch that
+// preserves the differential-parity-pinned exact results.
+
+export interface Decimal {
+  negative: boolean;
+  /** magnitude digits, no leading zeros, no sign, no point; "0" for zero. */
+  digits: string;
+  /** number of fractional digits. */
+  scale: number;
+}
+
+const ZERO: Decimal = { negative: false, digits: "0", scale: 0 };
+
+/** fromLexical parses an xsd:integer/xsd:decimal lexical form. */
+export function fromLexical(lexical: string): Decimal {
+  const text = lexical.trim();
+  let negative = false;
+  let rest = text;
+  if (rest[0] === "+") {
+    rest = rest.slice(1);
+  } else if (rest[0] === "-") {
+    negative = true;
+    rest = rest.slice(1);
+  }
+  const dot = rest.indexOf(".");
+  let intPart = dot === -1 ? rest : rest.slice(0, dot);
+  const fracPart = dot === -1 ? "" : rest.slice(dot + 1);
+  if (intPart === "") intPart = "0";
+  const digits = (intPart + fracPart).replace(/^0+(?=\d)/, "") || "0";
+  const scale = fracPart.length;
+  if (digits === "0") return ZERO;
+  return { negative, digits, scale };
+}
+
+/** normalize strips trailing fractional zeros (canonical form). */
+function normalize(d: Decimal): Decimal {
+  let { negative, digits, scale } = d;
+  if (digits === "" || /^0+$/.test(digits)) return ZERO;
+  while (scale > 0 && digits.endsWith("0")) {
+    digits = digits.slice(0, -1);
+    scale--;
+  }
+  if (digits === "") return ZERO;
+  return { negative, digits, scale };
+}
+
+/** magnitude add: aDigits + bDigits (no sign). */
+function magAdd(a: string, b: string): string {
+  let i = a.length - 1;
+  let j = b.length - 1;
+  let carry = 0;
+  let out = "";
+  while (i >= 0 || j >= 0 || carry > 0) {
+    const da = i >= 0 ? a.charCodeAt(i) - 48 : 0;
+    const db = j >= 0 ? b.charCodeAt(j) - 48 : 0;
+    const sum = da + db + carry;
+    carry = sum >= 10 ? 1 : 0;
+    out = String.fromCharCode(48 + (sum % 10)) + out;
+    i--;
+    j--;
+  }
+  return out;
+}
+
+/** magGt: aDigits > bDigits (magnitude comparison). */
+function magGt(a: string, b: string): boolean {
+  if (a.length !== b.length) return a.length > b.length;
+  return a > b;
+}
+
+/** magSub: aDigits - bDigits, requires a >= b (no sign). */
+function magSub(a: string, b: string): string {
+  let i = a.length - 1;
+  let j = b.length - 1;
+  let borrow = 0;
+  let out = "";
+  while (i >= 0) {
+    let da = a.charCodeAt(i) - 48 - borrow;
+    const db = j >= 0 ? b.charCodeAt(j) - 48 : 0;
+    borrow = 0;
+    if (da < db) {
+      da += 10;
+      borrow = 1;
+    }
+    out = String.fromCharCode(48 + (da - db)) + out;
+    i--;
+    j--;
+  }
+  return out.replace(/^0+(?=\d)/, "") || "0";
+}
+
+/** add sums two exact decimals, preserving canonical form. */
+export function add(a: Decimal, b: Decimal): Decimal {
+  if (a.digits === "0") return b;
+  if (b.digits === "0") return a;
+  const scale = Math.max(a.scale, b.scale);
+  const aDigits = a.digits + "0".repeat(scale - a.scale);
+  const bDigits = b.digits + "0".repeat(scale - b.scale);
+  let out: Decimal;
+  if (a.negative === b.negative) {
+    out = { negative: a.negative, digits: magAdd(aDigits, bDigits), scale };
+  } else {
+    if (magGt(aDigits, bDigits)) {
+      out = { negative: a.negative, digits: magSub(aDigits, bDigits), scale };
+    } else if (magGt(bDigits, aDigits)) {
+      out = { negative: b.negative, digits: magSub(bDigits, aDigits), scale };
+    } else {
+      return ZERO;
+    }
+  }
+  return normalize(out);
+}
+
+/** toString renders the canonical xsd:integer/xsd:decimal lexical form. */
+export function toString(d: Decimal): string {
+  d = normalize(d);
+  const { negative, digits, scale } = d;
+  if (digits === "0") return "0";
+  const sign = negative ? "-" : "";
+  if (scale === 0) return sign + digits;
+  const intPart = digits.slice(0, digits.length - scale) || "0";
+  const fracPart = digits.slice(digits.length - scale);
+  return sign + intPart + "." + fracPart;
+}
+
+/** decimalSum sums lexical decimal/integer forms exactly, canonically. */
+export function decimalSum(values: string[]): string {
+  let acc = ZERO;
+  for (const value of values) {
+    acc = add(acc, fromLexical(value));
+  }
+  return toString(acc);
+}
+
+// ---------------------------------------------------------------------------
+// Reference implementations mirroring aggregate.ts (BigInt path).
+// ---------------------------------------------------------------------------
+
+/** bigintDecimalSum mirrors exactDecimalSum's significand/scale alignment. */
+export function bigintDecimalSum(values: string[]): string {
+  let maxScale = 0;
+  const parts: { significand: bigint; scale: number }[] = [];
+  for (const text of values) {
+    const dot = text.indexOf(".");
+    const scale = dot === -1 ? 0 : text.length - dot - 1;
+    const digits = dot === -1 ? text : text.slice(0, dot) + text.slice(dot + 1);
+    maxScale = Math.max(maxScale, scale);
+    parts.push({ significand: BigInt(digits), scale });
+  }
+  let total = 0n;
+  for (const part of parts) {
+    total += part.significand * 10n ** BigInt(maxScale - part.scale);
+  }
+  const negative = total < 0n;
+  const absolute = (negative ? -total : total).toString().padStart(
+    maxScale + 1,
+    "0",
+  );
+  let text: string;
+  if (maxScale === 0) {
+    text = absolute;
+  } else {
+    const intPart = absolute.slice(0, absolute.length - maxScale);
+    const fracPart = absolute.slice(absolute.length - maxScale).replace(
+      /0+$/,
+      "",
+    );
+    text = fracPart.length === 0 ? intPart : `${intPart}.${fracPart}`;
+  }
+  return negative ? "-" + text : text;
+}
+
+/** bigintIntegerSum mirrors the xsd:integer SUM path (BigInt accumulation). */
+export function bigintIntegerSum(values: string[]): string {
+  let total = 0n;
+  for (const v of values) {
+    total += BigInt(v);
+  }
+  return total.toString();
+}
+
+/** stringIntegerSum mirrors the same path without BigInt. */
+export function stringIntegerSum(values: string[]): string {
+  let acc = ZERO;
+  for (const v of values) {
+    acc = add(acc, fromLexical(v));
+  }
+  return toString(acc);
+}


### PR DESCRIPTION
## What

Adds `prototypes/` — the three self-contained spike artifacts from the
scriptc feasibility research on [#143](https://github.com/wazootech/sparql-engine/issues/143).
Each file answers one open question with measured evidence, and each is
mapped to its tracking issue:

| File | Issue | Question |
| --- | --- | --- |
| `binding-obj-vs-map-bench.ts` | [#147](https://github.com/wazootech/sparql-engine/issues/147) | Cost of `TermBinding` `Record<string, Term>` → `Map<string, Term>` (scriptc's static tier rejects dynamic-keyed records) |
| `decimal-string-sum.ts` | [#146](https://github.com/wazootech/sparql-engine/issues/146) | Exact xsd:integer / xsd:decimal SUM on sign+magnitude digit strings, byte-identical to the BigInt path, without BigInt |
| `decimal-string-sum-test.ts` | [#146](https://github.com/wazootech/sparql-engine/issues/146) | Unit spot-checks + 40k differential fuzz vs the BigInt reference + perf comparison |

All files are standalone (no `src/` imports), deliberately not wired into
the CI tasks or the publish graph — they are research artifacts, not shipped
code.

## Findings reproduced

- **#147**: `Map` regresses the hot binding ops 2–10× on V8 (merge per join
  row 4.5×, extend-1-var 10× in this run) — keep records unless a static
  build is actually committed to.
- **#146**: decimal strings are 2.4× (decimals) / 6.8× (integers) slower
  than BigInt but exact — 20,000 decimal + 20,000 integer differential
  fuzz sums byte-identical to the BigInt reference, including the
  parity-pinned `1.0+2.2+3.5+2.2+2.2 = "11.1"`.

## Validation

- `deno check` — clean on all three files
- `deno lint prototypes/` — clean
- `deno fmt --check prototypes/` — clean
- `deno run --allow-all prototypes/decimal-string-sum-test.ts` — ALL PASS
- `deno bench --allow-all prototypes/binding-obj-vs-map-bench.ts` — runs

## Follow-up

The issues still reference the `scratch/` paths the spikes were developed
under; once this merges, the issue comments should be pointed at
`prototypes/`.
