### PR TITLE
feat: enforce timeoutMs/signal on SparqlRequest (#122)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@wazoo/sparql-engine",
   "description": "Zero-dependency SPARQL 1.1 & 1.2 query and update engine over RDF/JS Quad Stores.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/src/evaluator/abort.ts
+++ b/src/evaluator/abort.ts
@@ -1,0 +1,15 @@
+/**
+ * checkAborted throws the signal's abort reason when the request has been
+ * cancelled — the per-boundary cancellation check (issue #122). Evaluation
+ * boundaries (per-pattern, per-join, per-update-operation) call it so an
+ * aborted request stops at the next boundary instead of only at the
+ * end-of-request reject race in WazooSparqlEngine.execute. A caller-provided
+ * signal is forwarded into the engine's AbortController there, so the
+ * thrown reason is the caller's Error (or the engine's "SPARQL query timed
+ * out" / "SPARQL query aborted"), identical to what the race rejects with.
+ */
+export function checkAborted(signal: AbortSignal | undefined): void {
+  if (signal !== undefined) {
+    signal.throwIfAborted();
+  }
+}

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -21,6 +21,7 @@ import {
   simplePredicate,
   storeVersion,
 } from "@/quad-store.ts";
+import { checkAborted } from "@/evaluator/abort.ts";
 
 const { defaultGraph } = DataFactory;
 import {
@@ -166,7 +167,9 @@ export class BgpEvaluator {
   public async evaluateBgp(
     patterns: Pattern[],
     baseIri?: string,
+    signal?: AbortSignal,
   ): Promise<TermBinding[]> {
+    checkAborted(signal);
     // EXISTS support: when any pattern in the tree uses EXISTS/NOT EXISTS,
     // the store's quads are drained once into a synchronous index that the
     // injected hooks probe (the decided sync-hook contract). The snapshot is
@@ -176,6 +179,7 @@ export class BgpEvaluator {
     // snapshot is captured for this call and threaded down — a concurrent
     // call's rebuild never swaps it mid-evaluation.
     if (patternListContainsExists(patterns)) {
+      checkAborted(signal);
       await this.prepareExistsIndex();
     }
     // The top-level evaluation runs against the default graph (matching
@@ -194,6 +198,7 @@ export class BgpEvaluator {
       defaultScope,
       stats,
       baseIri,
+      signal,
     );
   }
 
@@ -792,7 +797,9 @@ export class BgpEvaluator {
     store: rdfjs.Source<rdfjs.Quad>,
     stats: PatternStatistics,
     baseIri?: string,
+    signal?: AbortSignal,
   ): Promise<TermBinding[]> {
+    checkAborted(signal);
     // Resolve the EXISTS snapshot once for this group and thread it down, so
     // every hook in the group shares one snapshot reference (issue #72). The
     // version cache makes repeated resolutions cheap for the sequential case.
@@ -809,7 +816,12 @@ export class BgpEvaluator {
       }
     }
     let result: Iterable<TermBinding> = bindings;
+    // Each pattern boundary is a cancellation checkpoint (issue #122): the
+    // check is per pattern, so a long chain stops at the next pattern once
+    // the request is aborted (the per-triple check inside joinBgp covers
+    // the joins within a BGP block).
     for (const pattern of nonFilters) {
+      checkAborted(signal);
       result = await this.evaluatePattern(
         pattern,
         result,
@@ -817,9 +829,11 @@ export class BgpEvaluator {
         snapshot,
         stats,
         baseIri,
+        signal,
       );
     }
     for (const filterPattern of filters) {
+      checkAborted(signal);
       result = await this.evaluatePattern(
         filterPattern,
         result,
@@ -827,6 +841,7 @@ export class BgpEvaluator {
         snapshot,
         stats,
         baseIri,
+        signal,
       );
     }
     // Materialize exactly once at the group boundary (an array result — the
@@ -846,6 +861,7 @@ export class BgpEvaluator {
     snapshot: ExistsSnapshot | null,
     stats: PatternStatistics,
     baseIri?: string,
+    signal?: AbortSignal,
   ): Promise<Iterable<TermBinding>> {
     switch (pattern.type) {
       case "bgp":
@@ -855,6 +871,7 @@ export class BgpEvaluator {
           store,
           snapshot,
           stats,
+          signal,
         );
       case "filter": {
         const context = expressionContainsExists(pattern.expression)
@@ -890,6 +907,7 @@ export class BgpEvaluator {
           store,
           stats,
           baseIri,
+          signal,
         );
         const context = filters.some(expressionContainsExists)
           ? this.scopedExistsContext(store, snapshot, baseIri)
@@ -909,6 +927,7 @@ export class BgpEvaluator {
           store,
           stats,
           baseIri,
+          signal,
         );
         return minus(bindings, right);
       }
@@ -919,7 +938,14 @@ export class BgpEvaluator {
         const branchResults: TermBinding[][] = [];
         for (const branch of pattern.patterns) {
           branchResults.push(
-            await this.evaluateGroup([branch], [{}], store, stats, baseIri),
+            await this.evaluateGroup(
+              [branch],
+              [{}],
+              store,
+              stats,
+              baseIri,
+              signal,
+            ),
           );
         }
         return innerJoin(bindings, branchResults.flat());
@@ -999,6 +1025,7 @@ export class BgpEvaluator {
             scopedStore,
             stats,
             baseIri,
+            signal,
           );
           for (const binding of inner) {
             if (graphName.termType === "Variable") {
@@ -1021,6 +1048,7 @@ export class BgpEvaluator {
           store,
           stats,
           baseIri,
+          signal,
         );
         return innerJoin(bindings, groupResult);
       }
@@ -1033,6 +1061,7 @@ export class BgpEvaluator {
             store,
             stats,
             baseIri,
+            signal,
           );
           return innerJoin(bindings, inner);
         } catch (err) {
@@ -1052,6 +1081,7 @@ export class BgpEvaluator {
         const subResults = await subEvaluator.evaluateSelectTermBindings(
           pattern as unknown as import("@/parser/sparql-parser.ts").SelectQuery,
           baseIri,
+          signal,
         );
         return innerJoin(bindings, subResults);
       }
@@ -1077,6 +1107,7 @@ export class BgpEvaluator {
     store: rdfjs.Source<rdfjs.Quad>,
     snapshot: ExistsSnapshot | null,
     stats: PatternStatistics,
+    signal?: AbortSignal,
   ): Promise<Iterable<TermBinding>> {
     // Reified-triple patterns (`<< s p o >>`, annotation `{| ... |}`) expand
     // into plain `rdf:reifies` triples before any scanning or reordering.
@@ -1119,6 +1150,9 @@ export class BgpEvaluator {
     }
     let result: Iterable<TermBinding> = bindings;
     for (const triple of expanded) {
+      // Per-join cancellation checkpoint (issue #122): each BGP join is a
+      // boundary, so an aborted request stops the chain at the next triple.
+      checkAborted(signal);
       if (isPropertyPath(triple.predicate)) {
         const entry = await scanPathEntry(
           store,
@@ -1148,6 +1182,7 @@ export class BgpEvaluator {
     store: rdfjs.Source<rdfjs.Quad>,
     prebuiltIndex: QuadIndex | null,
     stats: PatternStatistics,
+    signal?: AbortSignal,
   ): Promise<TermBinding[]> {
     const remaining = await Promise.all(
       triplePatterns.map((pattern) => scanEntry(store, pattern)),
@@ -1180,12 +1215,16 @@ export class BgpEvaluator {
       );
       if (order !== null) {
         for (const index of order) {
+          checkAborted(signal);
           result = joinTriplePattern(result, remaining[index], prebuiltIndex);
         }
         return result;
       }
     }
     while (remaining.length > 0) {
+      // Per-join cancellation checkpoint (issue #122): the greedy reorder
+      // loop checks once per joined pattern.
+      checkAborted(signal);
       let bestIndex = 0;
       let bestCost = Number.POSITIVE_INFINITY;
       for (let index = 0; index < remaining.length; index++) {

--- a/src/evaluator/sparql-evaluator.ts
+++ b/src/evaluator/sparql-evaluator.ts
@@ -138,24 +138,32 @@ export class SparqlEvaluator {
 
   /**
    * evaluateQuery processes a parsed SPARQL query and produces a typed SparqlResponse.
+   * The optional signal aborts evaluation at the next pattern/join boundary
+   * (issue #122); the engine's execute() also races it end-of-request.
    */
-  public async evaluateQuery(query: SparqlQuery): Promise<SparqlResponse> {
+  public async evaluateQuery(
+    query: SparqlQuery,
+    signal?: AbortSignal,
+  ): Promise<SparqlResponse> {
     switch (query.type) {
       case "query":
         switch (query.queryType) {
           case "SELECT":
-            return { kind: "select", data: await this.evaluateSelect(query) };
+            return {
+              kind: "select",
+              data: await this.evaluateSelect(query, signal),
+            };
           case "ASK":
-            return { kind: "ask", data: await this.evaluateAsk(query) };
+            return { kind: "ask", data: await this.evaluateAsk(query, signal) };
           case "CONSTRUCT":
             return {
               kind: "construct",
-              data: await this.evaluateConstruct(query),
+              data: await this.evaluateConstruct(query, signal),
             };
           case "DESCRIBE":
             return {
               kind: "construct",
-              data: await this.evaluateDescribe(query),
+              data: await this.evaluateDescribe(query, signal),
             };
           default:
             throw new Error(
@@ -172,11 +180,13 @@ export class SparqlEvaluator {
   public async evaluateSelectTermBindings(
     query: SelectQuery,
     baseIri?: string,
+    signal?: AbortSignal,
   ): Promise<TermBinding[]> {
     const evaluator = await this.bgpEvaluatorFor(query.from);
     const rawBindings = await evaluator.evaluateBgp(
       query.where || [],
       baseIri,
+      signal,
     );
     // Projection / HAVING / ORDER BY expressions share one default-graph
     // scoped candidate set across every solution (once per query) instead of
@@ -215,10 +225,12 @@ export class SparqlEvaluator {
 
   private async evaluateSelect(
     query: SelectQuery,
+    signal?: AbortSignal,
   ): Promise<SparqlSelectResults> {
     const termBindings = await this.evaluateSelectTermBindings(
       query,
       query.base,
+      signal,
     );
     const projected: SparqlBinding[] = termBindings.map((b) => {
       const sb: SparqlBinding = {};
@@ -354,9 +366,12 @@ export class SparqlEvaluator {
     return result;
   }
 
-  private async evaluateAsk(query: AskQuery): Promise<SparqlAskResults> {
+  private async evaluateAsk(
+    query: AskQuery,
+    signal?: AbortSignal,
+  ): Promise<SparqlAskResults> {
     const bindings = await (await this.bgpEvaluatorFor(query.from))
-      .evaluateBgp(query.where || [], query.base);
+      .evaluateBgp(query.where || [], query.base, signal);
     return {
       head: { link: null },
       boolean: bindings.length > 0,
@@ -396,11 +411,13 @@ export class SparqlEvaluator {
    */
   private async evaluateDescribe(
     query: DescribeQuery,
+    signal?: AbortSignal,
   ): Promise<SparqlConstructResults> {
     const bindings = query.where?.length
       ? await (await this.bgpEvaluatorFor(query.from)).evaluateBgp(
         query.where,
         query.base,
+        signal,
       )
       : [];
 
@@ -451,12 +468,13 @@ export class SparqlEvaluator {
 
   private async evaluateConstruct(
     query: ConstructQuery,
+    signal?: AbortSignal,
   ): Promise<SparqlConstructResults> {
     if (!query.template) {
       return { quads: [] };
     }
     const bindings = await (await this.bgpEvaluatorFor(query.from))
-      .evaluateBgp(query.where || [], query.base);
+      .evaluateBgp(query.where || [], query.base, signal);
 
     // Reified-triple templates (`<< s p o >>`, annotation `{| ... |}`)
     // expand into a reifier blank node joined to its `rdf:reifies` triple

--- a/src/evaluator/update-evaluator.ts
+++ b/src/evaluator/update-evaluator.ts
@@ -11,6 +11,7 @@ import type {
 import type { WazooSparqlTransaction } from "@/wazoo-sparql-engine.ts";
 import { BgpEvaluator } from "@/evaluator/bgp-evaluator.ts";
 import type { TermBinding } from "@/evaluator/bgp-evaluator.ts";
+import { checkAborted } from "@/evaluator/abort.ts";
 import {
   buildDatasetStore,
   buildQuadIndex,
@@ -125,6 +126,7 @@ export class UpdateEvaluator {
   public async executeUpdate(
     ast: UpdateQuery,
     baseIri?: string,
+    signal?: AbortSignal,
   ): Promise<void> {
     const transaction = this.options.createTransaction?.();
     if (!transaction) {
@@ -138,12 +140,15 @@ export class UpdateEvaluator {
             "addQuad/removeQuad or provide createTransaction",
         );
       }
+      // Each update operation is a cancellation checkpoint (issue #122).
       for (const operation of ast.updates) {
+        checkAborted(signal);
         await this.applyOperation(
           operation,
           (item) => writeStore.addQuad(item),
           (item) => writeStore.removeQuad(item),
           baseIri,
+          signal,
         );
       }
       return;
@@ -151,11 +156,13 @@ export class UpdateEvaluator {
 
     try {
       for (const operation of ast.updates) {
+        checkAborted(signal);
         await this.applyOperation(
           operation,
           (item) => transaction.add(item),
           (item) => transaction.delete(item),
           baseIri,
+          signal,
         );
       }
       await transaction.commit();
@@ -173,6 +180,7 @@ export class UpdateEvaluator {
     add: (item: rdfjs.Quad) => unknown,
     remove: (item: rdfjs.Quad) => unknown,
     baseIri?: string,
+    signal?: AbortSignal,
   ): Promise<void> {
     const op = operation as unknown as Record<string, unknown>;
     const opType = (op.updateType || op.type || op.action) as
@@ -213,6 +221,7 @@ export class UpdateEvaluator {
           add,
           remove,
           baseIri,
+          signal,
         );
         return;
       }
@@ -221,6 +230,7 @@ export class UpdateEvaluator {
           operation as Extract<UpdateOperation, { updateType: "deletewhere" }>,
           remove,
           baseIri,
+          signal,
         );
         return;
       }
@@ -519,6 +529,7 @@ export class UpdateEvaluator {
     add: (item: rdfjs.Quad) => unknown,
     remove: (item: rdfjs.Quad) => unknown,
     baseIri?: string,
+    signal?: AbortSignal,
   ): Promise<void> {
     const withGraph = operation.graph
       ? sparqlTermToRdfTerm(operation.graph)
@@ -546,9 +557,11 @@ export class UpdateEvaluator {
     const bindings = await evaluator.evaluateBgp(
       operation.where ?? [],
       baseIri,
+      signal,
     );
 
     for (const pattern of operation.delete ?? []) {
+      checkAborted(signal);
       await this.deleteMatches(pattern, bindings, remove, withGraph);
     }
     for (const binding of bindings) {
@@ -576,13 +589,16 @@ export class UpdateEvaluator {
     operation: InsertDeleteOperation,
     remove: (item: rdfjs.Quad) => unknown,
     baseIri?: string,
+    signal?: AbortSignal,
   ): Promise<void> {
     const wherePatterns = (operation.delete ?? []) as Pattern[];
     const bindings = await this.bgpEvaluator.evaluateBgp(
       wherePatterns,
       baseIri,
+      signal,
     );
     for (const pattern of operation.delete ?? []) {
+      checkAborted(signal);
       await this.deleteMatches(pattern, bindings, remove);
     }
   }

--- a/src/sparql-engine-interface.ts
+++ b/src/sparql-engine-interface.ts
@@ -24,6 +24,14 @@ export interface SparqlRequest {
 
   /** Query timeout in milliseconds (defaults to 30 seconds). */
   timeoutMs?: number;
+
+  /**
+   * signal aborts the request: the execute promise rejects (with the
+   * signal's reason when it is an Error, else a generic abort error) and
+   * the evaluation is cancelled at the next pattern/join boundary. The
+   * engine composes it with the timeout — whichever fires first wins.
+   */
+  signal?: AbortSignal;
 }
 
 /**

--- a/src/wazoo-sparql-engine.test.ts
+++ b/src/wazoo-sparql-engine.test.ts
@@ -1,7 +1,10 @@
+import type * as rdfjs from "@rdfjs/types";
 import { assertEquals, assertRejects } from "@std/assert";
 import { DataFactory, XSD_BOOLEAN } from "@/term/mod.ts";
 import { MemoryStore as Store } from "@/store/memory-store.ts";
 import { SparqlSyntaxError } from "@/parser/syntax-error.ts";
+import { SparqlParser } from "@/parser/sparql-parser.ts";
+import { SparqlEvaluator } from "@/evaluator/sparql-evaluator.ts";
 import { WazooSparqlEngine } from "@/wazoo-sparql-engine.ts";
 
 const { blankNode, namedNode, literal, quad } = DataFactory;
@@ -4248,4 +4251,131 @@ Deno.test("WazooSparqlEngine - relative LOAD source resolves against request bas
   assertEquals(loaded.length, 1);
   assertEquals(loaded[0].subject.value, "http://example.org/s");
   await Deno.remove(dir, { recursive: true });
+});
+
+/* ------------------------------------------------------------------ */
+/* timeoutMs / signal enforcement (issue #122)                        */
+/*                                                                    */
+/* The end-of-request reject race (Comunica's shape) is exercised     */
+/* against HangingStore, whose match stream never ends — evaluation   */
+/* hangs until the request times out or aborts. The per-boundary      */
+/* cancellation checks are exercised without any race (evaluator-     */
+/* level call with a pre-aborted signal).                             */
+/* ------------------------------------------------------------------ */
+
+/**
+ * hangingStore returns a store whose match stream never emits data and
+ * never ends — matchQuads awaits the stream forever, so evaluation hangs
+ * until the request's timeout or abort fires the end-of-request race.
+ * Only the event surface matchQuads touches (on/read) exists at runtime;
+ * the cast papers over the full EventEmitter/Store interfaces.
+ */
+function hangingStore(): rdfjs.Store<rdfjs.Quad> {
+  const stream = new EventTarget() as unknown as rdfjs.Stream<rdfjs.Quad>;
+  (stream as unknown as { on(): void }).on = () => {};
+  (stream as unknown as { read(): Promise<never> }).read = () =>
+    new Promise<never>(() => {});
+  return { match: () => stream } as unknown as rdfjs.Store<rdfjs.Quad>;
+}
+
+Deno.test("WazooSparqlEngine - timeoutMs rejects with Comunica's message", async () => {
+  const engine = new WazooSparqlEngine({ store: hangingStore() });
+  await assertRejects(
+    () =>
+      engine.execute({
+        query: "SELECT ?s WHERE { ?s ?p ?o }",
+        timeoutMs: 20,
+      }),
+    Error,
+    "SPARQL query timed out",
+  );
+});
+
+Deno.test("WazooSparqlEngine - caller signal aborts a hanging request", async () => {
+  const engine = new WazooSparqlEngine({ store: hangingStore() });
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(new Error("caller cancelled")), 20);
+  await assertRejects(
+    () =>
+      engine.execute({
+        query: "SELECT ?s WHERE { ?s ?p ?o }",
+        signal: controller.signal,
+      }),
+    Error,
+    "caller cancelled",
+  );
+});
+
+Deno.test("WazooSparqlEngine - pre-aborted signal rejects immediately", async () => {
+  const store = new Store();
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/s"),
+      namedNode("http://example.org/p"),
+      literal("o"),
+    ),
+  );
+  const engine = new WazooSparqlEngine({ store });
+  const controller = new AbortController();
+  controller.abort(new Error("aborted before start"));
+  await assertRejects(
+    () =>
+      engine.execute({
+        query: "SELECT ?s WHERE { ?s ?p ?o }",
+        signal: controller.signal,
+      }),
+    Error,
+    "aborted before start",
+  );
+});
+
+Deno.test("WazooSparqlEngine - pre-aborted signal rejects updates too", async () => {
+  const engine = new WazooSparqlEngine({ store: new Store() });
+  const controller = new AbortController();
+  controller.abort(new Error("aborted update"));
+  await assertRejects(
+    () =>
+      engine.execute({
+        query:
+          "INSERT DATA { <http://example.org/s> <http://example.org/p> <http://example.org/o> }",
+        signal: controller.signal,
+      }),
+    Error,
+    "aborted update",
+  );
+});
+
+Deno.test("WazooSparqlEngine - boundary check aborts evaluation without the race", async () => {
+  // No execute() race here: the rejection can only come from the per-boundary
+  // checkAborted at evaluateBgp entry (the signal is threaded through the
+  // evaluator, issue #122 scope 2).
+  const evaluator = new SparqlEvaluator(new Store());
+  const query = new SparqlParser().parse("SELECT ?s WHERE { ?s ?p ?o }");
+  const controller = new AbortController();
+  controller.abort(new Error("stop at boundary"));
+  await assertRejects(
+    () => evaluator.evaluateQuery(query, controller.signal),
+    Error,
+    "stop at boundary",
+  );
+});
+
+Deno.test("WazooSparqlEngine - timeoutMs on a fast query still succeeds", async () => {
+  const store = new Store();
+  store.addQuad(
+    quad(
+      namedNode("http://example.org/s"),
+      namedNode("http://example.org/p"),
+      literal("o"),
+    ),
+  );
+  const engine = new WazooSparqlEngine({ store });
+  const result = await engine.execute({
+    query: "SELECT ?s WHERE { ?s ?p ?o }",
+    timeoutMs: 5_000,
+  });
+  assertEquals(result.kind, "select");
+  if (result.kind === "select") {
+    assertEquals(result.data.results.bindings.length, 1);
+  }
 });

--- a/src/wazoo-sparql-engine.ts
+++ b/src/wazoo-sparql-engine.ts
@@ -77,6 +77,24 @@ export interface WazooSparqlEngineOptions {
   estimator?: JoinCostEstimator;
 }
 
+/** Default SPARQL query timeout in milliseconds (matches Comunica). */
+const DEFAULT_SPARQL_TIMEOUT_MS = 30_000;
+
+/**
+ * abortReasonForSignal maps an aborted signal to the request's rejection
+ * error: the signal's own reason when it is an Error, else a clear abort
+ * error. The timeout aborts the engine controller with the exact Comunica
+ * message ("SPARQL query timed out"), so both the end-of-request race and
+ * the per-boundary checks surface the same error.
+ */
+function abortReasonForSignal(signal: AbortSignal | undefined): Error {
+  const reason = signal?.reason;
+  if (reason instanceof Error) {
+    return reason;
+  }
+  return new Error("SPARQL query aborted");
+}
+
 /**
  * WazooSparqlEngine is the Wazoo SPARQL 1.1 & 1.2 engine over RDFJS Store sources.
  */
@@ -110,33 +128,85 @@ export class WazooSparqlEngine implements SparqlEngineInterface {
     });
   }
 
-  /** execute runs a SPARQL query/update against the configured store. */
+  /**
+   * execute runs a SPARQL query/update against the configured store,
+   * enforcing timeoutMs and signal (issue #122): the request promise
+   * rejects on timeout or abort (Comunica's end-of-request shape), and the
+   * composed signal is threaded through the evaluator so cancellation also
+   * lands at the next pattern/join boundary.
+   */
   public async execute(request: SparqlRequest): Promise<SparqlResponse> {
-    const raw = request.query;
-    const baseIri = request.baseIri;
-    // The parse depends on the base (the grammar resolves prefix IRIs and
-    // records query.base from it), so the cache key carries it.
-    const cacheKey = baseIri === undefined ? raw : `${raw}\u0000${baseIri}`;
-    let ast = this.queryCache.get(cacheKey);
-    if (ast === undefined) {
-      ast = this.parser.parse(
-        raw,
-        baseIri === undefined ? undefined : { baseIRI: baseIri },
-      );
-      this.queryCache.set(cacheKey, ast);
-      if (this.queryCache.size > WazooSparqlEngine.QUERY_CACHE_MAX) {
-        const oldest = this.queryCache.keys().next().value;
-        if (oldest !== undefined) {
-          this.queryCache.delete(oldest);
-        }
+    // One controller composes the timeout and the caller's signal; aborting
+    // it with an Error reason makes both the race and the boundary checks
+    // throw the identical message. A manual timer (not AbortSignal.timeout)
+    // is cleared on completion, so a fast query never leaves a pending
+    // 30-second timer holding the process open.
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      controller.abort(new Error("SPARQL query timed out"));
+    }, request.timeoutMs ?? DEFAULT_SPARQL_TIMEOUT_MS);
+    const callerSignal = request.signal;
+    const onCallerAbort = (): void => {
+      controller.abort(abortReasonForSignal(callerSignal));
+    };
+    if (callerSignal !== undefined) {
+      if (callerSignal.aborted) {
+        onCallerAbort();
+      } else {
+        callerSignal.addEventListener("abort", onCallerAbort, { once: true });
       }
     }
-    if (ast.type === "update") {
-      // The parser folds the request base into the AST when the query has
-      // no BASE directive, so ast.base is the effective base either way.
-      await this.updateEvaluator.executeUpdate(ast, ast.base ?? baseIri);
-      return { kind: "void" };
+    const signal = controller.signal;
+    // The end-of-request reject race (Comunica's shape): whichever fires
+    // first — the evaluation's own error, the timeout, or the caller's
+    // abort — settles the request promise.
+    const abortPromise = new Promise<never>((_, reject) => {
+      if (signal.aborted) {
+        reject(abortReasonForSignal(signal));
+        return;
+      }
+      signal.addEventListener(
+        "abort",
+        () => reject(abortReasonForSignal(signal)),
+        { once: true },
+      );
+    });
+    try {
+      const raw = request.query;
+      const baseIri = request.baseIri;
+      // The parse depends on the base (the grammar resolves prefix IRIs and
+      // records query.base from it), so the cache key carries it.
+      const cacheKey = baseIri === undefined ? raw : `${raw}\u0000${baseIri}`;
+      let ast = this.queryCache.get(cacheKey);
+      if (ast === undefined) {
+        ast = this.parser.parse(
+          raw,
+          baseIri === undefined ? undefined : { baseIRI: baseIri },
+        );
+        this.queryCache.set(cacheKey, ast);
+        if (this.queryCache.size > WazooSparqlEngine.QUERY_CACHE_MAX) {
+          const oldest = this.queryCache.keys().next().value;
+          if (oldest !== undefined) {
+            this.queryCache.delete(oldest);
+          }
+        }
+      }
+      if (ast.type === "update") {
+        // The parser folds the request base into the AST when the query has
+        // no BASE directive, so ast.base is the effective base either way.
+        await Promise.race([
+          this.updateEvaluator.executeUpdate(ast, ast.base ?? baseIri, signal),
+          abortPromise,
+        ]);
+        return { kind: "void" };
+      }
+      return await Promise.race([
+        this.evaluator.evaluateQuery(ast, signal),
+        abortPromise,
+      ]);
+    } finally {
+      clearTimeout(timer);
+      callerSignal?.removeEventListener("abort", onCallerAbort);
     }
-    return await this.evaluator.evaluateQuery(ast);
   }
 }


### PR DESCRIPTION
Closes #122 — part of [map #2](https://github.com/wazootech/sparql-engine/issues/2), decision [Fork B](https://github.com/wazootech/sparql-engine/issues/113) (superset). Coordinated with the lockstep half in [wazootech/worlds-client-ts](https://github.com/wazootech/worlds-client-ts) (same interface copy + signal support in the Comunica engine) — both PRs must merge; the `interface-parity` gate on each repo flips green on the second merge.

## What

`SparqlRequest` gains `signal?: AbortSignal` (kept `timeoutMs`), and the engine finally enforces both:

- **`execute()` end-of-request reject race (Comunica's shape)** — one `AbortController` composes the timeout (default 30 s, matching Comunica's `DEFAULT_SPARQL_TIMEOUT_MS` and the interface's documented default) with the caller's signal; the request promise races against it, so timeout/abort rejects without cancelling the underlying query. Timeout rejects with Comunica's exact `"SPARQL query timed out"`; a caller abort forwards the signal's `Error` reason (else `"SPARQL query aborted"`). A manual `setTimeout` (not `AbortSignal.timeout`) is cleared on completion, so a fast query never leaves a 30 s timer holding a CLI process open.
- **Boundary threading (scope 2)** — the composed signal flows through `evaluateQuery` → `evaluateSelectTermBindings` / ASK / CONSTRUCT / DESCRIBE → `evaluateBgp` → `evaluateGroup` (per-pattern checkpoints, recursive into OPTIONAL/MINUS/UNION/GRAPH/group/service/subqueries) → `joinBgp` / `evaluateWithReordering` (per-join checkpoints), and through `executeUpdate` (per-operation + DELETE WHERE evaluation). The shared `checkAborted` throws the same reason the race rejects with, via `signal.throwIfAborted()`. Full streaming cancellation still lands with the #74 lazy-slice track, as #113 notes.

## Verification

- 6 new tests: timeout race (hanging store), in-flight caller abort, pre-aborted rejection (query and update), boundary-check cancellation without the race (evaluator-level call, no race involved), and timeout-on-fast-query still succeeding.
- `deno task ci` green — 460 tests, 0 failed (fmt/lint/check/parser/publish/W3C 1.1 + 1.2 gates).
- `deno task bench:check` — all budgets pass; eager path unchanged (signal is `undefined` → no-op checks; the race is per-request, not per-row).
- `interface-parity` intentionally red until the client PR merges (it diffs against `worlds-client-ts` `main`).

## Merge order

Either order; the second merge reconciles both parity gates. #148 (prototypes) is unrelated — the branch for this work was cut from `main` after #148's commit.
