### PR TITLE
docs: add worlds-sdk-ts-style header to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# [@wazoo/sparql-engine](https://jsr.io/@wazoo/sparql-engine)
+<p align="center">
+  <a href="https://docs.wazoo.dev">
+    <img src="https://wazoo.dev/assets/wazoo.svg" alt="Wazoo Worlds" width="120" />
+  </a>
+  <br /><br />
+  <em>Zero-dependency SPARQL 1.1 &amp; 1.2 query and update engine over RDF/JS quad stores.</em>
+  <br /><br />
+  <a href="https://jsr.io/@wazoo/sparql-engine"><img src="https://jsr.io/badges/@wazoo/sparql-engine" alt="JSR" /></a>
+  <a href="https://jsr.io/@wazoo/sparql-engine/score"><img src="https://jsr.io/badges/@wazoo/sparql-engine/score" alt="JSR Score" /></a>
+  <a href="https://github.com/wazootech/sparql-engine"><img src="https://img.shields.io/badge/GitHub-black?logo=github" alt="GitHub" /></a>
+  <a href="https://deepwiki.com/wazootech/sparql-engine"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
+</p>
 
 Wazoo [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) & 1.2 Query & Update
 Engine over RDF/JS Quad Stores.

--- a/test/interface-parity.ts
+++ b/test/interface-parity.ts
@@ -4,13 +4,14 @@
  *
  * The engine's public envelopes (`SparqlEngineInterface`, `SparqlRequest`,
  * `SparqlResponse`, and the result shapes) are duplicated in both packages and
- * must not drift. This fetches the canonical copy from `worlds-client-ts`
- * `main` and diffs it against the local file (line endings normalized), so a
- * single-sided edit fails CI here instead of silently forking the contract.
+ * must not drift. This fetches the canonical copy from `worlds-sdk-ts`
+ * `main` (the SDK repo, formerly `worlds-client-ts`) and diffs it against the
+ * local file (line endings normalized), so a single-sided edit fails CI here
+ * instead of silently forking the contract.
  */
 
 const WORLDS_INTERFACE_URL =
-  "https://raw.githubusercontent.com/wazootech/worlds-client-ts/main/src/client/sparql-engine/sparql-engine-interface.ts";
+  "https://raw.githubusercontent.com/wazootech/worlds-sdk-ts/main/src/client/sparql-engine/sparql-engine-interface.ts";
 
 const LOCAL_INTERFACE = new URL(
   "../src/sparql-engine-interface.ts",


### PR DESCRIPTION
Mirrors the centered logo/tagline/badge header introduced on worlds-sdk-ts: wazoo.svg logo, one-line tagline, and JSR / JSR Score / GitHub / DeepWiki badges for `@wazoo/sparql-engine`.