### PR TITLE
docs: fix malformed benchmark table and stale memory-model prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,13 +259,17 @@ per-group baseline). Each cell is the per-iteration average; every query is
 cross-verified to return identical results on all three engines before timing.
 Timings are machine-specific — run `deno task bench` for your own numbers.
 
-Core joins, 400-person graph (~2,200 quads):| query | wazoo | comunica |
-oxigraph | | ---------------------------- | -------- | -------- | -------- | |
-full scan | 1.1 ms | 6.0 ms | 8.8 ms | | join (knows × name) | 0.91 ms | 3.4 ms
-| 1.6 ms | | asymmetric join | 1.7 ms | 23.0 ms | 11.5 ms | | reorder chain,
-written order | 105.5 ms | 107.8 ms | 2.2 ms | | reorder chain, planner on | 1.5
-ms | — | — | | dp-join, DP plan | 62.2 ms | 190.4 ms | 1120 ms | | dp-join,
-greedy plan | 125.2 ms | — | — |
+Core joins, 400-person graph (~2,200 quads):
+
+| query                        | wazoo    | comunica | oxigraph |
+| ---------------------------- | -------- | -------- | -------- |
+| full scan                    | 1.1 ms   | 6.0 ms   | 8.8 ms   |
+| join (knows × name)          | 0.91 ms  | 3.4 ms   | 1.6 ms   |
+| asymmetric join              | 1.7 ms   | 23.0 ms  | 11.5 ms  |
+| reorder chain, written order | 105.5 ms | 107.8 ms | 2.2 ms   |
+| reorder chain, planner on    | 1.5 ms   | —        | —        |
+| dp-join, DP plan             | 62.2 ms  | 190.4 ms | 1120 ms  |
+| dp-join, greedy plan         | 125.2 ms | —        | —        |
 
 EXISTS surface, 400-person graph:
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -387,13 +387,22 @@ joins the pair set against the incoming bindings.
 
 ## Memory & asynchrony model
 
-- **Materialized, not lazy.** Every stage works on plain arrays:
-  `ScanEntry.candidates` is a fully drained
+- **Indexed scans at the store, lazy between patterns.** `ScanEntry.candidates`
+  is a fully drained
   [`matchQuads`](https://github.com/wazootech/sparql-engine/blob/main/src/quad-store.ts)
-  result; `TermBinding[]` arrays are threaded through pattern evaluation;
-  [`aggregateValue`](https://github.com/wazootech/sparql-engine/blob/main/src/evaluator/aggregate.ts)
-  groups hold raw solutions. The engine favors pre-fetched + indexed scans over
-  per-binding stream round trips.
+  result — the engine favors pre-fetched + indexed scans over per-binding stream
+  round trips — but a multi-pattern BGP composes generator joins
+  ([`joinTriplePatternLazy`](https://github.com/wazootech/sparql-engine/blob/main/src/evaluator/join.ts))
+  that stream the intermediate binding flow instead of materializing an array
+  per pattern. The eager array join
+  ([`joinTriplePattern`](https://github.com/wazootech/sparql-engine/blob/main/src/evaluator/join.ts))
+  remains the fast path for a single-pattern BGP (no chain to stream, and
+  measurably lighter for the unselective full-scan case), for the reordered BGP
+  path whose cost estimate needs the full materialized result set, and for the
+  synchronous EXISTS hooks. CONSTRUCT template instantiations emit per solution
+  straight into the dedup set, so peak holds the dedup key set plus the graph
+  instead of that plus every constructed quad (issue
+  [#74](https://github.com/wazootech/sparql-engine/issues/74)).
 - **Streams only at the store boundary.** `rdfjs.Stream` is consumed exactly
   once, in
   [`matchQuads`](https://github.com/wazootech/sparql-engine/blob/main/src/quad-store.ts)


### PR DESCRIPTION
## What

- README.md: the `Core joins` benchmark block was a single malformed line (header and cells jammed together, rendering as one paragraph). Rebuilt it as a proper markdown table matching the `EXISTS surface` tables below.
- docs/02-architecture.md: the `Materialized, not lazy` bullet contradicted the lazy-slice implementation (issue #127) and lazy CONSTRUCT dedup (issue #74). Rewrote it as `Indexed scans at the store, lazy between patterns` describing generator joins for multi-pattern BGPs, the eager join's remaining fast paths (single-pattern BGP, reordered path, EXISTS hooks), and CONSTRUCT per-solution dedup.

## Verification

- `deno fmt --check`: clean
- `deno task docs:link-check`: 77 links, 0 broken
- `deno task ci`: all subtasks green (460 tests passed)