### PR TITLE
docs: cite prior art inline at each technique site

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,84 @@ answer. Treat them as the operator's responsibility:
   strategy beats scanning it. Prefer selective predicates on the hot path —
   indexes help only when buckets are smaller than the full set.
 
+## Prior art & attribution
+
+This engine's performance work (join reordering, hash joins, positional indexes,
+streaming, EXISTS snapshots) and spec-driven semantics build on published
+research, standards, and reference books. Citations appear inline in the source
+at each technique site as stock JSDoc `@see` / `{@link}` tags; this section
+collects them for reference and is kept in sync by convention: any PR that adds
+a citation to the code adds the matching line here (and vice versa).
+
+### Research papers
+
+- Bernstein, P. A., & Chiu, D.-M. W. "Using Semi-Joins to Solve Relational
+  Queries." Journal of the ACM 28(1), 1981, pp. 25–40.
+  https://doi.org/10.1145/322234.322238
+- Goldberg, D. "What Every Computer Scientist Should Know About Floating-Point
+  Arithmetic." ACM Computing Surveys 23(1), 1991, pp. 5–48.
+  https://doi.org/10.1145/103162.103163
+- Graefe, G. "Query Evaluation Techniques for Large Databases." ACM Computing
+  Surveys 25(2), 1993, pp. 73–170. https://doi.org/10.1145/152610.152611
+- Graefe, G. "Volcano — An Extensible and Parallel Query Evaluation System."
+  IEEE Transactions on Knowledge and Data Engineering 6(1), 1994, pp. 120–135.
+  https://doi.org/10.1109/69.273032
+- Gupta, A., & Mumick, I. S. "Maintenance of Materialized Views: Problems,
+  Techniques and Applications." IEEE Data Engineering Bulletin 18(2), 1995, pp.
+  3–18. https://dblp.org/rec/journals/debu/GuptaM95.html
+- Hartig, O. "Foundations of RDF* and SPARQL* (An Alternative Approach to
+  Statement-Level Metadata in Linked Data)." Proc. 11th Alberto Mendelzon Intl.
+  Workshop on Foundations of Data Management (AMW), CEUR-WS Vol-1912, 2017.
+  https://ceur-ws.org/Vol-1912/paper12.pdf
+- Kitsuregawa, M., Tanaka, H., & Yamamori, T. "Architecture and Performance of
+  Relational Algebra Machine GRACE." Proc. Intl. Conf. on Parallel Processing
+  (ICPP), 1983, pp. 241–250.
+- Kostylev, E. V., Reutter, J. L., Romero, M., & Vrgoč, D. "SPARQL with Property
+  Paths." Proc. 14th Intl. Semantic Web Conf. (ISWC 2015), LNCS 9366, Springer,
+  2015, pp. 3–18. https://doi.org/10.1007/978-3-319-25007-6_1
+- Neumann, T., & Weikum, G. "RDF-3X: A RISC-Style Engine for RDF." Proc. VLDB
+  Endowment 1(1), 2008, pp. 647–659. https://doi.org/10.14778/1453856.1453927
+- Pérez, J., Arenas, M., & Gutierrez, C. "Semantics and Complexity of SPARQL."
+  ACM Transactions on Database Systems 34(3), 2009, art. 16.
+  https://doi.org/10.1145/1567274.1567278
+- Selinger, P. G., Astrahan, M. M., Chamberlin, D. D., Lorie, R. A., & Price, T.
+  G. "Access Path Selection in a Relational Database Management System." Proc.
+  ACM SIGMOD, 1979, pp. 23–34. https://doi.org/10.1145/582095.582099
+- Sellis, T. K. "Multiple-Query Optimization." ACM Transactions on Database
+  Systems 13(1), 1988, pp. 23–52. https://doi.org/10.1145/42201.42203
+- Shapiro, L. D. "Join Processing in Database Systems with Large Main Memories."
+  ACM Transactions on Database Systems 11(3), 1986, pp. 239–264.
+  https://doi.org/10.1145/6314.6315
+- Stocker, M., Seaborne, A., Bernstein, A., Kiefer, C., & Reynolds, D. "SPARQL
+  Basic Graph Pattern Optimization Using Selectivity Estimation." Proc. 17th
+  Intl. World Wide Web Conf. (WWW '08), ACM, 2008, pp. 595–604.
+  https://doi.org/10.1145/1367497.1367578
+- Weiss, C., Karras, P., & Bernstein, A. "Hexastore: Sextuple Indexing for
+  Semantic Web Data Management." Proc. VLDB Endowment 1(1), 2008, pp. 1008–1019.
+  https://doi.org/10.14778/1453856.1453965
+
+### Standards & RFCs
+
+- Harris, S., & Seaborne, A. (eds.). "SPARQL 1.1 Query Language." W3C
+  Recommendation, 21 March 2013. https://www.w3.org/TR/sparql11-query/
+- Malhotra, A., Melton, J., & Walsh, N. (eds.). "XQuery 1.0 and XPath 2.0
+  Functions and Operators (Second Edition)." W3C Recommendation, 14
+  December 2010. https://www.w3.org/TR/2010/REC-xpath-functions-20101214/
+- National Institute of Standards and Technology. "Secure Hash Standard (SHS)."
+  FIPS PUB 180-4, August 2015.
+  https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
+- "RDF 1.2 Concepts and Abstract Data Model." W3C Candidate Recommendation, 7
+  April 2026. https://www.w3.org/TR/rdf12-concepts/
+- Rivest, R. "The MD5 Message-Digest Algorithm." IETF RFC 1321, April 1992.
+  https://www.rfc-editor.org/rfc/rfc1321
+
+### Reference books
+
+- Aho, A. V., Sethi, R., & Ullman, J. D. "Compilers: Principles, Techniques, and
+  Tools." Addison-Wesley, 1986, ch. 4 (syntax analysis, LR parsing).
+- Cormen, T. H., Leiserson, C. E., Rivest, R. L., & Stein, C. "Introduction to
+  Algorithms," 3rd ed. MIT Press, 2009, §22.2 (breadth-first search).
+
 ## Releases
 
 Every merge to `main` runs the Publish workflow. Following the standard JSR

--- a/src/evaluator/aggregate.ts
+++ b/src/evaluator/aggregate.ts
@@ -38,6 +38,12 @@ export type SolutionGroup = {
  * the same value (undefined values group together). The key binding carries
  * each group expression's value under its variable when the expression is a
  * variable or carries an AS ?v alias; bare expressions only partition.
+ *
+ * Prior art: partitioning by a hashed group key (each solution hashes its
+ * group-expression values and appends to the matching bucket) is
+ * hash-based grouping/aggregation, the classic main-memory aggregation
+ * strategy.
+ * @see {@link https://doi.org/10.1145/152610.152611 Graefe, "Query Evaluation Techniques for Large Databases," ACM Computing Surveys 25(2), 1993, pp. 73–170}
  */
 export function groupSolutions(
   solutions: TermBinding[],
@@ -262,6 +268,12 @@ function numericLiteral(
  * "11.100000000000001"). Each term parses to a BigInt significand and a
  * scale; scales align to the maximum and the sum renders with trailing
  * fractional zeros stripped.
+ *
+ * Prior art: fixed-point arithmetic on (BigInt significand, scale) pairs
+ * — summing scaled integers instead of binary floats — avoids the
+ * rounding error that Goldberg's analysis shows in naive floating-point
+ * accumulation.
+ * @see {@link https://doi.org/10.1145/103162.103163 Goldberg, "What Every Computer Scientist Should Know About Floating-Point Arithmetic," ACM Computing Surveys 23(1), 1991, pp. 5–48}
  */
 function exactDecimalSum(defined: rdfjs.Term[]): rdfjs.Literal {
   let maxScale = 0;

--- a/src/evaluator/bgp-evaluator.ts
+++ b/src/evaluator/bgp-evaluator.ts
@@ -88,6 +88,13 @@ export interface BgpEvaluatorOptions {
    * is already bound by earlier joins is processed early even when it has
    * many candidates. Defaults to true. Disabling it preserves written order
    * exactly.
+   *
+   * Prior art: greedy BGP join ordering driven by per-pattern selectivity
+   * estimates — each pattern scanned once, then joined in ascending
+   * estimated cost — is the approach of Stocker et al., rooted in System
+   * R's cost-based join ordering and access-path selection.
+   * @see {@link https://doi.org/10.1145/1367497.1367578 Stocker et al., "SPARQL Basic Graph Pattern Optimization Using Selectivity Estimation," WWW '08, ACM, 2008, pp. 595–604}
+   * @see {@link https://doi.org/10.1145/582095.582099 Selinger et al., "Access Path Selection in a Relational Database Management System," SIGMOD '79, pp. 23–34}
    */
   reorderPatterns?: boolean;
 
@@ -121,6 +128,14 @@ export interface BgpEvaluatorOptions {
  * extend pass, GRAPH a graph-scoped evaluation over a scoped store view,
  * and nested groups recurse. Unsupported pattern types (SERVICE) raise a
  * clear error rather than being silently dropped.
+ *
+ * Prior art: the algebra translations — OPTIONAL as LeftJoin(P1, P2, F),
+ * MINUS as a shared-variable anti-join, BIND as Extend, VALUES as a
+ * natural join, UNION as Join(P, Union(Q1, Q2)) — follow the formal SPARQL
+ * algebra of Pérez, Arenas & Gutierrez, as adopted by the SPARQL 1.1 spec
+ * §18.2.
+ * @see {@link https://doi.org/10.1145/1567274.1567278 Pérez, Arenas & Gutierrez, "Semantics and Complexity of SPARQL," ACM TODS 34(3), 2009, art. 16}
+ * @see {@link https://www.w3.org/TR/sparql11-query/ Harris & Seaborne (eds.), "SPARQL 1.1 Query Language," W3C Recommendation, 2013}
  */
 export class BgpEvaluator {
   private readonly reorderPatterns: boolean;
@@ -212,6 +227,15 @@ export class BgpEvaluator {
    * The SparqlEvaluator calls it for projection / ORDER BY / HAVING
    * expressions when they contain EXISTS even though the WHERE clause does
    * not.
+   *
+   * Prior art: evaluating a correlated EXISTS as a semi-join — probe the
+   * (once-drained, once-indexed) candidate set per outer solution instead
+   * of re-evaluating the subquery — is the semi-join reduction of
+   * Bernstein & Chiu; keeping the snapshot across queries with a
+   * mutation-version check is a materialized-view cache with lazy
+   * invalidation.
+   * @see {@link https://doi.org/10.1145/322234.322238 Bernstein & Chiu, "Using Semi-Joins to Solve Relational Queries," JACM 28(1), 1981, pp. 25–40}
+   * @see {@link https://dblp.org/rec/journals/debu/GuptaM95.html Gupta & Mumick, "Maintenance of Materialized Views: Problems, Techniques and Applications," IEEE Data Eng. Bulletin 18(2), 1995, pp. 3–18}
    */
   public async prepareExistsIndex(): Promise<ExistsSnapshot> {
     const version = storeVersion(this.store);
@@ -790,6 +814,12 @@ export class BgpEvaluator {
    * step. Nested group calls (OPTIONAL/MINUS/UNION/GRAPH bodies, subquery
    * WHEREs) resolve their own groups eagerly here, so their results arrive
    * as arrays; only the enclosing group's own solution flow streams.
+   *
+   * Prior art: pushing solutions through the pattern chain as a streaming
+   * iterator — each operator pulls rows from the previous one instead of
+   * materializing per-step arrays — is the Volcano iterator/pipeline model
+   * of query evaluation.
+   * @see {@link https://doi.org/10.1109/69.273032 Graefe, "Volcano — An Extensible and Parallel Query Evaluation System," IEEE TKDE 6(1), 1994, pp. 120–135}
    */
   private async evaluateGroup(
     patterns: Pattern[],
@@ -1175,6 +1205,10 @@ export class BgpEvaluator {
    * estimate needs the full current result set, so each join materializes
    * here (the reordered path stays eager; the lazy chain applies to the
    * written-order path).
+   * (Prior art: greedy selectivity-based BGP reordering and cost-based
+   * join ordering — see BgpEvaluatorOptions.reorderPatterns:
+   * {@link https://doi.org/10.1145/1367497.1367578 Stocker et al., "SPARQL Basic Graph Pattern Optimization Using Selectivity Estimation," WWW '08, ACM, 2008, pp. 595–604};
+   * {@link https://doi.org/10.1145/582095.582099 Selinger et al., "Access Path Selection in a Relational Database Management System," SIGMOD '79, pp. 23–34}.)
    */
   private async evaluateWithReordering(
     triplePatterns: Triple[],

--- a/src/evaluator/expression-evaluator.ts
+++ b/src/evaluator/expression-evaluator.ts
@@ -176,6 +176,14 @@ export interface ExpressionEvaluatorOptions {
  * ExpressionEvaluator evaluates SPARQL 1.1 expression trees (operators,
  * functions, and constants) against a single solution binding, returning a
  * value term or a typed error term for runtime failures.
+ *
+ * Prior art: SPARQL 1.1 §17 delegates the semantics of its built-in
+ * functions and operators to XQuery/XPath 2.0 — string, numeric, date/time
+ * and boolean functions, casts, and the canonical value-space rules (e.g.
+ * SUBSTR, REGEX, the numeric promotion rules, and the canonical double
+ * lexical form) follow that specification.
+ * @see {@link https://www.w3.org/TR/2010/REC-xpath-functions-20101214/ Malhotra, Melton & Walsh (eds.), "XQuery 1.0 and XPath 2.0 Functions and Operators (Second Edition)," W3C Recommendation, 2010}
+ * @see {@link https://www.w3.org/TR/sparql11-query/ Harris & Seaborne (eds.), "SPARQL 1.1 Query Language," W3C Recommendation, 2013}
  */
 export class ExpressionEvaluator {
   /** functions is the registry of custom IRI function evaluators. */
@@ -1100,6 +1108,9 @@ export class ExpressionEvaluator {
    * 1-based start, optional length, positions before 1 clipped, a negative
    * or zero length yielding the empty string. Non-integer positions are a
    * type error, matching the reference engines.
+   * (Prior art: XPath/XQuery F&O `fn:substring` —
+   * {@link https://www.w3.org/TR/2010/REC-xpath-functions-20101214/ XQuery 1.0 and XPath 2.0 Functions and Operators (Second Edition), W3C Recommendation, 2010},
+   * cited on ExpressionEvaluator.)
    */
   private substr(
     expressions: Expression[],
@@ -1705,6 +1716,10 @@ export class ExpressionEvaluator {
    * pattern or flags, or a non-string argument, is an evaluation error
    * (unbound) — the reference engine throws on malformed patterns, which is
    * a deviation we deliberately do not replicate.
+   * (Prior art: XPath/XQuery F&O `fn:matches` semantics, evaluated through
+   * the host ECMAScript regex engine —
+   * {@link https://www.w3.org/TR/2010/REC-xpath-functions-20101214/ XQuery 1.0 and XPath 2.0 Functions and Operators (Second Edition), W3C Recommendation, 2010},
+   * cited on ExpressionEvaluator.)
    */
   private regex(
     args: Expression[],

--- a/src/evaluator/join.ts
+++ b/src/evaluator/join.ts
@@ -353,12 +353,22 @@ function* minusStreamNested(
 /* the whole right side, turning the O(n·m) nested loop into a probe  */
 /* of O(n) buckets. Multiset semantics are preserved: every compatible */
 /* pair still produces its merged binding, duplicates included.       */
+/*                                                                    */
+/* Prior art: the build-once-index-probe-per-tuple in-memory hash     */
+/* join is the classic scheme of Shapiro (and GRACE):                 */
+/*   @see {@link https://doi.org/10.1145/6314.6315 Shapiro, "Join Processing in Database Systems with Large Main Memories," ACM TODS 11(3), 1986, pp. 239–264} */
+/*   @see Kitsuregawa, Tanaka & Yamamori, "Architecture and Performance of Relational Algebra Machine GRACE," ICPP, 1983, pp. 241–250 */
 /* ------------------------------------------------------------------ */
 
 /**
  * JOIN_PRODUCT_THRESHOLD is the pair count below which the nested loop is
  * kept: hash-setup (indexing the right side) costs more than the scan it
  * saves for tiny joins.
+ *
+ * Prior art: choosing a join method from an estimated cost (here the
+ * product of the input sizes) is cost-based join-method selection.
+ * @see {@link https://doi.org/10.1145/152610.152611 Graefe, "Query Evaluation Techniques for Large Databases," ACM Computing Surveys 25(2), 1993, pp. 73–170}
+ * @see {@link https://doi.org/10.1145/582095.582099 Selinger et al., "Access Path Selection in a Relational Database Management System," SIGMOD '79, pp. 23–34}
  */
 const JOIN_PRODUCT_THRESHOLD = 4096;
 
@@ -368,6 +378,9 @@ const JOIN_PRODUCT_THRESHOLD = 4096;
  * unknown without materializing, so the product threshold cannot apply, but
  * a right side this small keeps the nested loop cheap for any left length.
  * Larger right sides dispatch to the (inherently eager) hash index.
+ * (Same cost-based method-selection prior art as JOIN_PRODUCT_THRESHOLD:
+ * {@link https://doi.org/10.1145/152610.152611 Graefe, "Query Evaluation Techniques for Large Databases," ACM Computing Surveys 25(2), 1993, pp. 73–170};
+ * {@link https://doi.org/10.1145/582095.582099 Selinger et al., "Access Path Selection in a Relational Database Management System," SIGMOD '79, pp. 23–34}.)
  */
 const STREAM_NESTED_THRESHOLD = 64;
 
@@ -513,6 +526,10 @@ function buildHashIndex(
  * construction, plus the (usually few) partial rights it agrees with. A
  * partial l probes the bucket of its most selective bound variable and
  * verifies, plus partial rights that do not bind that variable.
+ *
+ * Prior art: probing the bucket with the fewest candidates (most selective
+ * bound variable) is access-path selection on the join key.
+ * @see {@link https://doi.org/10.1145/582095.582099 Selinger et al., "Access Path Selection in a Relational Database Management System," SIGMOD '79, pp. 23–34}
  */
 function compatibleCandidates(
   l: TermBinding,
@@ -1080,6 +1097,11 @@ export function isMultisetPath(path: PathElement): boolean {
  * set is computed from every graph node. Pair sets are deduplicated unless the
  * path is multiset, matching SPARQL's path semantics (each pair appears once
  * regardless of how many routes connect it unless the operator is multiset).
+ *
+ * Prior art: anchoring the walk at a constant endpoint (instead of
+ * exploring every node) computes only the reachable set from the bound
+ * end — the standard directed-evaluation optimization for reachability
+ * queries. {@link https://doi.org/10.1007/978-3-319-25007-6_1 Kostylev et al., "SPARQL with Property Paths," ISWC 2015, LNCS 9366, pp. 3–18} (see also pathSteps)
  */
 export async function scanPathEntry(
   store: rdfjs.Source<rdfjs.Quad>,
@@ -1273,6 +1295,14 @@ async function graphNodes(
  * In forward direction term is the path subject and the result is the set of
  * reachable objects; in backward direction term is the path object and the
  * result is the set of reachable subjects. Results are deduplicated.
+ *
+ * Prior art: the semantics are the W3C property-path semantics (SPARQL
+ * 1.1 §9.1), formalized by Kostylev et al.; the closures for the * and +
+ * operators are breadth-first traversals over the anchored node (CLRS
+ * §22.2).
+ * @see {@link https://doi.org/10.1007/978-3-319-25007-6_1 Kostylev et al., "SPARQL with Property Paths," ISWC 2015, LNCS 9366, pp. 3–18}
+ * @see {@link https://www.w3.org/TR/sparql11-query/ Harris & Seaborne (eds.), "SPARQL 1.1 Query Language," W3C Recommendation, 2013}
+ * @see Cormen, Leiserson, Rivest & Stein, "Introduction to Algorithms," 3rd ed., MIT Press, 2009, §22.2 (breadth-first search)
  */
 async function pathSteps(
   store: rdfjs.Source<rdfjs.Quad>,

--- a/src/evaluator/reified.ts
+++ b/src/evaluator/reified.ts
@@ -84,6 +84,13 @@ function expandQuotedTerm(term: SparqlTerm): ExpandedTerm {
  * `<< s p o ~ r >>`, or an explicit `?r rdf:reifies <<( s p o )>>` — passes
  * through with only its reifier side expanded: the object is a data triple
  * term and is decomposed by the join, never re-expanded.
+ *
+ * Prior art: materializing statement-level metadata as reifier resources
+ * connected by `rdf:reifies` — instead of storing quoted triples as
+ * first-class terms — is the RDF 1.2 reification representation, with the
+ * alternative RDF-star/triple-term model formalized by Hartig.
+ * @see {@link https://ceur-ws.org/Vol-1912/paper12.pdf Hartig, "Foundations of RDF* and SPARQL*," AMW 2017, CEUR-WS Vol-1912}
+ * @see {@link https://www.w3.org/TR/rdf12-concepts/ "RDF 1.2 Concepts and Abstract Data Model," W3C Candidate Recommendation, 2026}
  */
 export function expandReifiedTriples(triples: Triple[]): Triple[] {
   const expanded: Triple[] = [];

--- a/src/evaluator/select-pipeline.ts
+++ b/src/evaluator/select-pipeline.ts
@@ -54,6 +54,13 @@ export function pipelineNeedsExistsIndex(query: SelectQuery): boolean {
  * shared by the async SparqlEvaluator (which evaluates the WHERE over the
  * store) and the synchronous EXISTS subquery path (which evaluates it over
  * the graph-scoped candidate snapshot). One pipeline, both call sites.
+ *
+ * Prior art: the stage order — VALUES as a natural join, GROUP BY /
+ * aggregates, HAVING, ORDER BY, projection, then DISTINCT/REDUCED and
+ * OFFSET/LIMIT — follows the SPARQL 1.1 evaluation order (§18.2.4–§18.5)
+ * over the formal algebra of Pérez, Arenas & Gutierrez.
+ * @see {@link https://www.w3.org/TR/sparql11-query/ Harris & Seaborne (eds.), "SPARQL 1.1 Query Language," W3C Recommendation, 2013}
+ * @see {@link https://doi.org/10.1145/1567274.1567278 Pérez, Arenas & Gutierrez, "Semantics and Complexity of SPARQL," ACM TODS 34(3), 2009, art. 16}
  */
 export function applySelectPipeline(
   rawBindings: TermBinding[],

--- a/src/evaluator/update-evaluator.ts
+++ b/src/evaluator/update-evaluator.ts
@@ -610,6 +610,12 @@ export class UpdateEvaluator {
    * the store exactly once; the resulting candidates are indexed positionally
    * and probed in memory per solution. Unbound variables skip the triple;
    * blank nodes act as wildcards.
+   *
+   * Prior art: running one store scan per template and probing its indexed
+   * candidates for every solution — instead of re-scanning per solution —
+   * shares one access path across many evaluations, the multiple-query
+   * optimization idea of Sellis.
+   * @see {@link https://doi.org/10.1145/42201.42203 Sellis, "Multiple-Query Optimization," ACM TODS 13(1), 1988, pp. 23–52}
    */
   private async deleteMatches(
     pattern: Pattern,

--- a/src/parser/generate-parser.ts
+++ b/src/parser/generate-parser.ts
@@ -7,6 +7,12 @@
  *   jison lib/sparql.jison -p slr -m js -o lib/SparqlParser.js
  *   echo 'module.exports=SparqlParser' >> lib/SparqlParser.js
  *
+ * Prior art: the generated parsers are table-driven LR (SLR) parsers built
+ * from a context-free grammar — the classic compiler-construction
+ * technique of Aho, Sethi & Ullman (the grammar itself is sparqljs 3.7.4's
+ * jison grammar; see README.md).
+ * @see Aho, Sethi & Ullman, "Compilers: Principles, Techniques, and Tools," Addison-Wesley, 1986, ch. 4 (syntax analysis, LR parsing)
+ *
  * then post-processes the output into ESM/TS:
  *
  *   - inlines `Wildcard` (upstream `lib/Wildcard.js`) so the generated SPARQL

--- a/src/quad-store.ts
+++ b/src/quad-store.ts
@@ -12,6 +12,15 @@ import { DataFactory, sameRdfTerm, termKey } from "@/term/mod.ts";
  * carrying that term, enabling O(1) bucket probes per solution. It backs
  * both the BGP hash join and the batched DELETE scans, so both paths probe
  * with identical semantics.
+ *
+ * Prior art: probing a pre-built positional bucket index instead of
+ * re-scanning is the RDF-store index pattern of RDF-3X and Hexastore
+ * (every quad is mirrored into per-position indexes so any constrained
+ * pattern scans only its bucket), and picking the smallest constrained
+ * bucket to probe is System R access-path selection.
+ * @see {@link https://doi.org/10.14778/1453856.1453927 Neumann & Weikum, "RDF-3X: A RISC-Style Engine for RDF," PVLDB 1(1), 2008, pp. 647–659}
+ * @see {@link https://doi.org/10.14778/1453856.1453965 Weiss, Karras & Bernstein, "Hexastore: Sextuple Indexing for Semantic Web Data Management," PVLDB 1(1), 2008, pp. 1008–1019}
+ * @see {@link https://doi.org/10.1145/582095.582099 Selinger et al., "Access Path Selection in a Relational Database Management System," SIGMOD '79, pp. 23–34}
  */
 export interface QuadIndex {
   bySubject: Map<string, rdfjs.Quad[]>;

--- a/src/store/memory-store.ts
+++ b/src/store/memory-store.ts
@@ -270,6 +270,14 @@ function unindexPosition(
  * map keyed by all four positions and mirrored into four positional indexes
  * (subject / predicate / object / graph), so match scans only the smallest
  * constrained bucket instead of the whole store.
+ *
+ * Prior art: the mirror-into-per-position-indexes design (any pattern
+ * resolves through one bucket rather than a full scan) is the RDF-store
+ * index pattern of RDF-3X and Hexastore, and probing the smallest
+ * constrained bucket is System R-style access-path selection.
+ * @see {@link https://doi.org/10.14778/1453856.1453927 Neumann & Weikum, "RDF-3X: A RISC-Style Engine for RDF," PVLDB 1(1), 2008, pp. 647–659}
+ * @see {@link https://doi.org/10.14778/1453856.1453965 Weiss, Karras & Bernstein, "Hexastore: Sextuple Indexing for Semantic Web Data Management," PVLDB 1(1), 2008, pp. 1008–1019}
+ * @see {@link https://doi.org/10.1145/582095.582099 Selinger et al., "Access Path Selection in a Relational Database Management System," SIGMOD '79, pp. 23–34}
  */
 export class MemoryStore implements rdfjs.Store<rdfjs.Quad> {
   private quads: Map<string, rdfjs.Quad> = new Map();

--- a/src/term/hash.ts
+++ b/src/term/hash.ts
@@ -4,6 +4,12 @@
  * evaluator can call them without awaiting. SHA-1/SHA-256 use 32-bit word
  * arithmetic; SHA-384/SHA-512 use BigInt for the 64-bit words. All five
  * return lowercase hexadecimal strings of the digest.
+ *
+ * Prior art: the algorithms are the standard published message digests —
+ * MD5 per IETF RFC 1321 and the SHA family per NIST FIPS 180-4 (which
+ * SPARQL 1.1 §17.4.1.7 delegates to).
+ * @see {@link https://www.rfc-editor.org/rfc/rfc1321 Rivest, "The MD5 Message-Digest Algorithm," IETF RFC 1321, 1992}
+ * @see {@link https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf NIST, "Secure Hash Standard (SHS)," FIPS PUB 180-4, 2015}
  */
 
 const MD5_S = [

--- a/src/term/ordering.ts
+++ b/src/term/ordering.ts
@@ -63,6 +63,12 @@ function compareLiterals(a: rdfjs.Literal, b: rdfjs.Literal): number {
  * object, recursively. Blank-node labels and the relative order of terms the
  * spec leaves undefined are compared deterministically. Returns a negative,
  * zero, or positive number suitable for Array.prototype.sort.
+ *
+ * Prior art: the ordering rules are SPARQL 1.1 §12.4 (ORDER BY), with the
+ * cross-datatype numeric comparisons following the XPath 2.0 value
+ * ordering the spec delegates to.
+ * @see {@link https://www.w3.org/TR/sparql11-query/ Harris & Seaborne (eds.), "SPARQL 1.1 Query Language," W3C Recommendation, 2013}
+ * @see {@link https://www.w3.org/TR/2010/REC-xpath-functions-20101214/ Malhotra, Melton & Walsh (eds.), "XQuery 1.0 and XPath 2.0 Functions and Operators (Second Edition)," W3C Recommendation, 2010}
  */
 export function compareRdfTerms(
   a: rdfjs.Term | undefined,


### PR DESCRIPTION
Closes #138.

## Summary

Credits the engine's external prior art — join reordering, hash joins + method dispatch, positional SPO/G indexes, Volcano-style streaming, EXISTS semi-join snapshots, property paths, SPARQL algebra, hash functions, term ordering — with **stock JSDoc `@see` / `{@link}` citations placed inline at each technique site**, plus a hand-maintained README bibliography.

This lands the final decision from #138: the earlier `PRIOR_ART` registry design (`src/prior-art.ts` + `@cite PRIOR_ART.<KEY>` indirection) was dropped after review — it shipped a runtime module nothing imported, added an unenforced key convention, and was foreign to how citations normally work in a JS codebase. See the design-note comment on #138 for the full comparison.

## What changed

- **41 technique sites across 12 files** now carry their full citation inline (`@see {@link …}` for standalone tags, `{@link …}` for mid-sentence references). No key indirection — a reader of `join.ts` sees "Shapiro, ACM TODS 11(3), 1986" directly.
- **`src/prior-art.ts` deleted** (added and removed across the branch, so the net diff is comment-only).
- **README.md**: `## Prior art & attribution` bibliography kept as a plain, hand-maintained list of all cited sources (research papers / standards & RFCs / reference books), with the intro updated to describe the inline-citation convention.

## Verification

- Comment-only change: no runtime code, package entrypoints, or closure sizes affected.
- All cited links verified to resolve (DOIs via Crossref API, standards/RFC/CEUR/NIST/W3C directly).
- `deno fmt --check`, `deno lint`, `deno check` pass; full test suite **460 passed / 0 failed**.
