### PR TITLE
docs: reference @worlds/sdk for the retired Comunica adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       # conformance checks so a subquery-in-EXISTS regression fails here too.
       - run: deno task test:exists-ref
   # Identical-spec parity gate: src/sparql-engine-interface.ts must match
-  # @worlds/client's copy (line endings normalized). A single-sided edit fails
+  # @worlds/sdk's copy (line endings normalized). A single-sided edit fails
   # this job instead of silently forking the shared SparqlEngineInterface.
   interface-parity:
     runs-on: ubuntu-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,11 +45,11 @@ Any external `rdfjs.Store` works — e.g. `@worlds/sqlite`'s `SqliteStore`, or
 `WazooSparqlEngine` implements `SparqlEngineInterface`, the same contract
 `@worlds/sdk`'s durable client factories (`createLibsqlClient`,
 `createDenokvClient`, `createSqliteSdk`) wire into every `Sdk`. The former
-`@worlds/client` `ComunicaSparqlEngine` adapter (which this engine used to
-mirror as a drop-in replacement) was removed from the SDK on 2026-08-17; the
-wazoo engine is now the only shipped engine. `WazooSparqlTransaction` mirrors
-the structural shape of `@worlds/sdk`'s `Transaction`, so durable backends can
-pass their existing transaction objects.
+`@worlds/sdk` `ComunicaSparqlEngine` adapter (which this engine used to mirror
+as a drop-in replacement) was removed from the SDK on 2026-08-17; the wazoo
+engine is now the only shipped engine. `WazooSparqlTransaction` mirrors the
+structural shape of `@worlds/sdk`'s `Transaction`, so durable backends can pass
+their existing transaction objects.
 
 The interface is intentionally duplicated in `@worlds/sdk` under an
 identical-spec policy: the two copies must stay identical (gated by

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,10 +7,10 @@
   implements and `@worlds/sdk`'s durable client factories wire into every `Sdk`.
   The interface is duplicated identically in `@worlds/sdk` under an
   identical-spec policy; reconcile any drift deliberately.
-- **ComunicaSparqlEngine** — the retired `@worlds/client` adapter
-  (`@worlds/client/comunica`) that `WazooSparqlEngine` used to mirror as a
-  drop-in replacement. The SDK removed the adapter on 2026-08-17; Comunica now
-  lives on only as a parity reference in this repo's differential harness.
+- **ComunicaSparqlEngine** — the retired `@worlds/sdk` adapter
+  (`@worlds/sdk/comunica`) that `WazooSparqlEngine` used to mirror as a drop-in
+  replacement. The SDK removed the adapter on 2026-08-17; Comunica now lives on
+  only as a parity reference in this repo's differential harness.
 - **Parity reference** — the installed `@comunica/query-sparql-rdfjs-lite`
   (5.3.0) that the wazoo engine is measured against. The porting surface is the
   lite config (`config-rdfjs-lite-v5-1-3.json` in the Comunica monorepo).

--- a/docs/06-supplemental-context.md
+++ b/docs/06-supplemental-context.md
@@ -93,8 +93,8 @@ label identity.
   with the parity reference.
 - **SparqlEngineInterface** — the shared execution contract; duplicated
   identically in `@worlds/sdk` under an identical-spec policy.
-- **ComunicaSparqlEngine** — the retired `@worlds/client` adapter
-  (`@worlds/client/comunica`) the wazoo engine used to mirror; removed from the
+- **ComunicaSparqlEngine** — the retired `@worlds/sdk` adapter
+  (`@worlds/sdk/comunica`) the wazoo engine used to mirror; removed from the
   SDK, kept only as a parity reference.
 - **Parity reference** — the installed `@comunica/query-sparql-rdfjs-lite`; the
   porting surface is its lite config.


### PR DESCRIPTION
Cleanup after the \@worlds/client\ -> \@worlds/sdk\ rename. \@worlds/client\ now means the generated data-plane HTTP client; this fixes references that mean the SDK.