### PR TITLE
docs: update backend factory name to createLibsqlSdk

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,13 +43,13 @@ Any external `rdfjs.Store` works — e.g. `@worlds/sqlite`'s `SqliteStore`, or
 ## Relationship to @worlds/sdk
 
 `WazooSparqlEngine` implements `SparqlEngineInterface`, the same contract
-`@worlds/sdk`'s durable client factories (`createLibsqlClient`,
-`createDenokvClient`, `createSqliteSdk`) wire into every `Sdk`. The former
-`@worlds/sdk` `ComunicaSparqlEngine` adapter (which this engine used to mirror
-as a drop-in replacement) was removed from the SDK on 2026-08-17; the wazoo
-engine is now the only shipped engine. `WazooSparqlTransaction` mirrors the
-structural shape of `@worlds/sdk`'s `Transaction`, so durable backends can pass
-their existing transaction objects.
+`@worlds/sdk`'s durable backend factory (`createLibsqlSdk` from
+`@worlds/libsql`) wires into every `Sdk`. The former `@worlds/sdk`
+`ComunicaSparqlEngine` adapter (which this engine used to mirror as a drop-in
+replacement) was removed from the SDK on 2026-08-17; the wazoo engine is now the
+only shipped engine. `WazooSparqlTransaction` mirrors the structural shape of
+`@worlds/sdk`'s `Transaction`, so durable backends can pass their existing
+transaction objects.
 
 The interface is intentionally duplicated in `@worlds/sdk` under an
 identical-spec policy: the two copies must stay identical (gated by

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ for the W3C suite notes.
   Node.js, and browser environments.
 - **The engine behind `@worlds/sdk`**: Implements
   [`SparqlEngineInterface`](https://jsr.io/@wazoo/sparql-engine/doc/~/SparqlEngineInterface),
-  which `@worlds/sdk`'s durable client factories (`createLibsqlClient`,
-  `createDenokvClient`, `createSqliteSdk`) wire into every `Sdk` — no adapter
-  needed. (The SDK's former `@worlds/sdk/comunica` adapter was removed; Comunica
-  survives only as a differential parity oracle in this repo.)
+  which `@worlds/sdk`'s durable backend factory (`createLibsqlSdk` from
+  `@worlds/libsql`) wires into every `Sdk` — no adapter needed. (The SDK's
+  former `@worlds/sdk/comunica` adapter was removed; Comunica survives only as a
+  differential parity oracle in this repo.)
 
 ## Usage
 


### PR DESCRIPTION
Updates the @worlds/sdk durable backend factory name from createLibsqlClient to createLibsqlSdk following the @worlds/libsql 0.3.0 rename. Drop-in doc-only change.