### PR TITLE
docs: drop archived @worlds/denokv store references

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,7 +29,7 @@ durable `node:sqlite` store that used to ship behind the `./sqlite` subpath
 moved to `@worlds/sqlite` (2026-08-17), packaged with the worlds impl — see
 [`SqliteStore`](https://github.com/wazootech/worlds-sqlite/blob/main/src/sqlite/rdfjs-store/sqlite-store.ts).
 Any external `rdfjs.Store` works — e.g. `@worlds/sqlite`'s `SqliteStore`, or
-`@worlds/libsql`'s `LibsqlRdfjsStore` / `@worlds/denokv`'s `DenokvRdfjsStore`.
+`@worlds/libsql`'s `LibsqlRdfjsStore`.
 
 ## Contracts
 

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -294,7 +294,7 @@ The engine never owns data. It binds to any `rdfjs.Source` / `rdfjs.Store`:
   its `SqliteStore` wires to the engine via `createTransaction` (see
   `docs/durable-transactions.md`).
 - Any external `rdfjs.Store` — e.g. `@worlds/sqlite`'s `SqliteStore`, or
-  `@worlds/libsql`'s `LibsqlRdfjsStore` / `@worlds/denokv`'s `DenokvRdfjsStore`.
+  `@worlds/libsql`'s `LibsqlRdfjsStore`.
 
 `src/quad-store.ts` is the adapter layer between the evaluator and the store:
 

--- a/docs/03-api-contracts.md
+++ b/docs/03-api-contracts.md
@@ -202,9 +202,9 @@ export type QuadWriteStore = rdfjs.Store & {
 
 [`MemoryStore`](https://jsr.io/@wazoo/sparql-engine/doc/~/MemoryStore),
 [`@worlds/sqlite`](https://github.com/wazootech/worlds-sqlite)'s `SqliteStore`,
-and `@worlds/libsql`'s `LibsqlRdfjsStore` / `@worlds/denokv`'s
-`DenokvRdfjsStore` all satisfy it. If neither `createTransaction` nor
-`addQuad`/`removeQuad` is available, updates throw a clear error.
+and `@worlds/libsql`'s `LibsqlRdfjsStore` all satisfy it. If neither
+`createTransaction` nor `addQuad`/`removeQuad` is available, updates throw a
+clear error.
 
 ### 2. Durable transactions
 


### PR DESCRIPTION
The Deno KV backend (`@worlds/denokv`) is archived; `@worlds/libsql` is the supported durable backend. Removes `DenokvRdfjsStore` from the external-store examples in `ARCHITECTURE.md` and wiki pages 02/03. Docs-only change; `deno fmt --check` passes.