### PR TITLE
feat: live playground landing state, share links, README demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
 Wazoo [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) & 1.2 Query & Update
 Engine over RDF/JS Quad Stores.
 
+## Try it in your browser
+
+[**Open the Wazoo SPARQL Playground**](https://wazootech.github.io/sparql-engine/playground/)
+— run `SELECT` / `ASK` / `CONSTRUCT` / `UPDATE` queries over sample datasets
+entirely in the browser, no install, nothing sent to a server. Every query you
+run gets a shareable URL.
+
 ## Compatibility
 
 - **SPARQL 1.1 — full.** `SELECT` / `ASK` / `CONSTRUCT` / `DESCRIBE`, UPDATE,

--- a/docs/01-quickstart.md
+++ b/docs/01-quickstart.md
@@ -8,6 +8,11 @@ layout: default
 Get the engine running, execute SPARQL against a store, and run the test suites
 — in about five minutes.
 
+> **Try it without installing anything:** the
+> [**Wazoo SPARQL Playground**](https://wazootech.github.io/sparql-engine/playground/)
+> runs the engine in your browser over sample datasets — no setup, and every
+> query you run is shareable via its URL.
+
 ## Environment
 
 The project is a **Deno 2.x** package published to

--- a/playground/index.html
+++ b/playground/index.html
@@ -134,6 +134,10 @@
     select:hover {
       border-color: var(--muted);
     }
+    button:disabled {
+      opacity: 0.45;
+      cursor: default;
+    }
     textarea {
       background: var(--bg);
       color: var(--text);
@@ -302,6 +306,24 @@
       color: var(--muted);
       font-size: 11.5px;
     }
+    .toast {
+      position: fixed;
+      bottom: 18px;
+      left: 50%;
+      transform: translateX(-50%);
+      max-width: min(90vw, 680px);
+      background: var(--panel-2);
+      border: 1px solid var(--accent);
+      border-radius: 6px;
+      padding: 8px 14px;
+      font-size: 12.5px;
+      box-shadow: 0 4px 18px #000a;
+      z-index: 10;
+      word-break: break-all;
+    }
+    .toast code {
+      color: var(--accent-2);
+    }
     footer {
       border-top: 1px solid var(--border);
       padding: 6px 16px;
@@ -370,6 +392,7 @@
       <div class="controls">
         <button id="copy-results" title="Copy serialized results">Copy</button>
         <button id="export-results" title="Download serialized results">Export</button>
+        <button id="share-results" class="primary" title="Copy a shareable link to this dataset and query" disabled>Share link</button>
       </div>
     </div>
         <div id="results">
@@ -666,6 +689,7 @@
       lastResponse = response;
       renderResponse(response, ms);
       updateShareHash(query);
+      $("share-results").disabled = false;
     }
 
     function renderResponse(response, ms) {
@@ -808,6 +832,83 @@
       URL.revokeObjectURL(a.href);
     };
 
+    // Share link: the current dataset + query as a restorable URL. Sample
+    // datasets are keyed by id; custom datasets embed their Turtle inline
+    // (capped so links stay sane for large pasted or file-loaded datasets).
+    const MAX_SHARE_TTL = 12000;
+
+    function buildShareUrl() {
+      if (!lastQuery) return null;
+      const id = currentDatasetId();
+      const q = b64(lastQuery);
+      if (id === "custom") {
+        const t = b64(datasetInput.value);
+        if (t.length > MAX_SHARE_TTL) return "too-large";
+        return `${location.origin}${location.pathname}#d=custom&t=${t}&q=${q}`;
+      }
+      return `${location.origin}${location.pathname}#d=${id}&q=${q}`;
+    }
+
+    async function copyText(text) {
+      if (navigator.clipboard && window.isSecureContext) {
+        try {
+          await navigator.clipboard.writeText(text);
+          return true;
+        } catch {
+          /* fall through to the execCommand fallback */
+        }
+      }
+      const area = document.createElement("textarea");
+      area.value = text;
+      area.setAttribute("readonly", "");
+      area.style.position = "fixed";
+      area.style.opacity = "0";
+      document.body.appendChild(area);
+      area.select();
+      let ok = false;
+      try {
+        ok = document.execCommand("copy");
+      } catch {
+        ok = false;
+      }
+      area.remove();
+      return ok;
+    }
+
+    function showToast(message) {
+      const toast = document.createElement("div");
+      toast.className = "toast";
+      toast.innerHTML = message;
+      document.body.appendChild(toast);
+      setTimeout(() => toast.remove(), 4000);
+    }
+
+    function flashButton(button, text) {
+      const original = button.textContent;
+      button.textContent = text;
+      setTimeout(() => {
+        button.textContent = original;
+      }, 1200);
+    }
+
+    $("share-results").onclick = async () => {
+      const url = buildShareUrl();
+      if (url === null) return;
+      if (url === "too-large") {
+        showToast(
+          "Dataset too large to fit in a share link — export the Turtle file instead.",
+        );
+        return;
+      }
+      const ok = await copyText(url);
+      if (ok) {
+        flashButton($("share-results"), "Copied!");
+      } else {
+        showToast(`Share link: <code>${escapeHtml(url)}</code>`);
+        flashButton($("share-results"), "Link shown");
+      }
+    };
+
     // ---------- share URLs (hash: dataset id + query) ----------
     function b64(s) {
       return btoa(unescape(encodeURIComponent(s))).replace(/\+/g, "-").replace(
@@ -822,20 +923,37 @@
     }
 
     function updateShareHash(query) {
+      // Stamps sample-dataset runs into the URL. Custom datasets are too
+      // heavy to embed on every run — their share links are built on demand
+      // by the Share link button instead.
       const id = currentDatasetId();
-      if (id === "custom") return; // only sample datasets are shareable
+      if (id === "custom") return;
       const q = b64(query);
       history.replaceState(null, "", `#d=${id}&q=${q}`);
     }
 
     function restoreFromHash() {
-      const m = location.hash.match(/^#d=([a-z]+)&q=([A-Za-z0-9_-]+)$/);
+      // #d=<id>[&t=<b64url turtle>]&q=<b64url query> — sample datasets are
+      // keyed by id; custom datasets carry their Turtle inline, so any state
+      // is restorable from a cold navigation.
+      const m = location.hash.match(
+        /^#d=([a-z]+)(?:&t=([A-Za-z0-9_-]+))?&q=([A-Za-z0-9_-]+)$/,
+      );
       if (!m) return false;
       const id = m[1];
-      if (!(id in DATASETS)) return false;
-      selectDataset(id);
+      const customTtl = m[2];
+      if (id === "custom") {
+        if (!customTtl) return false;
+        datasetSelect.value = "custom";
+        datasetInput.value = unb64(customTtl);
+        renderChips("custom");
+      } else if (id in DATASETS) {
+        selectDataset(id);
+      } else {
+        return false;
+      }
       try {
-        queryInput.value = unb64(m[2]);
+        queryInput.value = unb64(m[3]);
       } catch {
         /* ignore malformed */
       }

--- a/playground/index.html
+++ b/playground/index.html
@@ -851,10 +851,27 @@
       }
     });
 
-    if (!restoreFromHash()) {
-      selectDataset("foaf");
+    // Live landing: on a cold visit run the default FOAF example, and on a
+    // shared URL run the shared query — results are never an empty prompt.
+    function applyLandingState() {
+      if (!restoreFromHash()) {
+        selectDataset("foaf");
+      }
+      loadDataset();
+      runQuery();
     }
-    loadDataset();
+
+    // The URL fragment is the source of truth for shared state: re-apply it
+    // on same-document navigation too (back/forward, pasted hashes), not just
+    // on page load, so shared links survive cold navigation and fragment
+    // edits without a reload.
+    window.addEventListener("hashchange", () => {
+      if (restoreFromHash()) {
+        runQuery();
+      }
+    });
+
+    applyLandingState();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Three-part polish for HN traffic:

## Playground: live landing + robust share URLs
- **Live landing state** — a cold visit auto-runs the default FOAF example, and opening a shared URL auto-runs its query, so the results panel is never an empty prompt on arrival. The auto-run also stamps the URL with the shareable `#d=..&q=..` hash.
- **`hashchange` restore (nuqs-style URL state)** — shared state re-applies on same-document fragment navigation (back/forward, pasted hashes) as well as on page load, so shared links survive cold navigation without a reload.

## Playground: prominent Share link button
- Primary-styled **Share link** button beside Copy/Export, enabled after a run, copies a restorable URL for the current dataset + query.
- Sample datasets share as `#d=<id>&q=..`; **custom datasets now share too** — their Turtle embeds inline (`#d=custom&t=..&q=..`, capped at ~12 KB encoded) so pasted/file-loaded data is linkable. `restoreFromHash` gained the `&t=` parameter; hashchange re-applies it.
- Clipboard copy falls back to an inline toast showing the link when the clipboard is unavailable.

## Docs: point visitors at the demo
- README intro gains a "Try it in your browser" section linking the hosted playground
- `docs/01-quickstart.md` opening gains a "try it without installing anything" note

Verified in the browser against the vendored bundle (console clean): cold-load auto-run, shared sample URL restore, same-document fragment change, custom-dataset share → cold-navigate restore. `deno fmt --check` and `deno lint` pass.