### PR TITLE
feat(playground): add DESIGN.md system-adaptive light mode

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -8,6 +8,7 @@
       content="Try @wazoo/sparql-engine in your browser — zero dependencies, pure TypeScript, over an in-memory RDF/JS store." />
     <style>
     :root {
+      color-scheme: dark; /* native controls follow the dark theme */
       /* Wazoo design tokens — wazoo.dev/DESIGN.md (dark-mode default). */
       --wz-void: #040404;
       --wz-surface: #0f0f0f;
@@ -32,6 +33,17 @@
       --accent-2: #79c0ff;
       --warn: var(--wz-warn);
       --err: var(--wz-err);
+      /* Syntax palette — dark values here; the light-mode block at the end
+         of the stylesheet overrides them (system-adaptive per DESIGN). */
+      --tok-kw: #ff8c00;
+      --tok-str: #a5d6ff;
+      --tok-iri: #79c0ff;
+      --tok-var: #d2a8ff;
+      --tok-pname: #ffb74d;
+      --tok-num: #79c0ff;
+      --tok-bnode: #79c0ff;
+      --tok-comment: #7d7d7f;
+      --tok-punct: #7d7d7f;
       --mono: "IBM Plex Mono", ui-monospace, "SF Mono", "Cascadia Code", Menlo,
         Consolas, monospace;
       --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
@@ -269,36 +281,36 @@
       background: rgba(255, 140, 0, 0.22);
     }
     .tok-kw {
-      color: #ff8c00;
+      color: var(--tok-kw);
     }
     .tok-dir {
-      color: #ff8c00;
+      color: var(--tok-kw);
       font-style: italic;
     }
     .tok-str {
-      color: #a5d6ff;
+      color: var(--tok-str);
     }
     .tok-iri {
-      color: #79c0ff;
+      color: var(--tok-iri);
     }
     .tok-var {
-      color: #d2a8ff;
+      color: var(--tok-var);
     }
     .tok-pname {
-      color: #ffb74d;
+      color: var(--tok-pname);
     }
     .tok-num {
-      color: #79c0ff;
+      color: var(--tok-num);
     }
     .tok-bnode {
-      color: #79c0ff;
+      color: var(--tok-bnode);
     }
     .tok-comment {
-      color: #7d7d7f;
+      color: var(--tok-comment);
       font-style: italic;
     }
     .tok-punct {
-      color: #7d7d7f;
+      color: var(--tok-punct);
     }
     .chips {
       display: flex;
@@ -527,6 +539,66 @@
         transition-duration: 0.01ms !important;
         animation-duration: 0.01ms !important;
         animation-iteration-count: 1 !important;
+      }
+    }
+
+    /* DESIGN: system-adaptive light mode — Eggshell / Ink
+       (wazoo.dev/DESIGN.md). Dark stays the default; this applies when the
+       OS prefers light. Light surfaces aren't specified by DESIGN, so they
+       are derived as warm off-whites. Tokens flip mechanically; the syntax
+       palette and kind badges get explicit light values. */
+    @media (prefers-color-scheme: light) {
+      :root {
+        color-scheme: light;
+        --wz-void: #f7f2e8;
+        --wz-surface: #efe9dc;
+        --wz-surface-2: #e7e0d1;
+        --wz-border: #d9d1c0;
+        --wz-text: #1f1b14;
+        --wz-heading: #14100a;
+        --wz-muted: #6f685c;
+        --wz-primary: #f57c00;
+        --wz-primary-light: #c2410c;
+        --wz-primary-dark: #9a3412;
+        --wz-err: #b91c1c;
+        --wz-warn: #a16207;
+        --accent-2: #1d4ed8;
+        --tok-kw: #c2410c;
+        --tok-str: #0369a1;
+        --tok-iri: #1d4ed8;
+        --tok-var: #6d28d9;
+        --tok-pname: #b45309;
+        --tok-num: #1d4ed8;
+        --tok-bnode: #1d4ed8;
+        --tok-comment: #78716c;
+        --tok-punct: #78716c;
+      }
+      .kind-select {
+        background: rgba(194, 65, 12, 0.1);
+        color: #9a3412;
+        border: 1px solid rgba(194, 65, 12, 0.35);
+      }
+      .kind-ask {
+        background: rgba(31, 27, 20, 0.06);
+        color: var(--text);
+        border: 1px solid rgba(31, 27, 20, 0.3);
+      }
+      .kind-construct {
+        background: rgba(29, 78, 216, 0.08);
+        color: #1e40af;
+        border: 1px solid rgba(29, 78, 216, 0.35);
+      }
+      .kind-void {
+        background: rgba(161, 98, 7, 0.1);
+        color: #92400e;
+        border: 1px solid rgba(161, 98, 7, 0.35);
+      }
+      .err {
+        background: rgba(185, 28, 28, 0.07);
+        border: 1px solid rgba(185, 28, 28, 0.35);
+      }
+      button.primary {
+        color: #1f1b14;
       }
     }
     </style>


### PR DESCRIPTION
Implements [#178](https://github.com/wazootech/sparql-engine/issues/178): DESIGN.md's system-adaptive light mode behind `prefers-color-scheme`. Dark stays the default.

## What shipped (one file, `playground/index.html`)

- **Token overrides** — a `@media (prefers-color-scheme: light)` block re-declares the `--wz-*` tokens: Eggshell `#F7F2E8` bg, Ink `#1F1B14` text, deeper-ink headings `#14100A`, warm off-white surfaces/borders (derived — DESIGN doesn't specify light elevations), and the DESIGN dark-variant accent `#F57C00`. Because the whole UI (panels, tables, toast, footer, error box) goes through `var(--wz-*)` aliases, it flips mechanically.
- **Syntax palette** — `.tok-*` colors moved to `--tok-*` custom properties (dark values in `:root`, light values in the block): dark orange keywords `#C2410C`, blue IRIs `#1D4ED8`, violet vars `#6D28D9`, teal-blue strings `#0369A1`, amber pnames `#B45309`, stone comments `#78716C`.
- **Native controls** — `color-scheme: dark` on `:root` and `color-scheme: light` in the block, so the select popup and scrollbars match the theme (previously they followed the OS, mismatching the dark page).
- **Kind badges + error box** — light-friendly tints; primary-button text warms to ink.

## Verified in a browser (both schemes)

Dark default (real scheme): `color-scheme: dark` set, Void `rgb(4,4,4)` bg, ink-free palette unchanged, landing works — no regression. Light (forced via a test server that flips the media condition in the same bytes): eggshell `rgb(247,242,232)` bg, ink text, deeper-ink h1, derived surfaces/borders, all syntax kinds readable (`kw #C2410C`, `var #6D28D9`, `iri #1D4ED8`, `str #0369A1`, `pname #B45309`, `comment #78716C` italic), ask-true/badges/`td.uri`/error box in light tints, `color-scheme: light`. Screenshot confirms the warm cream + orange look. Console clean; `deno fmt --check` + `deno lint` pass.

Known tradeoff: small accent *text* (chips/links) uses `#F57C00` per DESIGN's dark variant (~2.4:1 on eggshell) — spec-faithful, but below WCAG AA for small text; flagged in the issue's acceptance.