### PR TITLE
fix(playground): AA contrast for light-mode text accents

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -30,6 +30,10 @@
       --text: var(--wz-text);
       --muted: var(--wz-muted);
       --accent: var(--wz-primary);
+      /* Accent used for small text (links, chips, tag, inline code, result
+         values): gets a darker, AA-passing value in light mode, while
+         --accent stays the fill color. */
+      --accent-text: var(--wz-primary);
       --accent-2: #79c0ff;
       --warn: var(--wz-warn);
       --err: var(--wz-err);
@@ -115,13 +119,13 @@
       font-family: var(--mono);
       font-size: 11px;
       letter-spacing: -0.025em;
-      color: var(--accent);
+      color: var(--accent-text);
       border: 1px solid var(--border);
       border-radius: 8px;
       padding: 1px 8px;
     }
     header a {
-      color: var(--accent);
+      color: var(--accent-text);
       text-decoration: none;
       font-size: 12px;
       transition: color 0.2s;
@@ -323,7 +327,7 @@
       font-family: var(--mono);
       font-size: 11px;
       letter-spacing: -0.025em;
-      color: var(--accent);
+      color: var(--accent-text);
       border: 1px solid var(--border);
       border-radius: 8px;
       padding: 2px 8px;
@@ -416,7 +420,7 @@
       color: var(--wz-heading);
     }
     .ask-true {
-      color: var(--accent);
+      color: var(--accent-text);
     }
     .ask-false {
       color: var(--err);
@@ -464,7 +468,7 @@
       word-break: break-all;
     }
     .toast code {
-      color: var(--accent);
+      color: var(--accent-text);
     }
     footer {
       border-top: 1px solid var(--border);
@@ -563,6 +567,7 @@
         --wz-err: #b91c1c;
         --wz-warn: #a16207;
         --accent-2: #1d4ed8;
+        --accent-text: #9a3412; /* small text accents clear WCAG AA (≈6.6:1) */
         --tok-kw: #c2410c;
         --tok-str: #0369a1;
         --tok-iri: #1d4ed8;


### PR DESCRIPTION
Stacked on #181 (base: `feat/light-mode`). Small follow-up to the light mode: accent *text* was hard to read.

## Problem
In light mode, small accent text (header links, version tag, chips, toast code, and the ASK result value) used the primary accent `#F57C00` — only **~2.4:1** on Eggshell `#F7F2E8`, failing WCAG AA for small text.

## Fix
- New `--accent-text` token: `var(--wz-primary)` in dark mode (**dark is byte-behavior-identical**), `#9A3412` in the light block (~**6.6:1**, WCAG AA).
- Swapped the small-text sites — `header a`, `header .tag`, `.chip`, `.toast code`, `.ask-true` — to `var(--accent-text)`.
- `#F57C00` stays for **fills**: primary buttons, badges, borders, hover states, selection.

## Verified (browser, both schemes)
- Dark: tag/link/chip/ask-true all still `rgb(255,140,0)` — unchanged.
- Light (forced): tag/link/chip/ask-true all `rgb(154,52,18)` = `#9A3412`; primary button fill still `rgb(245,124,0)` = `#F57C00`. Console clean; `deno fmt --check` + `deno lint` pass.