### PR TITLE
fix(term): escape termKey delimiters to prevent key collisions

### DIFF
--- a/src/term/identity.ts
+++ b/src/term/identity.ts
@@ -6,20 +6,32 @@ import type * as rdfjs from "@rdfjs/types";
  * nesting handled recursively. Two terms produce the same key exactly when
  * they are the same RDF term, so termKey is a sound hash-index key.
  */
+/**
+ * escapeTermValue escapes the characters reserved by the termKey
+ * serialization (the `|` field separators and the \` escape marker) so
+ * that distinct term values can never render the same key. Backslash is
+ * escaped first so escape sequences themselves stay unambiguous.
+ */
+function escapeTermValue(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("|", "\\|");
+}
+
 export function termKey(term: rdfjs.Term): string {
   switch (term.termType) {
     case "NamedNode":
-      return `uri:${term.value}`;
+      return `uri:${escapeTermValue(term.value)}`;
     case "BlankNode":
-      return `bnode:${term.value}`;
+      return `bnode:${escapeTermValue(term.value)}`;
     case "Variable":
-      return `var:${term.value}`;
+      return `var:${escapeTermValue(term.value)}`;
     case "DefaultGraph":
       return "default";
     case "Literal":
       return (
-        `literal:${term.value}|${term.language ?? ""}|` +
-        `${term.direction ?? ""}|${term.datatype?.value ?? ""}`
+        `literal:${escapeTermValue(term.value)}|` +
+        `${escapeTermValue(term.language ?? "")}|` +
+        `${escapeTermValue(term.direction ?? "")}|` +
+        `${escapeTermValue(term.datatype?.value ?? "")}`
       );
     case "Quad":
       return (

--- a/src/term/term.test.ts
+++ b/src/term/term.test.ts
@@ -41,6 +41,17 @@ Deno.test("termKey agrees with sameRdfTerm on term identity", () => {
     quad(ex("s"), ex("p"), literal("o")),
     quad(ex("s"), ex("p"), literal("other")),
     quad(quad(ex("s1"), ex("p1"), ex("o1")), ex("p"), literal("nested")),
+    literal("a|b"),
+    literal("a", "b"),
+    literal("a\\|b"),
+    literal("a\\b"),
+    namedNode("http://x/a|b"),
+    blankNode("a|b"),
+    literal("a", namedNode("http://x/|")),
+    quad(ex("s"), ex("p"), literal("a|b")),
+    quad(ex("s"), ex("p"), literal("a", "b")),
+    quad(namedNode("a"), namedNode("x|uri:y"), namedNode("z")),
+    quad(namedNode("a"), namedNode("x"), namedNode("y|uri:z")),
   ];
   for (let i = 0; i < terms.length; i++) {
     for (let j = 0; j < terms.length; j++) {
@@ -51,6 +62,48 @@ Deno.test("termKey agrees with sameRdfTerm on term identity", () => {
       );
     }
   }
+});
+
+Deno.test("termKey escapes delimiters so term values can never collide", () => {
+  // Regression: `"a|b"` (plain literal) and `"a"` with language `b` both
+  // used to render `literal:a|b||` and collide onto the same key.
+  const pipeInValue = literal("a|b");
+  const pipeAsLang = literal("a", "b");
+  assertNotEquals(termKey(pipeInValue), termKey(pipeAsLang));
+
+  // Backslash is escaped before pipe so a literal backslash + pipe cannot
+  // mimic an escaped pipe.
+  const backslashThenPipe = literal("a\\|b");
+  const plainBackslash = literal("a\\b");
+  assertNotEquals(termKey(backslashThenPipe), termKey(plainBackslash));
+  assertNotEquals(termKey(backslashThenPipe), termKey(literal("a|b")));
+
+  // Delimiters in non-literal term values and datatype URIs stay distinct.
+  assertNotEquals(
+    termKey(namedNode("http://x/a|b")),
+    termKey(namedNode("http://x/a")),
+  );
+  assertNotEquals(termKey(blankNode("a|b")), termKey(blankNode("a")));
+  assertNotEquals(
+    termKey(literal("a", namedNode("http://x/|"))),
+    termKey(literal("a", namedNode("http://x/"))),
+  );
+
+  // RDF-star nesting composes safely.
+  assertNotEquals(
+    termKey(quad(ex("s"), ex("p"), literal("a|b"))),
+    termKey(quad(ex("s"), ex("p"), literal("a", "b"))),
+  );
+
+  // Pre-fix, these two distinct RDF-star terms rendered the identical key
+  // because `|` inside a term value could be read as a field separator:
+  //   quad(namedNode("a"), namedNode("x|uri:y"), namedNode("z"))
+  //   quad(namedNode("a"), namedNode("x"), namedNode("y|uri:z"))
+  // both encoded to `quad:uri:a|uri:x|uri:y|uri:z`.
+  assertNotEquals(
+    termKey(quad(namedNode("a"), namedNode("x|uri:y"), namedNode("z"))),
+    termKey(quad(namedNode("a"), namedNode("x"), namedNode("y|uri:z"))),
+  );
 });
 
 Deno.test("canonicalize agrees across the RDF/JS and SparqlValue representations", () => {


### PR DESCRIPTION
Closes #185

## Problem
`termKey` (used as the composite primary key in the SQLite/IndexedDB quad stores and as a hash-index key throughout the engine) rendered term values into the key **without escaping the `|` field separator**. Distinct RDF terms could therefore collide onto the same key — a silent primary-key collision:

- `quad(namedNode("a"), namedNode("x|uri:y"), namedNode("z"))` → `quad:uri:a|uri:x|uri:y|uri:z`
- `quad(namedNode("a"), namedNode("x"), namedNode("y|uri:z"))` → `quad:uri:a|uri:x|uri:y|uri:z`

(The `|` inside a term value aligns with the field separators + `uri:` prefix pattern. Literal values with `|` break the encoding structurally too.)

## Fix
Added `escapeTermValue` in `src/term/identity.ts` — escapes **backslash first**, then **pipe** — applied to every value-bearing field (named nodes, blank nodes, variables, and all four literal fields; nested quads compose recursively).

- **Injective by construction**: "same key ⟺ same term" now provably holds.
- **Backward compatible**: keys for values without `|`/`\` are byte-identical; only previously-broken terms change.
- No consumer parses `termKey` or splits on `|` (all uses are opaque Map/Set keys), so escaping is safe everywhere.

## Tests
- New regression test including the **verified pre-fix collision pair** above.
- Adversarial terms added to the existing pairwise `termKey ⟺ sameRdfTerm` injectivity corpus (now ~26 terms, checked N×N).

## Verification
- Full suite: **462 passed, 0 failed** · `deno lint` clean (84 files) · `deno check src/mod.ts` clean