### PR TITLE
docs: remove identical-spec policy from CONTEXT.md glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,8 +5,8 @@
 - **SparqlEngineInterface** — the shared execution contract
   (`execute(request) => Promise<SparqlResponse>`) that `WazooSparqlEngine`
   implements and `@worlds/sdk`'s durable client factories wire into every `Sdk`.
-  The interface is duplicated identically in `@worlds/sdk` under an
-  identical-spec policy; reconcile any drift deliberately.
+  The interface lives in this repo as the single source of truth; `@worlds/sdk`
+  re-exports it from `@wazoo/sparql-engine`.
 - **ComunicaSparqlEngine** — the retired `@worlds/sdk` adapter
   (`@worlds/sdk/comunica`) that `WazooSparqlEngine` used to mirror as a drop-in
   replacement. The SDK removed the adapter on 2026-08-17; Comunica now lives on


### PR DESCRIPTION
## Summary

Completes the interface-parity cleanup: after the policy was dismantled ([sparql-engine#184](https://github.com/wazootech/sparql-engine/pull/184), [worlds-sdk-ts#186](https://github.com/wazootech/worlds-sdk-ts/pull/186)), `@worlds/sdk` re-exports the engine interface instead of duplicating it. The CONTEXT.md glossary still described the old identical-spec policy — updated to reflect the single source of truth.

Closes out the last stray reference: `docs/04-source-map.md` and `docs/06-supplemental-context.md` are already handled by open PR [#186](https://github.com/wazootech/sparql-engine/pull/186).