### PR TITLE
Add scheduled wiki sync workflow

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,150 @@
+# Wiki sync — scheduled CI driver for the wiki-sync skill.
+#
+# Instantiated for wazootech/sparql-engine from skills/wiki-sync/workflows/
+# wiki-sync.yml in wazootech/wiki (copy-to-install; local customizations:
+# Deno toolchain, docs validation step, Pi wiring enabled).
+#
+# Contract (skills/wiki-sync/SKILL.md, "Scheduled syncs (CI)"):
+# - Exits cheaply when no wiki-relevant source changed since docs/.sync-base.
+# - Resumes an open docs/sync-ci PR; new deltas force-push onto it.
+# - The agent bumps docs/.sync-base inside the single docs-only commit this
+#   workflow creates, so merging the PR anchors the wiki; interrupted runs
+#   leave the anchor untouched and the next run redoes the delta.
+# - Verification rides the PR via this repo's CI (ci.yml: docs-drift,
+#   docs-links, deno task ci); humans merge.
+#
+# Trigger: workflow_dispatch only until the first manual runs prove the loop;
+# then uncomment the weekly cron below.
+
+name: Wiki sync
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "0 6 * * 1"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # Resume an open docs/sync-ci branch when one exists, THEN read the
+      # anchor: the branch carries its own .sync-base, which scopes the new
+      # delta correctly in both fresh and resumed runs.
+      - name: Resolve state
+        id: state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="docs/sync-ci"
+          OPEN_PR="$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')"
+          if [ "$OPEN_PR" != "0" ]; then
+            git fetch origin "$BRANCH"
+            git checkout -b "$BRANCH" "origin/$BRANCH"
+          else
+            git checkout -b "$BRANCH" origin/main
+          fi
+          BASE="$(cat docs/.sync-base 2>/dev/null || git log -1 --format=%H -- docs/)"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          if git diff --quiet "$BASE"..origin/main -- src test bench .github; then
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No wiki-relevant source changes since $BASE"
+          else
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            git diff --stat "$BASE"..origin/main -- src test bench .github
+          fi
+
+      - name: Stop — wiki current
+        if: steps.state.outputs.relevant == 'false'
+        run: echo "Nothing to sync; stopping cleanly."
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      # =====================================================================
+      # AGENT WIRING — Pi, provider-agnostic: Pi resolves its model from
+      # whichever provider key the environment carries (ANTHROPIC_API_KEY
+      # below; OPENAI_API_KEY, GEMINI_API_KEY, ... equally valid — set the
+      # chosen key as a repository secret of the same name).
+      # Alternative wirings (OpenCode, Claude Code, Codex) live in the
+      # upstream template: skills/wiki-sync/workflows/wiki-sync.yml.
+      #
+      # The skill file IS the prompt: follow skills/wiki-sync/SKILL.md end
+      # to end against THIS checkout, editing only docs/, leaving ALL
+      # changes uncommitted (no git add/commit/push, no PRs) — the workflow
+      # owns committing and PR creation below.
+      # =====================================================================
+      - name: Run wiki-sync via Pi
+        if: steps.state.outputs.relevant == 'true'
+        env:
+          BASE: ${{ steps.state.outputs.base }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          curl -fsSL https://pi.dev/install.sh | sh
+          PROMPT="$(cat skills/wiki-sync/SKILL.md)
+            Follow this skill end to end for THIS checkout. Base commit:
+            ${BASE}. Edit only docs/; bump docs/.sync-base last, after the
+            skill's Step 8 validation passes. Leave all changes
+            uncommitted: do not git add, commit, push, or open PRs."
+          pi -p "$PROMPT"
+
+      # Re-run doc validators BEFORE the commit so failed validation lands
+      # nothing (invariant 6 enforced mechanically).
+      - name: Validate docs
+        if: steps.state.outputs.relevant == 'true'
+        run: |
+          deno fmt --check docs/
+
+      - name: Commit and push
+        id: commit
+        if: steps.state.outputs.relevant == 'true'
+        env:
+          BASE: ${{ steps.state.outputs.base }}
+          BRANCH: ${{ steps.state.outputs.branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Agent made no documentation changes; nothing to land."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            HEAD="$(git rev-parse origin/main)"
+            git commit -m "docs: scheduled wiki sync (${BASE:0:12}..${HEAD:0:12})"
+            git push -u origin "$BRANCH" --force-with-lease
+          fi
+
+      - name: Open or update PR
+        if: >-
+          steps.state.outputs.relevant == 'true' &&
+          steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE: ${{ steps.state.outputs.base }}
+          BRANCH: ${{ steps.state.outputs.branch }}
+        run: |
+          HEAD="$(git rev-parse origin/main)"
+          LOG="$(git log --oneline "$BASE"..origin/main | sed 's/^/    /')"
+          BODY="$(printf '%s\n\nSynced %s..%s:\n\n%s\n\nEdits follow the wiki-sync skill. The anchor (docs/.sync-base) rides inside the docs-only commit: merging anchors the wiki.' \
+            "Scheduled wiki sync." "$BASE" "$HEAD" "$LOG")"
+          EXISTING="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number')"
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "null" ]; then
+            gh pr edit "$EXISTING" --body "$BODY"
+          else
+            gh pr create --title "docs: scheduled wiki sync" \
+              --body "$BODY" --base main --head "$BRANCH"
+          fi

--- a/docs/08-maintenance.md
+++ b/docs/08-maintenance.md
@@ -137,3 +137,16 @@ nothing in the wiki. If the `AGENTS.md` directive opts into `line-numbers`,
 `measurements`, or `full`, run the full-tree verification passes (Steps 3–4 with
 the opt-in sub-steps) every few source merges — incremental passes miss drift
 that accumulates in line citations and snapshot tables.
+
+## Scheduled syncs
+
+A GitHub Actions workflow (`.github/workflows/wiki-sync.yml`, installed from the
+copy-to-install template shipped with the `wiki-sync` skill) drives this
+procedure unattended. It gates on the Step 1 quiet check, reuses an open
+`docs/sync-ci` pull request instead of stacking branches, and lands all edits as
+one `github-actions[bot]` commit whose `.sync-base` bump anchors the wiki on
+merge; interrupted runs leave the anchor untouched. Trigger runs manually via
+_Actions → Wiki sync → Run workflow_ until dogfooded loops prove out, then
+enable the weekly cron in the workflow's commented schedule block. The workflow
+invokes the [Pi](https://pi.dev/) coding agent, which resolves its model from
+whichever provider key is configured as a repository secret.


### PR DESCRIPTION
## Summary

Installs the scheduled wiki-sync CI workflow from the copy-to-install template shipped in wazootech/wiki#253, plus its docs paragraph.

### `.github/workflows/wiki-sync.yml`

- **Delta gate** — exits cleanly when nothing under `src/ test/ bench/ .github/` changed since `docs/.sync-base`; reuses an open `docs/sync-ci` PR (new deltas force-push onto it) instead of stacking branches.
- **Agent wiring: Pi** (`pi -p`) — provider-agnostic; the model follows whichever provider key is set as a repository secret. Alternatives (OpenCode, Claude Code, Codex) remain documented in the upstream template.
- **Validation before landing** — `deno fmt --check docs/` runs between the agent and the commit, so failed validation lands nothing (anchor untouched).
- **Bot authorship** — single docs-only commit by `github-actions[bot]` carrying the `.sync-base` bump; merging anchors the wiki.
- **Trigger** — `workflow_dispatch` only; weekly cron shipped commented out until manual runs prove the loop.

### `docs/08-maintenance.md`

Short "Scheduled syncs" section mirroring the skill contract.

## Verification

- YAML parses; `deno fmt --check` clean on both touched files.
- `deno task ci`: 462 passed / 0 failed.
- Note: no repository secrets are configured yet, so a dispatch with a non-empty delta will fail at the agent step by design — adding a provider key secret is the one remaining human step. A dispatch against today's docs-only delta exercises the gate and clean-skip path without needing any secret.
