### PR TITLE
Make local generation the default wiki-sync posture

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,8 +1,15 @@
-# Wiki sync — scheduled CI driver for the wiki-sync skill.
+# Wiki sync — optional CI layer for the wiki-sync skill.
 #
 # Instantiated for wazootech/sparql-engine from skills/wiki-sync/workflows/
 # wiki-sync.yml in wazootech/wiki (copy-to-install; local customizations:
 # Deno toolchain, docs validation step, Pi wiring enabled).
+#
+# The default wiki-sync posture is local generation: an agent runs the skill
+# directly in a checkout that already holds its model credentials. This
+# workflow is an extra layer — dispatch it manually when you want CI to run
+# the same procedure. Scheduling is intentionally absent: recurring runs need
+# a provider credential available every cycle; add a cron only if that
+# changes.
 #
 # Contract (skills/wiki-sync/SKILL.md, "Scheduled syncs (CI)"):
 # - Exits cheaply when no wiki-relevant source changed since docs/.sync-base.
@@ -12,16 +19,11 @@
 #   leave the anchor untouched and the next run redoes the delta.
 # - Verification rides the PR via this repo's CI (ci.yml: docs-drift,
 #   docs-links, deno task ci); humans merge.
-#
-# Trigger: workflow_dispatch only until the first manual runs prove the loop;
-# then uncomment the weekly cron below.
 
 name: Wiki sync
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: "0 6 * * 1"
 
 permissions:
   contents: write
@@ -103,13 +105,14 @@ jobs:
           deno-version: v2.x
 
       # =====================================================================
-      # AGENT WIRING — Pi, provider-agnostic: Pi resolves its model from
-      # whichever provider key the environment carries (ANTHROPIC_API_KEY
-      # below; OPENAI_API_KEY, GEMINI_API_KEY, ... equally valid — set the
-      # chosen key as a repository secret of the same name).
-      # Alternative wirings (OpenCode, Claude Code, Codex) live in the
-      # upstream template: skills/wiki-sync/workflows/wiki-sync.yml in
-      # wazootech/wiki.
+      # AGENT WIRING — harness/provider is the maintainer's choice; this
+      # instantiation ships with Pi (provider-agnostic: it resolves its
+      # model from whichever provider key the environment carries). For
+      # local development we use OpenCode — swap to its wiring from the
+      # upstream template (skills/wiki-sync/workflows/wiki-sync.yml in
+      # wazootech/wiki) if you prefer the same harness in CI.
+      # Set whichever provider key your chosen wiring reads as a repository
+      # secret of the same name.
       #
       # The skill file IS the prompt (resolved to SKILL_PATH above): follow
       # it end to end against THIS checkout, editing only docs/, leaving

--- a/docs/08-maintenance.md
+++ b/docs/08-maintenance.md
@@ -140,13 +140,18 @@ that accumulates in line citations and snapshot tables.
 
 ## Scheduled syncs
 
-A GitHub Actions workflow (`.github/workflows/wiki-sync.yml`, installed from the
-copy-to-install template shipped with the `wiki-sync` skill) drives this
-procedure unattended. It gates on the Step 1 quiet check, reuses an open
-`docs/sync-ci` pull request instead of stacking branches, and lands all edits as
-one `github-actions[bot]` commit whose `.sync-base` bump anchors the wiki on
-merge; interrupted runs leave the anchor untouched. Trigger runs manually via
-_Actions → Wiki sync → Run workflow_ until dogfooded loops prove out, then
-enable the weekly cron in the workflow's commented schedule block. The workflow
-invokes the [Pi](https://pi.dev/) coding agent, which resolves its model from
-whichever provider key is configured as a repository secret.
+The default sync posture is **local generation** — an agent runs the `wiki-sync`
+skill directly in a checkout that already holds its model credentials, on demand
+after source changes land. Following the software-factory pattern of build value
+locally, then move to the cloud, CI is an opt-in extra layer rather than the
+primary path: `.github/workflows/wiki-sync.yml` (installed from the
+copy-to-install template shipped with the skill) wraps the same procedure for
+manual dispatch via _Actions → Wiki sync → Run workflow_. It gates on the Step 1
+quiet check, reuses an open `docs/sync-ci` pull request instead of stacking
+branches, and lands all edits as one `github-actions[bot]` commit whose
+`.sync-base` bump anchors the wiki on merge; interrupted runs leave the anchor
+untouched. No schedule is configured — recurring runs need a provider credential
+available every cycle, so add a cron only if that changes. The agent harness and
+provider are the maintainer's choice (the instantiation ships with
+[Pi](https://pi.dev/); we use OpenCode locally), selected by whichever key is
+configured as a repository secret.


### PR DESCRIPTION
## Summary

Completes the manual-only posture correction started upstream in wazootech/wiki#257:

- **Workflow**: the commented weekly-cron schedule is removed entirely, and the header states the design decision plainly — recurring runs need a provider credential available every cycle; this repo does not have one. The workflow remains an opt-in `workflow_dispatch` layer around the same procedure.
- **Agent wiring note**: harness/provider is documented as the maintainer's choice (instantiation ships with Pi; OpenCode recommended for local development), selected via whichever key is configured as a repository secret.
- **`docs/08-maintenance.md`**: the Scheduled syncs section now leads with local generation as the default posture — an agent runs the wiki-sync skill directly in a checkout that already holds credentials — citing the software-factory pattern of build value locally, then move to the cloud (Vercel).

No functional change: dispatch behavior, gate logic, and bot-commit mechanics are identical to what was dogfooded green earlier.

## Verification

- `deno fmt --check` clean on both touched files.
